### PR TITLE
Correct printAM3PreOrOffsetIndexOp disp value

### DIFF
--- a/arch/ARM/ARMDisassembler.c
+++ b/arch/ARM/ARMDisassembler.c
@@ -450,8 +450,6 @@ static DecodeStatus _ARM_getInstruction(cs_struct *ud, MCInst *MI, const uint8_t
 		// not enough data
 		return MCDisassembler_Fail;
 
-	ud->ITBlock.size = 0;
-
 	if (MI->flat_insn->detail) {
 		memset(&MI->flat_insn->detail->arm, 0, sizeof(cs_arm));
 		for (i = 0; i < ARR_SIZE(MI->flat_insn->detail->arm.operands); i++)
@@ -694,7 +692,6 @@ static DecodeStatus _Thumb_getInstruction(cs_struct *ud, MCInst *MI, const uint8
 		// not enough data
 		return MCDisassembler_Fail;
 
-	ud->ITBlock.size = 0;
 	if (MI->flat_insn->detail) {
 		memset(&MI->flat_insn->detail->arm, 0, sizeof(cs_arm));
 		for (i = 0; i < ARR_SIZE(MI->flat_insn->detail->arm.operands); i++)

--- a/arch/ARM/ARMInstPrinter.c
+++ b/arch/ARM/ARMInstPrinter.c
@@ -1056,10 +1056,10 @@ static void printAM3PreOrOffsetIndexOp(MCInst *MI, unsigned Op, SStream *O,
 
 	if (MI->csh->detail) {
 		if (subtracted) {
-			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].mem.disp = (int)MCOperand_getImm(MO3);
+			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].mem.disp = (int)ImmOffs;
 			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].subtracted = true;
 		} else
-			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].mem.disp = (int)-MCOperand_getImm(MO3);
+			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].mem.disp = (int)-ImmOffs;
 	}
 
 	SStream_concat0(O, "]");


### PR DESCRIPTION
Hi,
The `ldrh r0, [r1, #-2] (\xB2\x00\x51\xE1)` has incorrect mem.disp = -258 instead of -2.