### PR TITLE
Use const on all read-only buffers

### DIFF
--- a/arch/AArch64/AArch64Disassembler.c
+++ b/arch/AArch64/AArch64Disassembler.c
@@ -281,7 +281,7 @@ void AArch64_init(MCRegisterInfo *MRI)
 
 
 static DecodeStatus _getInstruction(MCInst *MI,
-		unsigned char *code, size_t code_len,
+		const uint8_t *code, size_t code_len,
 		uint16_t *Size,
 		uint64_t Address, MCRegisterInfo *MRI)
 {

--- a/arch/AArch64/AArch64Disassembler.h
+++ b/arch/AArch64/AArch64Disassembler.h
@@ -12,7 +12,7 @@
 
 void AArch64_init(MCRegisterInfo *MRI);
 
-bool AArch64_getInstruction(csh ud, unsigned char *code, size_t code_len,
+bool AArch64_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 		MCInst *instr, uint16_t *size, uint64_t address, void *info);
 
 #endif

--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -657,7 +657,7 @@ static void printVectorList(MCInst *MI, unsigned OpNum,
 #define PRINT_ALIAS_INSTR
 #include "AArch64GenAsmWriter.inc"
 
-void AArch64_post_printer(unsigned int insn, cs_insn *pub_insn, char *insn_asm)
+void AArch64_post_printer(unsigned int insn, cs_insn *pub_insn, const char *insn_asm)
 {
 	// check if this insn requests write-back
 	if (strrchr(insn_asm, '!') != NULL)

--- a/arch/AArch64/AArch64InstPrinter.h
+++ b/arch/AArch64/AArch64InstPrinter.h
@@ -23,6 +23,6 @@
 
 void AArch64_printInst(MCInst *MI, SStream *O, void *);
 
-void AArch64_post_printer(unsigned int insn, cs_insn *pub_insn, char *insn_asm);
+void AArch64_post_printer(unsigned int insn, cs_insn *pub_insn, const char *insn_asm);
 
 #endif

--- a/arch/AArch64/mapping.c
+++ b/arch/AArch64/mapping.c
@@ -436,7 +436,7 @@ static name_map reg_name_maps[] = {
 	{ ARM64_REG_Q31_Q0_Q1_Q2, "q31_q0_q1_q2"},
 };
 
-char *AArch64_reg_name(csh handle, unsigned int reg)
+const char *AArch64_reg_name(csh handle, unsigned int reg)
 {
 	if (reg >= ARM64_REG_MAX)
 		return NULL;
@@ -3684,7 +3684,7 @@ static name_map alias_insn_name_maps[] = {
 	{ ARM64_INS_NEGS, "negs" },
 };
 
-char *AArch64_insn_name(csh handle, unsigned int id)
+const char *AArch64_insn_name(csh handle, unsigned int id)
 {
 	if (id >= ARM64_INS_MAX)
 		return NULL;
@@ -3700,7 +3700,7 @@ char *AArch64_insn_name(csh handle, unsigned int id)
 }
 
 // map instruction name to public instruction ID
-arm64_reg AArch64_map_insn(char *name)
+arm64_reg AArch64_map_insn(const char *name)
 {
 	// NOTE: skip first NULL name in insn_name_maps
 	int i = name2id(&insn_name_maps[1], ARR_SIZE(insn_name_maps) - 1, name);

--- a/arch/AArch64/mapping.h
+++ b/arch/AArch64/mapping.h
@@ -8,7 +8,7 @@
 #include "../../include/arm64.h"
 
 // return name of regiser in friendly string
-char *AArch64_reg_name(csh handle, unsigned int reg);
+const char *AArch64_reg_name(csh handle, unsigned int reg);
 
 // given internal insn id, return public instruction info
 void AArch64_get_insn_id(cs_insn *insn, unsigned int id);
@@ -16,9 +16,9 @@ void AArch64_get_insn_id(cs_insn *insn, unsigned int id);
 // given public insn id, return internal instruction ID
 unsigned int AArch64_get_insn_id2(unsigned int id);
 
-char *AArch64_insn_name(csh handle, unsigned int id);
+const char *AArch64_insn_name(csh handle, unsigned int id);
 
 // map instruction name to public instruction ID
-arm64_reg AArch64_map_insn(char *name);
+arm64_reg AArch64_map_insn(const char *name);
 
 #endif

--- a/arch/ARM/ARMDisassembler.c
+++ b/arch/ARM/ARMDisassembler.c
@@ -435,7 +435,7 @@ void ARM_init(MCRegisterInfo *MRI)
 			0);
 }
 
-static DecodeStatus _ARM_getInstruction(cs_struct *ud, MCInst *MI, unsigned char *code, size_t code_len,
+static DecodeStatus _ARM_getInstruction(cs_struct *ud, MCInst *MI, const uint8_t *code, size_t code_len,
 		uint16_t *Size, uint64_t Address)
 {
 	uint8_t bytes[4];
@@ -656,7 +656,7 @@ static void UpdateThumbVFPPredicate(cs_struct *ud, MCInst *MI)
 	}
 }
 
-static DecodeStatus _Thumb_getInstruction(cs_struct *ud, MCInst *MI, unsigned char *code, size_t code_len,
+static DecodeStatus _Thumb_getInstruction(cs_struct *ud, MCInst *MI, const uint8_t *code, size_t code_len,
 		uint16_t *Size, uint64_t Address)
 {
 	uint8_t bytes[4];
@@ -830,7 +830,7 @@ static DecodeStatus _Thumb_getInstruction(cs_struct *ud, MCInst *MI, unsigned ch
 	return MCDisassembler_Fail;
 }
 
-bool Thumb_getInstruction(csh ud, unsigned char *code, size_t code_len, MCInst *instr,
+bool Thumb_getInstruction(csh ud, const uint8_t *code, size_t code_len, MCInst *instr,
 		uint16_t *size, uint64_t address, void *info)
 {
 	DecodeStatus status = _Thumb_getInstruction((cs_struct *)ud, instr, code, code_len, size, address);
@@ -839,7 +839,7 @@ bool Thumb_getInstruction(csh ud, unsigned char *code, size_t code_len, MCInst *
 	return status != MCDisassembler_Fail;
 }
 
-bool ARM_getInstruction(csh ud, unsigned char *code, size_t code_len, MCInst *instr,
+bool ARM_getInstruction(csh ud, const uint8_t *code, size_t code_len, MCInst *instr,
 		uint16_t *size, uint64_t address, void *info)
 {
 	DecodeStatus status = _ARM_getInstruction((cs_struct *)ud, instr, code, code_len, size, address);

--- a/arch/ARM/ARMDisassembler.h
+++ b/arch/ARM/ARMDisassembler.h
@@ -9,9 +9,9 @@
 
 void ARM_init(MCRegisterInfo *MRI);
 
-bool ARM_getInstruction(csh handle, unsigned char *code, size_t code_len, MCInst *instr, uint16_t *size, uint64_t address, void *info);
+bool ARM_getInstruction(csh handle, const uint8_t *code, size_t code_len, MCInst *instr, uint16_t *size, uint64_t address, void *info);
 
-bool Thumb_getInstruction(csh handle, unsigned char *code, size_t code_len, MCInst *instr, uint16_t *size, uint64_t address, void *info);
+bool Thumb_getInstruction(csh handle, const uint8_t *code, size_t code_len, MCInst *instr, uint16_t *size, uint64_t address, void *info);
 
 uint64_t ARM_getFeatureBits(int mode);
 

--- a/arch/ARM/ARMInstPrinter.c
+++ b/arch/ARM/ARMInstPrinter.c
@@ -219,7 +219,7 @@ static name_map insn_update_flgs[] = {
 	{ ARM_INS_UMULL, "umulls" },
 };
 
-void ARM_post_printer(unsigned int insn, cs_insn *pub_insn, char *insn_asm)
+void ARM_post_printer(unsigned int insn, cs_insn *pub_insn, const char *insn_asm)
 {
 	// check if this insn requests write-back
 	if (strrchr(insn_asm, '!') != NULL) {

--- a/arch/ARM/ARMInstPrinter.h
+++ b/arch/ARM/ARMInstPrinter.h
@@ -22,6 +22,6 @@
 #include "../../SStream.h"
 
 void ARM_printInst(MCInst *MI, SStream *O, void *Info);
-void ARM_post_printer(unsigned int insn, cs_insn *pub_insn, char *mnem);
+void ARM_post_printer(unsigned int insn, cs_insn *pub_insn, const char *mnem);
 
 #endif

--- a/arch/ARM/mapping.c
+++ b/arch/ARM/mapping.c
@@ -125,7 +125,7 @@ static name_map reg_name_maps[] = {
 	{ ARM_REG_S31, "s31"},
 };
 
-char *ARM_reg_name(csh handle, unsigned int reg)
+const char *ARM_reg_name(csh handle, unsigned int reg)
 {
 	if (reg >= ARM_REG_MAX)
 		return NULL;
@@ -2763,7 +2763,7 @@ static name_map insn_name_maps[] = {
 	{ ARM_INS_PUSH, "push" },
 };
 
-char *ARM_insn_name(csh handle, unsigned int id)
+const char *ARM_insn_name(csh handle, unsigned int id)
 {
 	if (id >= ARM_INS_MAX)
 		return NULL;
@@ -2771,7 +2771,7 @@ char *ARM_insn_name(csh handle, unsigned int id)
 	return insn_name_maps[id].name;
 }
 
-arm_reg ARM_map_insn(char *name)
+arm_reg ARM_map_insn(const char *name)
 {
 	int i = name2id(&insn_name_maps[1], ARR_SIZE(insn_name_maps) - 1, name);
 

--- a/arch/ARM/mapping.h
+++ b/arch/ARM/mapping.h
@@ -9,7 +9,7 @@
 #include "../../utils.h"
 
 // return name of regiser in friendly string
-char *ARM_reg_name(csh handle, unsigned int reg);
+const char *ARM_reg_name(csh handle, unsigned int reg);
 
 // given internal insn id, return public instruction ID
 void ARM_get_insn_id(cs_insn *insn, unsigned int id);
@@ -17,10 +17,10 @@ void ARM_get_insn_id(cs_insn *insn, unsigned int id);
 // given public insn id, return internal instruction info
 unsigned int ARM_get_insn_id2(unsigned int id);
 
-char *ARM_insn_name(csh handle, unsigned int id);
+const char *ARM_insn_name(csh handle, unsigned int id);
 
 // map instruction name to instruction ID
-arm_reg ARM_map_insn(char *name);
+arm_reg ARM_map_insn(const char *name);
 
 // check if this insn is relative branch
 bool ARM_rel_branch(unsigned int insn_id);

--- a/arch/Mips/MipsDisassembler.c
+++ b/arch/Mips/MipsDisassembler.c
@@ -243,7 +243,7 @@ static DecodeStatus readInstruction32(unsigned char *code, uint32_t *insn, bool 
 }
 
 static DecodeStatus MipsDisassembler_getInstruction(int mode, MCInst *instr,
-		unsigned char *code, size_t code_len,
+		const uint8_t *code, size_t code_len,
 		uint16_t *Size,
 		uint64_t Address, bool isBigEndian, MCRegisterInfo *MRI)
 {
@@ -278,7 +278,7 @@ static DecodeStatus MipsDisassembler_getInstruction(int mode, MCInst *instr,
 	return MCDisassembler_Fail;
 }
 
-bool Mips_getInstruction(csh ud, unsigned char *code, size_t code_len, MCInst *instr,
+bool Mips_getInstruction(csh ud, const uint8_t *code, size_t code_len, MCInst *instr,
 		uint16_t *size, uint64_t address, void *info)
 {
 	cs_struct *handle = (cs_struct *)(uintptr_t)ud;

--- a/arch/Mips/MipsDisassembler.h
+++ b/arch/Mips/MipsDisassembler.h
@@ -11,10 +11,10 @@
 
 void Mips_init(MCRegisterInfo *MRI);
 
-bool Mips_getInstruction(csh handle, unsigned char *code, size_t code_len,
+bool Mips_getInstruction(csh handle, const uint8_t *code, size_t code_len,
 		MCInst *instr, uint16_t *size, uint64_t address, void *info);
 
-bool Mips64_getInstruction(csh handle, unsigned char *code, size_t code_len,
+bool Mips64_getInstruction(csh handle, const uint8_t *code, size_t code_len,
 		MCInst *instr, uint16_t *size, uint64_t address, void *info);
 
 #endif

--- a/arch/Mips/mapping.c
+++ b/arch/Mips/mapping.c
@@ -173,7 +173,7 @@ static name_map reg_name_maps[] = {
 	{ MIPS_REG_W31, "w31"},
 };
 
-char *Mips_reg_name(csh handle, unsigned int reg)
+const char *Mips_reg_name(csh handle, unsigned int reg)
 {
 	if (reg >= MIPS_REG_MAX)
 		return NULL;
@@ -1917,7 +1917,7 @@ static name_map alias_insn_names[] = {
 	{ MIPS_INS_NEGU, "negu" },
 };
 
-char *Mips_insn_name(csh handle, unsigned int id)
+const char *Mips_insn_name(csh handle, unsigned int id)
 {
 	if (id >= MIPS_INS_MAX)
 		return NULL;
@@ -1932,7 +1932,7 @@ char *Mips_insn_name(csh handle, unsigned int id)
 	return insn_name_maps[id].name;
 }
 
-mips_reg Mips_map_insn(char *name)
+mips_reg Mips_map_insn(const char *name)
 {
 	// handle special alias first
 	int i;

--- a/arch/Mips/mapping.h
+++ b/arch/Mips/mapping.h
@@ -8,7 +8,7 @@
 #include "../../include/mips.h"
 
 // return name of regiser in friendly string
-char *Mips_reg_name(csh handle, unsigned int reg);
+const char *Mips_reg_name(csh handle, unsigned int reg);
 
 // given internal insn id, return public instruction info
 void Mips_get_insn_id(cs_insn *insn, unsigned int id);
@@ -17,10 +17,10 @@ void Mips_get_insn_id(cs_insn *insn, unsigned int id);
 unsigned int Mips_get_insn_id2(unsigned int id);
 
 // given public insn id, return internal insn id
-char *Mips_insn_name(csh handle, unsigned int id);
+const char *Mips_insn_name(csh handle, unsigned int id);
 
 // map instruction name to instruction ID
-mips_reg Mips_map_insn(char *name);
+mips_reg Mips_map_insn(const char *name);
 
 // map internal raw register to 'public' register
 mips_reg Mips_map_register(unsigned int r);

--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -35,7 +35,7 @@
 #include "X86GenInstrInfo.inc"
 
 struct reader_info {
-	unsigned char *code;
+	const uint8_t *code;
 	uint64_t size;
 	uint64_t offset;
 };
@@ -567,7 +567,7 @@ static void update_pub_insn(cs_insn *pub, InternalInstruction *inter)
 }
 
 // Public interface for the disassembler
-bool X86_getInstruction(csh ud, unsigned char *code, size_t code_len, MCInst *instr, uint16_t *size, uint64_t address, void *_info)
+bool X86_getInstruction(csh ud, const uint8_t *code, size_t code_len, MCInst *instr, uint16_t *size, uint64_t address, void *_info)
 {
 	cs_struct *handle = (cs_struct *)(uintptr_t)ud;
 	InternalInstruction insn;

--- a/arch/X86/X86Disassembler.h
+++ b/arch/X86/X86Disassembler.h
@@ -95,7 +95,7 @@
 #undef INSTRUCTION_SPECIFIER_FIELDS
 #undef INSTRUCTION_IDS
 
-bool X86_getInstruction(csh handle, unsigned char *code, size_t code_len,
+bool X86_getInstruction(csh handle, const uint8_t *code, size_t code_len,
 		MCInst *instr, uint16_t *size, uint64_t address, void *info);
 
 #endif

--- a/arch/X86/mapping.c
+++ b/arch/X86/mapping.c
@@ -301,7 +301,7 @@ static name_map reg_name_maps[] = {
 	{ X86_REG_R15W, "r15w" },
 };
 
-char *X86_reg_name(csh handle, unsigned int reg)
+const char *X86_reg_name(csh handle, unsigned int reg)
 {
 	cs_struct *ud = (cs_struct *)handle;
 
@@ -318,7 +318,7 @@ char *X86_reg_name(csh handle, unsigned int reg)
 	return reg_name_maps[reg].name;
 }
 
-x86_reg x86_map_regname(char *reg)
+x86_reg x86_map_regname(const char *reg)
 {
 	int i = name2id(&reg_name_maps[1], ARR_SIZE(reg_name_maps) - 1, reg);
 
@@ -1579,7 +1579,7 @@ static name_map insn_name_maps[] = {
 	{ X86_INS_XTEST, "xtest" },
 };
 
-char *X86_insn_name(csh handle, unsigned int id)
+const char *X86_insn_name(csh handle, unsigned int id)
 {
 	if (id >= X86_INS_MAX)
 		return NULL;
@@ -1588,7 +1588,7 @@ char *X86_insn_name(csh handle, unsigned int id)
 }
 
 // return insn id, given insn mnemonic
-x86_reg X86_map_insn(char *name)
+x86_reg X86_map_insn(const char *name)
 {
 	int i = name2id(&insn_name_maps[1], ARR_SIZE(insn_name_maps) - 1, name);
 

--- a/arch/X86/mapping.h
+++ b/arch/X86/mapping.h
@@ -17,19 +17,19 @@ x86_reg x86_map_sib_index(int r);
 x86_reg x86_map_segment(int r);
 
 // map register name to x86_reg
-x86_reg x86_map_regname(char *reg);
+x86_reg x86_map_regname(const char *reg);
 
 // return name of regiser in friendly string
-char *X86_reg_name(csh handle, unsigned int reg);
+const char *X86_reg_name(csh handle, unsigned int reg);
 
 // given internal insn id, return public instruction info
 void X86_get_insn_id(cs_insn *insn, unsigned int id);
 
 // return insn name, given insn id
-char *X86_insn_name(csh handle, unsigned int id);
+const char *X86_insn_name(csh handle, unsigned int id);
 
 // return insn id, given insn mnemonic
-x86_reg X86_map_insn(char *mnem);
+x86_reg X86_map_insn(const char *mnem);
 
 // given public insn id, return internal insn id
 unsigned int X86_get_insn_id2(unsigned int insn_id);

--- a/cs.c
+++ b/cs.c
@@ -164,7 +164,7 @@ cs_err cs_close(csh handle)
 
 // fill insn with mnemonic & operands info
 static void fill_insn(cs_struct *handle, cs_insn *insn, char *buffer, MCInst *mci,
-		PostPrinter_t printer, unsigned char *code)
+		PostPrinter_t printer, const uint8_t *code)
 {
 	memcpy(insn, &mci->pub_insn, sizeof(*insn));
 
@@ -231,7 +231,7 @@ cs_err cs_option(csh ud, cs_opt_type type, size_t value)
 	return CS_ERR_OK;
 }
 
-size_t cs_disasm(csh ud, unsigned char *buffer, size_t size, uint64_t offset, size_t count, cs_insn *insn)
+size_t cs_disasm(csh ud, const uint8_t *buffer, size_t size, uint64_t offset, size_t count, cs_insn *insn)
 {
 	cs_struct *handle = (cs_struct *)(uintptr_t)ud;
 	MCInst mci;
@@ -281,7 +281,7 @@ size_t cs_disasm(csh ud, unsigned char *buffer, size_t size, uint64_t offset, si
 
 // dynamicly allocate memory to contain disasm insn
 // NOTE: caller must free() the allocated memory itself to avoid memory leaking
-size_t cs_disasm_dyn(csh ud, unsigned char *buffer, size_t size, uint64_t offset, size_t count, cs_insn **insn)
+size_t cs_disasm_dyn(csh ud, const uint8_t *buffer, size_t size, uint64_t offset, size_t count, cs_insn **insn)
 {
 	cs_struct *handle = (cs_struct *)(uintptr_t)ud;
 	MCInst mci;
@@ -369,7 +369,7 @@ void cs_free(void *m)
 }
 
 // return friendly name of regiser in a string
-char *cs_reg_name(csh ud, unsigned int reg)
+const char *cs_reg_name(csh ud, unsigned int reg)
 {
 	cs_struct *handle = (cs_struct *)(uintptr_t)ud;
 
@@ -380,7 +380,7 @@ char *cs_reg_name(csh ud, unsigned int reg)
 	return handle->reg_name(ud, reg);
 }
 
-char *cs_insn_name(csh ud, unsigned int insn)
+const char *cs_insn_name(csh ud, unsigned int insn)
 {
 	cs_struct *handle = (cs_struct *)(uintptr_t)ud;
 

--- a/cs_priv.h
+++ b/cs_priv.h
@@ -13,11 +13,11 @@ typedef void (*Printer_t)(MCInst *MI, SStream *OS, void *info);
 
 // function to be called after Printer_t
 // this is the best time to gather insn's characteristics
-typedef void (*PostPrinter_t)(unsigned int insn, cs_insn *, char *mnem);
+typedef void (*PostPrinter_t)(unsigned int insn, cs_insn *, const char *mnem);
 
-typedef bool (*Disasm_t)(csh handle, unsigned char *code, size_t code_len, MCInst *instr, uint16_t *size, uint64_t address, void *info);
+typedef bool (*Disasm_t)(csh handle, const uint8_t *code, size_t code_len, MCInst *instr, uint16_t *size, uint64_t address, void *info);
 
-typedef char *(*GetName_t)(csh handle, unsigned int reg);
+typedef const char *(*GetName_t)(csh handle, unsigned int reg);
 
 typedef void (*GetID_t)(cs_insn *insn, unsigned int id);
 

--- a/include/capstone.h
+++ b/include/capstone.h
@@ -71,7 +71,7 @@ typedef struct cs_insn {
 	// Size of this instruction
 	uint16_t size;
 	// Machine bytes of this instruction, with number of bytes indicated by @size above
-	unsigned char bytes[16];
+	uint8_t bytes[16];
 
 	// Ascii text of instruction mnemonic
 	char mnemonic[32];
@@ -189,7 +189,7 @@ cs_err cs_errno(csh handle);
  On failure, call cs_errno() for error code.
 */
 size_t cs_disasm(csh handle,
-		unsigned char *code, size_t code_size,
+		const uint8_t *code, size_t code_size,
 		uint64_t address,
 		size_t count,
 		cs_insn *insn);
@@ -216,7 +216,7 @@ size_t cs_disasm(csh handle,
  On failure, call cs_errno() for error code.
 */
 size_t cs_disasm_dyn(csh handle,
-		unsigned char *code, size_t code_size,
+		const uint8_t *code, size_t code_size,
 		uint64_t address,
 		size_t count,
 		cs_insn **insn);
@@ -236,7 +236,7 @@ void cs_free(void *mem);
  @reg: register id
  @return: string name of the register, or NULL if @reg_id is invalid.
 */
-char *cs_reg_name(csh handle, unsigned int reg_id);
+const char *cs_reg_name(csh handle, unsigned int reg_id);
 
 /*
  Return friendly name of an instruction in a string
@@ -247,7 +247,7 @@ char *cs_reg_name(csh handle, unsigned int reg_id);
 
  @return: string name of the instruction, or NULL if @insn_id is invalid.
 */
-char *cs_insn_name(csh handle, unsigned int insn_id);
+const char *cs_insn_name(csh handle, unsigned int insn_id);
 
 /*
  Check if a disassembled instruction belong to a particular group.

--- a/utils.c
+++ b/utils.c
@@ -39,7 +39,7 @@ int insn_find(insn_map *m, unsigned int max, unsigned int id)
 	return -1;
 }
 
-int name2id(name_map* map, int max, char *name)
+int name2id(name_map* map, int max, const char *name)
 {
 	int i;
 

--- a/utils.h
+++ b/utils.h
@@ -38,7 +38,7 @@ typedef struct name_map {
 
 // map a name to its ID
 // return 0 if not found
-int name2id(name_map* map, int max, char *name);
+int name2id(name_map* map, int max, const char *name);
 
 // reverse mapid to id
 // return 0 if not found


### PR DESCRIPTION
This change shouldn't break the bindings and it properly defines which buffers must be read only and doesn't require to be free'd and cannot be modified.
