### PR TITLE
ARM IT-block bug fix

### DIFF
--- a/arch/ARM/ARMDisassembler.c
+++ b/arch/ARM/ARMDisassembler.c
@@ -450,8 +450,6 @@ static DecodeStatus _ARM_getInstruction(cs_struct *ud, MCInst *MI, const uint8_t
 		// not enough data
 		return MCDisassembler_Fail;
 
-	ud->ITBlock.size = 0;
-
 	if (MI->flat_insn->detail) {
 		memset(&MI->flat_insn->detail->arm, 0, sizeof(cs_arm));
 		for (i = 0; i < ARR_SIZE(MI->flat_insn->detail->arm.operands); i++)
@@ -694,7 +692,6 @@ static DecodeStatus _Thumb_getInstruction(cs_struct *ud, MCInst *MI, const uint8
 		// not enough data
 		return MCDisassembler_Fail;
 
-	ud->ITBlock.size = 0;
 	if (MI->flat_insn->detail) {
 		memset(&MI->flat_insn->detail->arm, 0, sizeof(cs_arm));
 		for (i = 0; i < ARR_SIZE(MI->flat_insn->detail->arm.operands); i++)


### PR DESCRIPTION
ITBlock->size is set to 0 every time _ARM_getInstruction and _Thumb_getInstruction called.
But since it's used to check if the instructions after ARM_INS_IT are in IT-block or not, set to 0 cause IT-block's instructions are incorrectly moved out of the block and their condition flag go wrong.