### PR TITLE
Renamed the project names to be consistent with *nix's ones

### DIFF
--- a/msvc/msvc-2012.sln
+++ b/msvc/msvc-2012.sln
@@ -8,47 +8,47 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test", "test\test.vcxproj",
 		{5B01D900-2359-44CA-9914-6B0C6AFB7BE7} = {5B01D900-2359-44CA-9914-6B0C6AFB7BE7}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test-x86", "test-x86\test-x86.vcxproj", "{9C69243E-C7DC-42A4-AB86-0696E51697C8}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_x86", "test_x86\test_x86.vcxproj", "{9C69243E-C7DC-42A4-AB86-0696E51697C8}"
 	ProjectSection(ProjectDependencies) = postProject
 		{5B01D900-2359-44CA-9914-6B0C6AFB7BE7} = {5B01D900-2359-44CA-9914-6B0C6AFB7BE7}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test-arm", "test-arm\test-arm.vcxproj", "{349B99E4-2E79-44FE-96F9-02D9B4EC0584}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_arm", "test_arm\test_arm.vcxproj", "{349B99E4-2E79-44FE-96F9-02D9B4EC0584}"
 	ProjectSection(ProjectDependencies) = postProject
 		{5B01D900-2359-44CA-9914-6B0C6AFB7BE7} = {5B01D900-2359-44CA-9914-6B0C6AFB7BE7}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test-arm64", "test-arm64\test-arm64.vcxproj", "{CBE31473-7D0E-41F5-AFCB-8C8422ED8908}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_arm64", "test_arm64\test_arm64.vcxproj", "{CBE31473-7D0E-41F5-AFCB-8C8422ED8908}"
 	ProjectSection(ProjectDependencies) = postProject
 		{5B01D900-2359-44CA-9914-6B0C6AFB7BE7} = {5B01D900-2359-44CA-9914-6B0C6AFB7BE7}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test-mips", "test-mips\test-mips.vcxproj", "{28B2D82F-3E95-4ECE-8118-0E891BD453E0}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_mips", "test_mips\test_mips.vcxproj", "{28B2D82F-3E95-4ECE-8118-0E891BD453E0}"
 	ProjectSection(ProjectDependencies) = postProject
 		{5B01D900-2359-44CA-9914-6B0C6AFB7BE7} = {5B01D900-2359-44CA-9914-6B0C6AFB7BE7}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test-ppc", "test-ppc\test-ppc.vcxproj", "{0B78E956-F897-4149-BFB2-BE87DA3A6F0D}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_ppc", "test_ppc\test_ppc.vcxproj", "{0B78E956-F897-4149-BFB2-BE87DA3A6F0D}"
 	ProjectSection(ProjectDependencies) = postProject
 		{5B01D900-2359-44CA-9914-6B0C6AFB7BE7} = {5B01D900-2359-44CA-9914-6B0C6AFB7BE7}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test-sparc", "test-sparc\test-sparc.vcxproj", "{9E735ABA-00D9-4114-A9E7-0568D8DFF94B}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_sparc", "test_sparc\test_sparc.vcxproj", "{9E735ABA-00D9-4114-A9E7-0568D8DFF94B}"
 	ProjectSection(ProjectDependencies) = postProject
 		{5B01D900-2359-44CA-9914-6B0C6AFB7BE7} = {5B01D900-2359-44CA-9914-6B0C6AFB7BE7}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test-systemz", "test-systemz\test-systemz.vcxproj", "{D83F2A2D-D5F1-421E-A5B7-B47F1ECABAD2}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_systemz", "test_systemz\test_systemz.vcxproj", "{D83F2A2D-D5F1-421E-A5B7-B47F1ECABAD2}"
 	ProjectSection(ProjectDependencies) = postProject
 		{5B01D900-2359-44CA-9914-6B0C6AFB7BE7} = {5B01D900-2359-44CA-9914-6B0C6AFB7BE7}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test-detail", "test-detail\test-detail.vcxproj", "{A510F308-3094-4FF6-9DFC-539CC5260BA4}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_detail", "test_detail\test_detail.vcxproj", "{A510F308-3094-4FF6-9DFC-539CC5260BA4}"
 	ProjectSection(ProjectDependencies) = postProject
 		{5B01D900-2359-44CA-9914-6B0C6AFB7BE7} = {5B01D900-2359-44CA-9914-6B0C6AFB7BE7}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test-skipdata", "test-skipdata\test-skipdata.vcxproj", "{B09819BB-7EF1-4B04-945D-58117E6940A1}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_skipdata", "test_skipdata\test_skipdata.vcxproj", "{B09819BB-7EF1-4B04-945D-58117E6940A1}"
 	ProjectSection(ProjectDependencies) = postProject
 		{5B01D900-2359-44CA-9914-6B0C6AFB7BE7} = {5B01D900-2359-44CA-9914-6B0C6AFB7BE7}
 	EndProjectSection

--- a/msvc/test_arm/test_arm.vcxproj
+++ b/msvc/test_arm/test_arm.vcxproj
@@ -18,14 +18,11 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="..\..\tests\test_systemz.c" />
-  </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{D83F2A2D-D5F1-421E-A5B7-B47F1ECABAD2}</ProjectGuid>
+    <ProjectGuid>{349B99E4-2E79-44FE-96F9-02D9B4EC0584}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>capstonetestsystemz</RootNamespace>
-    <ProjectName>test-systemz</ProjectName>
+    <RootNamespace>capstonetestarm</RootNamespace>
+    <ProjectName>test_arm</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -158,6 +155,9 @@
       <AdditionalDependencies>capstone.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\tests\test_arm.c" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/msvc/test_arm64/test_arm64.vcxproj
+++ b/msvc/test_arm64/test_arm64.vcxproj
@@ -19,10 +19,10 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{9E735ABA-00D9-4114-A9E7-0568D8DFF94B}</ProjectGuid>
+    <ProjectGuid>{CBE31473-7D0E-41F5-AFCB-8C8422ED8908}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>capstonetestsparc</RootNamespace>
-    <ProjectName>test-sparc</ProjectName>
+    <RootNamespace>capstonetestarm64</RootNamespace>
+    <ProjectName>test_arm64</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -156,7 +156,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\tests\test_sparc.c" />
+    <ClCompile Include="..\..\tests\test_arm64.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc/test_detail/test_detail.vcxproj
+++ b/msvc/test_detail/test_detail.vcxproj
@@ -18,14 +18,11 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="..\..\tests\test_ppc.c" />
-  </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{0B78E956-F897-4149-BFB2-BE87DA3A6F0D}</ProjectGuid>
+    <ProjectGuid>{A510F308-3094-4FF6-9DFC-539CC5260BA4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>capstonetestppc</RootNamespace>
-    <ProjectName>test-ppc</ProjectName>
+    <RootNamespace>capstonetestdetail</RootNamespace>
+    <ProjectName>test_detail</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -158,6 +155,9 @@
       <AdditionalDependencies>capstone.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\tests\test_detail.c" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/msvc/test_mips/test_mips.vcxproj
+++ b/msvc/test_mips/test_mips.vcxproj
@@ -19,10 +19,10 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{CBE31473-7D0E-41F5-AFCB-8C8422ED8908}</ProjectGuid>
+    <ProjectGuid>{28B2D82F-3E95-4ECE-8118-0E891BD453E0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>capstonetestarm64</RootNamespace>
-    <ProjectName>test-arm64</ProjectName>
+    <RootNamespace>capstonetestmips</RootNamespace>
+    <ProjectName>test_mips</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -156,7 +156,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\tests\test_arm64.c" />
+    <ClCompile Include="..\..\tests\test_mips.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc/test_ppc/test_ppc.vcxproj
+++ b/msvc/test_ppc/test_ppc.vcxproj
@@ -18,11 +18,14 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\tests\test_ppc.c" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{28B2D82F-3E95-4ECE-8118-0E891BD453E0}</ProjectGuid>
+    <ProjectGuid>{0B78E956-F897-4149-BFB2-BE87DA3A6F0D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>capstonetestmips</RootNamespace>
-    <ProjectName>test-mips</ProjectName>
+    <RootNamespace>capstonetestppc</RootNamespace>
+    <ProjectName>test_ppc</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -155,9 +158,6 @@
       <AdditionalDependencies>capstone.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <ClCompile Include="..\..\tests\test_mips.c" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/msvc/test_skipdata/test_skipdata.vcxproj
+++ b/msvc/test_skipdata/test_skipdata.vcxproj
@@ -19,10 +19,10 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{9C69243E-C7DC-42A4-AB86-0696E51697C8}</ProjectGuid>
+    <ProjectGuid>{B09819BB-7EF1-4B04-945D-58117E6940A1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>capstonetestx86</RootNamespace>
-    <ProjectName>test-x86</ProjectName>
+    <RootNamespace>capstonetestskipdata</RootNamespace>
+    <ProjectName>test_skipdata</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -156,7 +156,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\tests\test_x86.c" />
+    <ClCompile Include="..\..\tests\test_skipdata.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc/test_sparc/test_sparc.vcxproj
+++ b/msvc/test_sparc/test_sparc.vcxproj
@@ -19,10 +19,10 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{A510F308-3094-4FF6-9DFC-539CC5260BA4}</ProjectGuid>
+    <ProjectGuid>{9E735ABA-00D9-4114-A9E7-0568D8DFF94B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>capstonetestdetail</RootNamespace>
-    <ProjectName>test-detail</ProjectName>
+    <RootNamespace>capstonetestsparc</RootNamespace>
+    <ProjectName>test_sparc</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -156,7 +156,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\tests\test_detail.c" />
+    <ClCompile Include="..\..\tests\test_sparc.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc/test_systemz/test_systemz.vcxproj
+++ b/msvc/test_systemz/test_systemz.vcxproj
@@ -18,11 +18,14 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\tests\test_systemz.c" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{B09819BB-7EF1-4B04-945D-58117E6940A1}</ProjectGuid>
+    <ProjectGuid>{D83F2A2D-D5F1-421E-A5B7-B47F1ECABAD2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>capstonetestskipdata</RootNamespace>
-    <ProjectName>test-skipdata</ProjectName>
+    <RootNamespace>capstonetestsystemz</RootNamespace>
+    <ProjectName>test_systemz</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -155,9 +158,6 @@
       <AdditionalDependencies>capstone.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <ClCompile Include="..\..\tests\test_skipdata.c" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/msvc/test_x86/test_x86.vcxproj
+++ b/msvc/test_x86/test_x86.vcxproj
@@ -19,10 +19,10 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{349B99E4-2E79-44FE-96F9-02D9B4EC0584}</ProjectGuid>
+    <ProjectGuid>{9C69243E-C7DC-42A4-AB86-0696E51697C8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>capstonetestarm</RootNamespace>
-    <ProjectName>test-arm</ProjectName>
+    <RootNamespace>capstonetestx86</RootNamespace>
+    <ProjectName>test_x86</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -156,7 +156,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\tests\test_arm.c" />
+    <ClCompile Include="..\..\tests\test_x86.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
Hey guys,

Just a quick commit that renames the MSVC project names to be consistent with *nix's ones!

Cheers,
0vercl0k
