### PR TITLE
ocaml: simplification in ocaml.c: op_count variable

### DIFF
--- a/bindings/ocaml/ocaml.c
+++ b/bindings/ocaml/ocaml.c
@@ -12,22 +12,6 @@
 
 #define ARR_SIZE(a) (sizeof(a)/sizeof(a[0]))
 
-// count the number of positive members in @oplist
-#define ARCH_LIST_COUNT(_arch, _optype) \
-static unsigned int _arch ## _list_count(_optype *list, unsigned int max) \
-{ \
-	unsigned int i; \
-	for(i = 0; i < max; i++) \
-		if (list[i].type == 0) \
-			return i; \
-	return max; \
-}
-
-ARCH_LIST_COUNT(arm, cs_arm_op)
-ARCH_LIST_COUNT(arm64, cs_arm64_op)
-ARCH_LIST_COUNT(mips, cs_mips_op)
-ARCH_LIST_COUNT(x86, cs_x86_op)
-
 
 // count the number of positive members in @list
 static unsigned int list_count(uint8_t *list, unsigned int max)
@@ -125,8 +109,10 @@ CAMLprim value _cs_disasm(cs_arch arch, csh handle, const uint8_t * code, size_t
 					Store_field(op_info_val, 0, Val_int(insn[j-1].detail->arm.cc));
 					Store_field(op_info_val, 1, Val_bool(insn[j-1].detail->arm.update_flags));
 					Store_field(op_info_val, 2, Val_bool(insn[j-1].detail->arm.writeback));
-					Store_field(op_info_val, 3, Val_int(insn[j-1].detail->arm.op_count));
-					lcount = arm_list_count(insn[j - 1].detail->arm.operands, ARR_SIZE(insn[j - 1].detail->arm.operands));
+
+					lcount = insn[j-1].detail->arm.op_count;
+
+					Store_field(op_info_val, 3, Val_int(lcount));
 					if (lcount > 0) {
 						array = caml_alloc(lcount, 0);
 						for (i = 0; i < lcount; i++) {
@@ -188,9 +174,10 @@ CAMLprim value _cs_disasm(cs_arch arch, csh handle, const uint8_t * code, size_t
 						 Store_field(op_info_val, 0, Val_int(insn[j-1].detail->arm64.cc));
 						 Store_field(op_info_val, 1, Val_bool(insn[j-1].detail->arm64.update_flags));
 						 Store_field(op_info_val, 2, Val_bool(insn[j-1].detail->arm64.writeback));
-						 Store_field(op_info_val, 3, Val_int(insn[j-1].detail->arm64.op_count));
+						 lcount = insn[j-1].detail->arm64.op_count;
 
-						 lcount = arm64_list_count(insn[j - 1].detail->arm64.operands, ARR_SIZE(insn[j - 1].detail->arm64.operands));
+						 Store_field(op_info_val, 3, Val_int(lcount));
+
 						 if (lcount > 0) {
 							 array = caml_alloc(lcount, 0);
 							 for (i = 0; i < lcount; i++) {
@@ -246,9 +233,11 @@ CAMLprim value _cs_disasm(cs_arch arch, csh handle, const uint8_t * code, size_t
 						 arch_info = caml_alloc(1, 2);
 
 						 op_info_val = caml_alloc(2, 0);
-						 Store_field(op_info_val, 0, Val_int(insn[j-1].detail->mips.op_count));
 
-						 lcount = mips_list_count(insn[j - 1].detail->mips.operands, ARR_SIZE(insn[j - 1].detail->mips.operands));
+						 lcount = insn[j-1].detail->mips.op_count;
+
+						 Store_field(op_info_val, 0, Val_int(lcount));
+
 						 if (lcount > 0) {
 							 array = caml_alloc(lcount, 0);
 							 for (i = 0; i < lcount; i++) {
@@ -385,8 +374,10 @@ CAMLprim value _cs_disasm(cs_arch arch, csh handle, const uint8_t * code, size_t
 
 					Store_field(op_info_val, 12, Val_int(insn[j-1].detail->x86.sib_base));
 
-					Store_field(op_info_val, 13, Val_int(insn[j-1].detail->x86.op_count));
-					lcount = x86_list_count(insn[j - 1].detail->x86.operands, ARR_SIZE(insn[j - 1].detail->x86.operands));
+					lcount = insn[j-1].detail->x86.op_count;
+
+					Store_field(op_info_val, 13, Val_int(lcount));
+
 					if (lcount > 0) {
 						array = caml_alloc(lcount, 0);
 						for (i = 0; i < lcount; i++) {

--- a/bindings/ocaml/test_detail.ml
+++ b/bindings/ocaml/test_detail.ml
@@ -15,6 +15,7 @@ let _THUMB_CODE2 = "\x4f\xf0\x00\x01\xbd\xe8\x00\x88";;
 let _MIPS_CODE = "\x0C\x10\x00\x97\x00\x00\x00\x00\x24\x02\x00\x0c\x8f\xa2\x00\x00\x34\x21\x34\x56";;
 let _MIPS_CODE2 = "\x56\x34\x21\x34\xc2\x17\x01\x00";;
 let _ARM64_CODE = "\x21\x7c\x02\x9b\x21\x7c\x00\x53\x00\x40\x21\x4b\xe1\x0b\x40\xb9";;
+let _PPC_CODE = "\x80\x20\x00\x00\x80\x3f\x00\x00\x10\x43\x23\x0e\xd0\x44\x00\x80\x4c\x43\x22\x02\x2d\x03\x00\x80\x7c\x43\x20\x14\x7c\x43\x20\x93\x4f\x20\x00\x21\x4c\xc8\x00\x21";;
 
 let all_tests = [
 	(CS_ARCH_X86, [CS_MODE_16], _X86_CODE16, "X86 16bit (Intel syntax)");
@@ -28,6 +29,8 @@ let all_tests = [
 	(CS_ARCH_ARM64, [CS_MODE_ARM], _ARM64_CODE, "ARM-64");
 	(CS_ARCH_MIPS, [CS_MODE_32; CS_MODE_BIG_ENDIAN], _MIPS_CODE, "MIPS-32 (Big-endian)");
 	(CS_ARCH_MIPS, [CS_MODE_64; CS_MODE_LITTLE_ENDIAN], _MIPS_CODE2, "MIPS-64-EL (Little-endian)");
+	(CS_ARCH_PPC, [CS_MODE_32; CS_MODE_BIG_ENDIAN], _PPC_CODE, "PPC-64");
+
 ];;
 
 


### PR DESCRIPTION
OCaml: little simplification in ocaml.c, we can use the variable op_count instead of counting manually.
Add PPC test in test_detail.ml
