### PR TITLE
Make capstone library compile with arm-none-eabi-gcc 4.8

### DIFF
--- a/arch/AArch64/AArch64Disassembler.c
+++ b/arch/AArch64/AArch64Disassembler.c
@@ -165,7 +165,7 @@ static DecodeStatus DecodeLDSTPairInstruction(MCInst *Inst,
 		void *Decoder);
 
 static DecodeStatus DecodeLoadPairExclusiveInstruction(MCInst *Inst,
-		unsigned Val,
+		uint32_t Val,
 		uint64_t Address,
 		void *Decoder);
 

--- a/arch/ARM/ARMDisassembler.c
+++ b/arch/ARM/ARMDisassembler.c
@@ -349,11 +349,11 @@ static DecodeStatus DecodeT2LDRDPreInstruction(MCInst *Inst,unsigned Insn,
 		uint64_t Address, const void *Decoder);
 static DecodeStatus DecodeT2STRDPreInstruction(MCInst *Inst,unsigned Insn,
 		uint64_t Address, const void *Decoder);
-static DecodeStatus DecodeT2Adr(MCInst *Inst, unsigned Val,
+static DecodeStatus DecodeT2Adr(MCInst *Inst, uint32_t Val,
 		uint64_t Address, const void *Decoder);
 static DecodeStatus DecodeT2LdStPre(MCInst *Inst, unsigned Val,
 		uint64_t Address, const void *Decoder);
-static DecodeStatus DecodeT2ShifterImmOperand(MCInst *Inst, unsigned Val,
+static DecodeStatus DecodeT2ShifterImmOperand(MCInst *Inst, uint32_t Val,
 		uint64_t Address, const void *Decoder);
 
 static DecodeStatus DecodeLDR(MCInst *Inst, unsigned Val,


### PR DESCRIPTION
As title says, capstone currently does not build with gcc-arm-none-eabi due clashing type definitions. This patch makes it work properly.

Note that I selected uint32_t over the generic unsigned but I suppose it could also work the other way around. 
