### PR TITLE
Fix compiler warnings about different sizes and sign.

### DIFF
--- a/arch/AArch64/AArch64Disassembler.c
+++ b/arch/AArch64/AArch64Disassembler.c
@@ -224,6 +224,7 @@ static DecodeStatus _getInstruction(cs_struct *ud, MCInst *MI,
 {
 	uint32_t insn;
 	DecodeStatus result;
+	size_t i;
 
 	if (code_len < 4) {
 		// not enough data
@@ -233,7 +234,7 @@ static DecodeStatus _getInstruction(cs_struct *ud, MCInst *MI,
 
 	if (MI->flat_insn->detail) {
 		memset(MI->flat_insn->detail, 0, sizeof(cs_detail));
-		for (size_t i = 0; i < ARR_SIZE(MI->flat_insn->detail->arm64.operands); i++)
+		for (i = 0; i < ARR_SIZE(MI->flat_insn->detail->arm64.operands); i++)
 			MI->flat_insn->detail->arm64.operands[i].vector_index = -1;
 	}
 

--- a/arch/ARM/ARMDisassembler.c
+++ b/arch/ARM/ARMDisassembler.c
@@ -694,10 +694,10 @@ static DecodeStatus _Thumb_getInstruction(cs_struct *ud, MCInst *MI, const uint8
 		return MCDisassembler_Fail;
 
 	ud->ITBlock.size = 0;
-
+	size_t i;
 	if (MI->flat_insn->detail) {
 		memset(&MI->flat_insn->detail->arm, 0, sizeof(cs_arm));
-		for (size_t i = 0; i < ARR_SIZE(MI->flat_insn->detail->arm.operands); i++)
+		for (i = 0; i < ARR_SIZE(MI->flat_insn->detail->arm.operands); i++)
 			MI->flat_insn->detail->arm.operands[i].vector_index = -1;
 	}
 

--- a/arch/PowerPC/PPCMapping.c
+++ b/arch/PowerPC/PPCMapping.c
@@ -8089,7 +8089,8 @@ static struct ppc_alias alias_insn_name_maps[] = {
 // given alias mnemonic, return instruction ID & CC
 bool PPC_alias_insn(const char *name, struct ppc_alias *alias)
 {
-	for(size_t i = 0; i < ARR_SIZE(alias_insn_name_maps); i++) {
+	size_t i;
+	for(i = 0; i < ARR_SIZE(alias_insn_name_maps); i++) {
 		if (!strcmp(name, alias_insn_name_maps[i].mnem)) {
 			alias->id = alias_insn_name_maps[i].id;
 			alias->cc = alias_insn_name_maps[i].cc;
@@ -8098,9 +8099,9 @@ bool PPC_alias_insn(const char *name, struct ppc_alias *alias)
 	}
 
 	// not really an alias insn
-	int i = name2id(&insn_name_maps[1], ARR_SIZE(insn_name_maps) - 1, name);
-	if (i != -1) {
-		alias->id = insn_name_maps[i].id;
+	int x = name2id(&insn_name_maps[1], ARR_SIZE(insn_name_maps) - 1, name);
+	if (x != -1) {
+		alias->id = insn_name_maps[x].id;
 		alias->cc = PPC_BC_INVALID;
 		return true;
 	}


### PR DESCRIPTION
Fix compiler warnings when compiling in 64 bits the PPC, and both ARM archs.
