### PR TITLE
Fix the X86_REL_ADDR macro in x86.h

### DIFF
--- a/include/x86.h
+++ b/include/x86.h
@@ -11,7 +11,7 @@ extern "C" {
 #include <stdint.h>
 
 // Calculate relative address for X86-64, given cs_insn structure
-#define X86_REL_ADDR(insn) (insn.addr + insn.size + insn.x86.disp)
+#define X86_REL_ADDR(insn) (insn.address + insn.size + insn.detail->x86.disp)
 
 //> X86 registers
 typedef enum x86_reg {


### PR DESCRIPTION
Leftover bug from 1.0.

https://twitter.com/capstone_engine/status/435823279731798016
