### PR TITLE
Changed type for cs_x86_op.reg

### DIFF
--- a/include/x86.h
+++ b/include/x86.h
@@ -183,7 +183,7 @@ typedef struct x86_op_mem {
 typedef struct cs_x86_op {
 		x86_op_type type;	// operand type
 		union {
-			unsigned int reg;	// register value for REG operand
+			x86_reg reg;	// register value for REG operand
 			int64_t imm;		// immediate value for IMM operand
 			double fp;		// floating point value for FP operand
 			x86_op_mem mem;		// base/index/scale/disp value for MEM operand


### PR DESCRIPTION
Fixed type for cs_x86_op reg to be a x86_reg instead of unsigned int.  This makes it easier to understand that reg is a x86_reg enumeration versus something else.  It is currently not clear which type reg is.