### PR TITLE
Fix for GCC MIPS toolchain

### DIFF
--- a/include/mips.h
+++ b/include/mips.h
@@ -11,6 +11,10 @@ extern "C" {
 #include <stdint.h>
 #include "platform.h"
 
+// GCC MIPS toolchain has a default macro called "mips" which breaks
+// compilation
+#undef mips
+
 #ifdef _MSC_VER
 #pragma warning(disable:4201)
 #endif


### PR DESCRIPTION
Closes #143

Patch was tested on the stable version. Did NOT try compiling the next branch
