### PR TITLE
Improve the build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,8 +253,12 @@ endif
 endif
 endif
 
+ifeq ($(CAPSTONE_SHARED),yes)
 LIBRARY = $(BLDIR)/lib$(LIBNAME).$(EXT)
+endif
+ifeq ($(CAPSTONE_STATIC),yes)
 ARCHIVE = $(BLDIR)/lib$(LIBNAME).$(AR_EXT)
+endif
 PKGCFGF = $(BLDIR)/$(LIBNAME).pc
 
 .PHONY: all clean install uninstall dist
@@ -265,14 +269,18 @@ ifndef BUILDDIR
 else
 	$(MAKE) -C tests BUILDDIR=$(BLDIR)
 endif
+ifeq ($(CAPSTONE_SHARED),yes)
 	$(INSTALL_DATA) $(BLDIR)/lib$(LIBNAME).$(EXT) $(BLDIR)/tests/
+endif
 
+ifeq ($(CAPSTONE_SHARED),yes)
 $(LIBRARY): $(LIBOBJ)
 ifeq ($(V),0)
 	$(call log,CCLD,$(@:$(BLDIR)/%=%))
 	@$(create-library)
 else
 	$(create-library)
+endif
 endif
 
 $(LIBOBJ): config.mk
@@ -285,6 +293,7 @@ $(LIBOBJ_SPARC): $(DEP_SPARC)
 $(LIBOBJ_SYSZ): $(DEP_SYSZ)
 $(LIBOBJ_X86): $(DEP_X86)
 
+ifeq ($(CAPSTONE_STATIC),yes)
 $(ARCHIVE): $(LIBOBJ)
 	@rm -f $(ARCHIVE)
 ifeq ($(V),0)
@@ -292,6 +301,7 @@ ifeq ($(V),0)
 	@$(create-archive)
 else
 	$(create-archive)
+endif
 endif
 
 $(PKGCFGF):
@@ -304,6 +314,7 @@ endif
 
 install: $(PKGCFGF) $(ARCHIVE) $(LIBRARY)
 	mkdir -p $(LIBDIR)
+ifeq ($(CAPSTONE_SHARED),yes)
 	# remove potential broken old libs
 	rm -f $(LIBDIR)/lib$(LIBNAME).*
 	$(INSTALL_LIB) $(BLDIR)/lib$(LIBNAME).$(EXT) $(LIBDIR)
@@ -312,7 +323,10 @@ ifneq ($(VERSION_EXT),)
 	mv lib$(LIBNAME).$(EXT) lib$(LIBNAME).$(VERSION_EXT) && \
 	ln -s lib$(LIBNAME).$(VERSION_EXT) lib$(LIBNAME).$(EXT)
 endif
+endif
+ifeq ($(CAPSTONE_STATIC),yes)
 	$(INSTALL_DATA) $(BLDIR)/lib$(LIBNAME).$(AR_EXT) $(LIBDIR)
+endif
 	mkdir -p $(INCDIR)/$(LIBNAME)
 	$(INSTALL_DATA) include/*.h $(INCDIR)/$(LIBNAME)
 	mkdir -p $(PKGCFGDIR)

--- a/config.mk
+++ b/config.mk
@@ -54,3 +54,17 @@ CAPSTONE_DIET ?= no
 # thus supports complete X86 instructions.
 
 CAPSTONE_X86_REDUCE ?= no
+
+
+################################################################################
+# Change 'CAPSTONE_STATIC = yes' to 'CAPSTONE_STATIC = no' to avoid building
+# a static library.
+
+CAPSTONE_STATIC ?= yes
+
+
+################################################################################
+# Change 'CAPSTONE_SHARED = yes' to 'CAPSTONE_SHARED = no' to avoid building
+# a shared library.
+
+CAPSTONE_SHARED ?= yes

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -86,13 +86,21 @@ $(BINARY): $(OBJS)
 $(TESTDIR)/%$(BIN_EXT): $(OBJDIR)/%.o
 	@mkdir -p $(@D)
 ifeq ($(V),0)
+ifeq ($(CAPSTONE_SHARED),yes)
 	$(call log,CCLD,$(notdir $@))
 	@$(link-dynamic)
+endif
+ifeq ($(CAPSTONE_STATIC),yes)
 	$(call log,CCLD,$(notdir $(call staticname,$@)))
 	@$(link-static)
+endif
 else
+ifeq ($(CAPSTONE_SHARED),yes)
 	$(link-dynamic)
+endif
+ifeq ($(CAPSTONE_STATIC),yes)
 	$(link-static)
+endif
 endif
 
 $(OBJDIR)/%.o: %.c


### PR DESCRIPTION
This allows Frida to use capstone's build system as-is:
https://github.com/frida/frida-build-env/commit/d618aaca4c4b7365c4a5b225ff58551c005eca80

I also made the output much less verbose by default (all other Frida-modules get this for free, and it's something I can recommend as it makes it much easier to spot warnings and anomalies in the build output). So when you need to debug compiler flags it's just a matter of adding `V=1`, e.g. `make V=1`.
