### PR TITLE
Prevent some capstone segfaults

### DIFF
--- a/cs.c
+++ b/cs.c
@@ -609,15 +609,15 @@ bool cs_insn_group(csh ud, cs_insn *insn, unsigned int group_id)
 		return false;
 	}
 
-    if(!insn->id) {
-        handle->errnum = CS_ERR_SKIPDATA;
-        return false;
-    }
+	if(!insn->id) {
+		handle->errnum = CS_ERR_SKIPDATA;
+		return false;
+	}
 
-    if(!insn->detail) {
-        handle->errnum = CS_ERR_DETAIL;
-        return false;
-    }
+	if(!insn->detail) {
+		handle->errnum = CS_ERR_DETAIL;
+		return false;
+	}
 
 	return arr_exist(insn->detail->groups, insn->detail->groups_count, group_id);
 }
@@ -634,15 +634,15 @@ bool cs_reg_read(csh ud, cs_insn *insn, unsigned int reg_id)
 		return false;
 	}
 
-    if(!insn->id) {
-        handle->errnum = CS_ERR_SKIPDATA;
-        return false;
-    }
+	if(!insn->id) {
+		handle->errnum = CS_ERR_SKIPDATA;
+		return false;
+	}
 
-    if(!insn->detail) {
-        handle->errnum = CS_ERR_DETAIL;
-        return false;
-    }
+	if(!insn->detail) {
+		handle->errnum = CS_ERR_DETAIL;
+		return false;
+	}
 
 	return arr_exist(insn->detail->regs_read, insn->detail->regs_read_count, reg_id);
 }
@@ -653,20 +653,21 @@ bool cs_reg_write(csh ud, cs_insn *insn, unsigned int reg_id)
 		return false;
 
 	struct cs_struct *handle = (struct cs_struct *)(uintptr_t)ud;
+
 	if (!handle->detail) {
 		handle->errnum = CS_ERR_DETAIL;
 		return false;
 	}
 
-    if(!insn->id) {
-        handle->errnum = CS_ERR_SKIPDATA;
-        return false;
-    }
+	if(!insn->id) {
+		handle->errnum = CS_ERR_SKIPDATA;
+		return false;
+	}
 
-    if(!insn->detail) {
-        handle->errnum = CS_ERR_DETAIL;
-        return false;
-    }
+	if(!insn->detail) {
+		handle->errnum = CS_ERR_DETAIL;
+		return false;
+	}
 
 	return arr_exist(insn->detail->regs_write, insn->detail->regs_write_count, reg_id);
 }
@@ -683,15 +684,15 @@ int cs_op_count(csh ud, cs_insn *insn, unsigned int op_type)
 		return -1;
 	}
 
-    if(!insn->id) {
-        handle->errnum = CS_ERR_SKIPDATA;
-        return -1;
-    }
+	if(!insn->id) {
+		handle->errnum = CS_ERR_SKIPDATA;
+		return -1;
+	}
 
-    if(!insn->detail) {
-        handle->errnum = CS_ERR_DETAIL;
-        return -1;
-    }
+	if(!insn->detail) {
+		handle->errnum = CS_ERR_DETAIL;
+		return -1;
+	}
 
 	unsigned int count = 0, i;
 
@@ -754,15 +755,15 @@ int cs_op_index(csh ud, cs_insn *insn, unsigned int op_type,
 		return -1;
 	}
 
-    if(!insn->id) {
-        handle->errnum = CS_ERR_SKIPDATA;
-        return -1;
-    }
+	if(!insn->id) {
+		handle->errnum = CS_ERR_SKIPDATA;
+		return -1;
+	}
 
-    if(!insn->detail) {
-        handle->errnum = CS_ERR_DETAIL;
-        return -1;
-    }
+	if(!insn->detail) {
+		handle->errnum = CS_ERR_DETAIL;
+		return -1;
+	}
 
 	unsigned int count = 0, i;
 


### PR DESCRIPTION
Do not access instruction details if the instruction is marked as SKIPDATA or if the details are NULL

Fixes issues #105
