### PR TITLE
replace %zu conversions with PRIu64 so it doesn't explode on cygwin

### DIFF
--- a/tests/test.c
+++ b/tests/test.c
@@ -147,12 +147,12 @@ static void test()
 
 			size_t j;
 			for (j = 0; j < count; j++) {
-				printf("0x%zu:\t%s\t\t%s\n",
-						insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIu64 ":\t%s\t\t%s\n",
+						(uint64_t) insn[j].address, insn[j].mnemonic, insn[j].op_str);
 			}
 
 			// print out the next offset, after the last insn
-			printf("0x%zu:\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIu64 ":\n", (uint64_t) insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm_dyn()
 			cs_free(insn);

--- a/tests/test_arm.c
+++ b/tests/test_arm.c
@@ -196,10 +196,10 @@ static void test()
 
 			size_t j;
 			for (j = 0; j < count; j++) {
-				printf("0x%zu:\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIu64 ":\t%s\t%s\n", (uint64_t) insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(platforms[i].mode, &insn[j]);
 			}
-			printf("0x%zu:\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIu64 ":\n", (uint64_t) insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm_dyn()
 			cs_free(insn);

--- a/tests/test_arm64.c
+++ b/tests/test_arm64.c
@@ -162,10 +162,10 @@ static void test()
 
 			size_t j;
 			for (j = 0; j < count; j++) {
-				printf("0x%zu:\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIu64 ":\t%s\t%s\n", (uint64_t) insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(platforms[i].mode, &insn[j]);
 			}
-			printf("0x%zu:\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIu64 ":\n", (uint64_t) insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm_dyn()
 			cs_free(insn);

--- a/tests/test_detail.c
+++ b/tests/test_detail.c
@@ -148,8 +148,8 @@ static void test()
 			int n;
 			for (j = 0; j < count; j++) {
 				cs_insn *i = &(all_insn[j]);
-				printf("0x%zu:\t%s\t\t%s // insn-ID: %u, insn-mnem: %s\n",
-						i->address, i->mnemonic, i->op_str,
+				printf("0x%" PRIu64 ":\t%s\t\t%s // insn-ID: %u, insn-mnem: %s\n",
+						(uint64_t) i->address, i->mnemonic, i->op_str,
 						i->id, cs_insn_name(handle, i->id));
 
 				// print implicit registers used by this instruction
@@ -187,7 +187,7 @@ static void test()
 			}
 
 			// print out the next offset, after the last insn
-			printf("0x%zu:\n", all_insn[j-1].address + all_insn[j-1].size);
+			printf("0x%" PRIu64 ":\n", (uint64_t) all_insn[j-1].address + all_insn[j-1].size);
 
 			// free memory allocated by cs_disasm_dyn()
 			cs_free(all_insn);

--- a/tests/test_mips.c
+++ b/tests/test_mips.c
@@ -109,10 +109,10 @@ static void test()
 
 			size_t j;
 			for (j = 0; j < count; j++) {
-				printf("0x%zu:\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIu64 ":\t%s\t%s\n", (uint64_t) insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(platforms[i].mode, &insn[j]);
 			}
-			printf("0x%zu:\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIu64 ":\n", (uint64_t) insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm_dyn()
 			cs_free(insn);

--- a/tests/test_x86.c
+++ b/tests/test_x86.c
@@ -163,10 +163,10 @@ static void test()
 
 			size_t j;
 			for (j = 0; j < count; j++) {
-				printf("0x%zu:\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIu64 ":\t%s\t%s\n", (uint64_t) insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(handle, platforms[i].mode, &insn[j]);
 			}
-			printf("0x%zu:\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIu64 ":\n", (uint64_t) insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm_dyn()
 			cs_free(insn);


### PR DESCRIPTION
tested on:

Cygwin: Cygwin gcc, 32-bit MingW and 64-bit MingW
Linux: nix32, clang, cross-win32, cross-win64

NOTE: Please someone test this on OSX
