### PR TITLE
MIPS: Add HI, LO, and PC registers to MipsMapping.c

### DIFF
--- a/arch/Mips/MipsMapping.c
+++ b/arch/Mips/MipsMapping.c
@@ -174,6 +174,10 @@ static name_map reg_name_maps[] = {
 	{ MIPS_REG_W29, "w29"},
 	{ MIPS_REG_W30, "w30"},
 	{ MIPS_REG_W31, "w31"},
+
+	{ MIPS_REG_HI, "hi"},
+	{ MIPS_REG_LO, "lo"},
+	{ MIPS_REG_PC, "pc"},
 };
 #endif
 


### PR DESCRIPTION
- Using MIPS_REG_HI, MIPS_REG_LO, and MIPS_REG_PC with cs_reg_name() caused out-of-bounds reads
