### PR TITLE
python: Use setuptools instead of distutils to setup

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -10,7 +10,10 @@ from distutils import log
 from distutils import dir_util
 from distutils.command.build_clib import build_clib
 from distutils.command.sdist import sdist
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils import setup
 from distutils.sysconfig import get_python_lib
 
 # prebuilt libraries for Windows - for sdist


### PR DESCRIPTION
This allows you to

`python setup.py develop`

and work from your local copy. As far as I know it's a drop in replacement.