### PR TITLE
Fix build out of tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ifndef BUILDDIR
 BLDIR = .
 OBJDIR = .
 else
-BLDIR = $(BUILDDIR)
+BLDIR = $(abspath $(BUILDDIR))
 OBJDIR = $(BLDIR)/obj
 endif
 INCDIR = $(DESTDIR)$(PREFIX)/include
@@ -254,7 +254,7 @@ PKGCFGF = $(BLDIR)/$(LIBNAME).pc
 .PHONY: all clean install uninstall dist
 
 all: $(LIBRARY) $(ARCHIVE) $(PKGCFGF)
-	$(MAKE) -C tests
+	$(MAKE) -C tests BUILDDIR=$(BLDIR)
 	$(INSTALL_DATA) $(BLDIR)/lib$(LIBNAME).$(EXT) $(BLDIR)/tests/
 
 $(LIBRARY): $(LIBOBJ)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,7 +10,7 @@ OBJDIR = .
 LIBDIR = ..
 else
 TESTDIR = $(BUILDDIR)/tests
-OBJDIR = $(BUILDDIR)/obj
+OBJDIR = $(BUILDDIR)/obj/tests
 LIBDIR = $(BUILDDIR)
 endif
 


### PR DESCRIPTION
Just some minor fixes to allow `BUILDDIR` to be an absolute or relative path.
