### PR TITLE
Silencing Clang warnings

### DIFF
--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -333,7 +333,8 @@ static bool printSysAlias(MCInst *MI, SStream *O)
 	unsigned CnVal = (unsigned)MCOperand_getImm(Cn);
 	unsigned CmVal = (unsigned)MCOperand_getImm(Cm);
 	unsigned Op2Val = (unsigned)MCOperand_getImm(Op2);
-	unsigned insn_id, op_ic = 0, op_dc = 0, op_at = 0, op_tlbi = 0;
+	unsigned insn_id = ARM64_INS_INVALID;
+	unsigned op_ic = 0, op_dc = 0, op_at = 0, op_tlbi = 0;
 
 	if (CnVal == 7) {
 		switch (CmVal) {

--- a/arch/ARM/ARMModule.c
+++ b/arch/ARM/ARMModule.c
@@ -48,7 +48,7 @@ static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 			else
 				handle->disasm = ARM_getInstruction;
 
-			handle->mode = value;
+			handle->mode = (cs_mode)value;
 			break;
 		case CS_OPT_SYNTAX:
 			ARM_getRegName(handle, (int)value);

--- a/arch/Mips/MipsModule.c
+++ b/arch/Mips/MipsModule.c
@@ -46,7 +46,7 @@ static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 		else
 			handle->disasm = Mips64_getInstruction;
 
-		handle->mode = value;
+		handle->mode = (cs_mode)value;
 	}
 	return CS_ERR_OK;
 }

--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -312,7 +312,7 @@ static void unconsumeByte(struct InternalInstruction *insn)
 					insn->readerCursor + offset);        \
 			if (ret)                                                    \
 			return ret;                                               \
-			combined = combined | ((uint64_t)byte << (offset * 8));     \
+			combined = combined | (type)((uint64_t)byte << (offset * 8));     \
 		}                                                             \
 		*ptr = combined;                                              \
 		insn->readerCursor += sizeof(type);                           \

--- a/arch/X86/X86Module.c
+++ b/arch/X86/X86Module.c
@@ -51,7 +51,7 @@ static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 			else
 				handle->regsize_map = regsize_map_32;
 
-			handle->mode = value;
+			handle->mode = (cs_mode)value;
 			break;
 		case CS_OPT_SYNTAX:
 			switch(value) {

--- a/cs.c
+++ b/cs.c
@@ -363,7 +363,7 @@ cs_err cs_option(csh ud, cs_opt_type type, size_t value)
 		default:
 			break;
 		case CS_OPT_DETAIL:
-			handle->detail = value;
+			handle->detail = (cs_opt_value)value;
 			return CS_ERR_OK;
 		case CS_OPT_SKIPDATA:
 			handle->skipdata = (value == CS_OPT_ON);

--- a/xcode/Capstone.xcodeproj/xcshareddata/xcschemes/Dynamic Library.xcscheme
+++ b/xcode/Capstone.xcodeproj/xcshareddata/xcschemes/Dynamic Library.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCFE23CC19DDCC9500EF8EA9"
+               BuildableName = "libcapstone.dylib"
+               BlueprintName = "CapstoneDynamic"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DCFE23CC19DDCC9500EF8EA9"
+            BuildableName = "libcapstone.dylib"
+            BlueprintName = "CapstoneDynamic"
+            ReferencedContainer = "container:Capstone.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DCFE23CC19DDCC9500EF8EA9"
+            BuildableName = "libcapstone.dylib"
+            BlueprintName = "CapstoneDynamic"
+            ReferencedContainer = "container:Capstone.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcode/Capstone.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
+++ b/xcode/Capstone.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC474F6719DE6F3B00BCA449"
+               BuildableName = "Capstone.framework"
+               BlueprintName = "CapstoneFramework"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DC474F6719DE6F3B00BCA449"
+            BuildableName = "Capstone.framework"
+            BlueprintName = "CapstoneFramework"
+            ReferencedContainer = "container:Capstone.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DC474F6719DE6F3B00BCA449"
+            BuildableName = "Capstone.framework"
+            BlueprintName = "CapstoneFramework"
+            ReferencedContainer = "container:Capstone.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcode/Capstone.xcodeproj/xcshareddata/xcschemes/Static Library.xcscheme
+++ b/xcode/Capstone.xcodeproj/xcshareddata/xcschemes/Static Library.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCFE23BC19DDCC2D00EF8EA9"
+               BuildableName = "libcapstone.a"
+               BlueprintName = "CapstoneStatic"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DCFE23BC19DDCC2D00EF8EA9"
+            BuildableName = "libcapstone.a"
+            BlueprintName = "CapstoneStatic"
+            ReferencedContainer = "container:Capstone.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DCFE23BC19DDCC2D00EF8EA9"
+            BuildableName = "libcapstone.a"
+            BlueprintName = "CapstoneStatic"
+            ReferencedContainer = "container:Capstone.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcode/Capstone.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/xcode/Capstone.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC474E6319DDEA5F00BCA449"
+               BuildableName = "test"
+               BlueprintName = "test"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC474E8519DDEAA200BCA449"
+               BuildableName = "test_arm"
+               BlueprintName = "test_arm"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC474EE919DDEAE400BCA449"
+               BuildableName = "test_arm64"
+               BlueprintName = "test_arm64"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC474E9019DDEAA700BCA449"
+               BuildableName = "test_detail"
+               BlueprintName = "test_detail"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC5BFF3F19EE544E008CA585"
+               BuildableName = "test_iter"
+               BlueprintName = "test_iter"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC474E9B19DDEAAC00BCA449"
+               BuildableName = "test_mips"
+               BlueprintName = "test_mips"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC474EA619DDEAB000BCA449"
+               BuildableName = "test_ppc"
+               BlueprintName = "test_ppc"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC474EB119DDEAB700BCA449"
+               BuildableName = "test_skipdata"
+               BlueprintName = "test_skipdata"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC474EBC19DDEABC00BCA449"
+               BuildableName = "test_sparc"
+               BlueprintName = "test_sparc"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC474EC719DDEAC100BCA449"
+               BuildableName = "test_systemz"
+               BlueprintName = "test_systemz"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC474ED219DDEAC600BCA449"
+               BuildableName = "test_x86"
+               BlueprintName = "test_x86"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC474EDD19DDEACC00BCA449"
+               BuildableName = "test_xcore"
+               BlueprintName = "test_xcore"
+               ReferencedContainer = "container:Capstone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DC474E6319DDEA5F00BCA449"
+            BuildableName = "test"
+            BlueprintName = "test"
+            ReferencedContainer = "container:Capstone.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "/Users/felix/Library/Developer/Xcode/DerivedData/Capstone-edyokpvgjvaievbntdpiehlvqqiv/Build/Products/Tests">
+      </PathRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DC474E6319DDEA5F00BCA449"
+            BuildableName = "test"
+            BlueprintName = "test"
+            ReferencedContainer = "container:Capstone.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "/Users/felix/Library/Developer/Xcode/DerivedData/Capstone-edyokpvgjvaievbntdpiehlvqqiv/Build/Products/Tests">
+      </PathRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DC474E6319DDEA5F00BCA449"
+            BuildableName = "test"
+            BlueprintName = "test"
+            ReferencedContainer = "container:Capstone.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcode/Capstone.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/xcode/Capstone.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0630"
-   version = "2.0">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -201,12 +201,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      allowLocationSimulation = "YES"
-      launchAutomaticallySubstyle = "2">
-      <PathRunnable
-         runnableDebuggingMode = "0"
-         FilePath = "/Users/felix/Library/Developer/Xcode/DerivedData/Capstone-edyokpvgjvaievbntdpiehlvqqiv/Build/Products/Tests">
-      </PathRunnable>
+      allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -224,12 +219,7 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
-      debugDocumentVersioning = "YES"
-      launchAutomaticallySubstyle = "2">
-      <PathRunnable
-         runnableDebuggingMode = "0"
-         FilePath = "/Users/felix/Library/Developer/Xcode/DerivedData/Capstone-edyokpvgjvaievbntdpiehlvqqiv/Build/Products/Tests">
-      </PathRunnable>
+      debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"


### PR DESCRIPTION
This Xcode-centric PR tweaks Xcode project settings, silences several warnings about type conversions, and silences one warning about a possibly uninitialize variable.