### PR TITLE
Limit exported symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,7 @@ else ifeq ($(IS_CYGWIN),1)
 LIBRARY = $(BLDIR)/$(LIBNAME).$(EXT)
 else	# *nix
 LIBRARY = $(BLDIR)/lib$(LIBNAME).$(EXT)
+CFLAGS += -fvisibility=hidden
 endif
 endif
 

--- a/include/capstone.h
+++ b/include/capstone.h
@@ -24,7 +24,11 @@ extern "C" {
 #define CAPSTONE_EXPORT
 #endif
 #else
+#ifdef __GNUC__
+#define CAPSTONE_EXPORT __attribute__((visibility("default")))
+#else
 #define CAPSTONE_EXPORT
+#endif
 #endif
 
 #ifdef __GNUC__


### PR DESCRIPTION
Make sure that only symbols that are part of the API are exported by
the library -- similar to __declspec(dllexport) for the MSVC
compiler