### PR TITLE
Fixed a few bugs in ARM disassembly and added more testing stuff to test_arm.c

### DIFF
--- a/SStream.c
+++ b/SStream.c
@@ -23,7 +23,7 @@ void SStream_concat0(SStream *ss, char *s)
 {
 #ifndef CAPSTONE_DIET
 	strcpy(ss->buffer + ss->index, s);
-	ss->index += strlen(s);
+	ss->index += (int) strlen(s);
 #endif
 }
 

--- a/arch/ARM/ARMDisassembler.c
+++ b/arch/ARM/ARMDisassembler.c
@@ -1231,10 +1231,13 @@ static DecodeStatus DecodeRegListOperand(MCInst *Inst, unsigned Val,
 {
 	unsigned i;
 	DecodeStatus S = MCDisassembler_Success;
-
+	unsigned opcode = 0;
+	
 	bool NeedDisjointWriteback = false;
 	unsigned WritebackReg = 0;
-	switch (MCInst_getOpcode(Inst)) {
+
+	opcode = MCInst_getOpcode(Inst);
+	switch (opcode) {
 		default:
 			break;
 		case ARM_LDMIA_UPD:
@@ -1261,6 +1264,16 @@ static DecodeStatus DecodeRegListOperand(MCInst *Inst, unsigned Val,
 				Check(&S, MCDisassembler_SoftFail);
 		}
 	}
+
+    if (opcode == ARM_t2LDMIA_UPD && WritebackReg == ARM_SP) {
+        if (
+            Val & (1 << ARM_SP) 
+            || ((Val & (1 << ARM_PC)) && (Val & (1 << ARM_LR)))) {
+            // invalid thumb2 pop
+            // needs no sp in reglist and not both pc and lr set at the same time
+            return MCDisassembler_Fail;
+        }
+    }
 
 	return S;
 }

--- a/arch/ARM/ARMMapping.c
+++ b/arch/ARM/ARMMapping.c
@@ -13908,17 +13908,36 @@ static unsigned int insn_rel[] = {
 	0
 };
 
+static unsigned int insn_blx_rel_to_arm[] = {
+    ARM_tBLXi,
+    0
+};
+
 // check if this insn is relative branch
 bool ARM_rel_branch(cs_struct *h, unsigned int id)
 {
 	int i;
 
-	for (i = 0; insn_rel[i]; i++)
-		if (id == insn_rel[i])
+	for (i = 0; insn_rel[i]; i++) {
+		if (id == insn_rel[i]) {
+			return true;
+        }
+    }
+
+	// not found
+	return false;
+}
+
+bool ARM_blx_to_arm_mode(cs_struct *h, unsigned int id) {
+	int i;
+
+	for (i = 0; insn_blx_rel_to_arm[i]; i++)
+		if (id == insn_blx_rel_to_arm[i])
 			return true;
 
 	// not found
 	return false;
+
 }
 
 #endif

--- a/arch/ARM/ARMMapping.h
+++ b/arch/ARM/ARMMapping.h
@@ -18,4 +18,6 @@ const char *ARM_insn_name(csh handle, unsigned int id);
 // check if this insn is relative branch
 bool ARM_rel_branch(cs_struct *h, unsigned int insn_id);
 
+bool ARM_blx_to_arm_mode(cs_struct *h, unsigned int insn_id);
+
 #endif

--- a/arch/PowerPC/PPCModule.c
+++ b/arch/PowerPC/PPCModule.c
@@ -18,7 +18,7 @@ static cs_err init(cs_struct *ud)
 				CS_MODE_BIG_ENDIAN))
 		return CS_ERR_MODE;
 
-	mri = cs_mem_malloc(sizeof(*mri));
+	mri = (MCRegisterInfo *) cs_mem_malloc(sizeof(*mri));
 
 	PPC_init(mri);
 	ud->printer = PPC_printInst;
@@ -37,7 +37,7 @@ static cs_err init(cs_struct *ud)
 static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 {
 	if (type == CS_OPT_SYNTAX)
-		handle->syntax = value;
+		handle->syntax = (int) value;
 
 	return CS_ERR_OK;
 }

--- a/arch/Sparc/SparcModule.c
+++ b/arch/Sparc/SparcModule.c
@@ -36,7 +36,7 @@ static cs_err init(cs_struct *ud)
 static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 {
 	if (type == CS_OPT_SYNTAX)
-		handle->syntax = value;
+		handle->syntax = (int) value;
 
 	return CS_ERR_OK;
 }

--- a/arch/SystemZ/SystemZModule.c
+++ b/arch/SystemZ/SystemZModule.c
@@ -32,7 +32,7 @@ static cs_err init(cs_struct *ud)
 static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 {
 	if (type == CS_OPT_SYNTAX)
-		handle->syntax = value;
+		handle->syntax = (int) value;
 
 	return CS_ERR_OK;
 }

--- a/cs.c
+++ b/cs.c
@@ -532,7 +532,7 @@ size_t cs_disasm_ex(csh ud, const uint8_t *buffer, size_t size, uint64_t offset,
 			// we have to skip some amount of data, depending on arch & mode
 			insn_cache->id = 0;	// invalid ID for this "data" instruction
 			insn_cache->address = offset;
-			insn_cache->size = skipdata_bytes;
+			insn_cache->size = (uint16_t) skipdata_bytes;
 			memcpy(insn_cache->bytes, buffer, skipdata_bytes);
 			strncpy(insn_cache->mnemonic, handle->skipdata_setup.mnemonic,
 					sizeof(insn_cache->mnemonic) - 1);


### PR DESCRIPTION
- added a way to test what should be invalid instructions
- added a way to test what should be valid instructions
- fixed and added a test for a thumb-2 invalid sequence that was incorrectly allowed before these changes (pop.w with sp argument included)
- fixed and added a test for a blx from thumb to ARM that had its immediate argument incorrect (misaligned)
- eliminated some warnings by explicitly casting so I could turn on
  treat warnings as errors locally
- general notes: probably worth turning on treat all warnings as errors in the msvc project files, had a subtle bug that resulted from a missing declaration causing differences in dll and static compilation modes

( code was working incorrectly in dll form because of missing declaration in arch/ARM/ARMMapping.h for new function ARM_blx_to_arm_mode. Something about the linking was confusing ld when making the dll, and the resulting offsets were wonky (e.g. the added ble test would show up as #0x1fc instead of #0x1fe like it should have )
