### PR TITLE
Add DESTDIR support for the python binding.

### DIFF
--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -13,13 +13,21 @@ install:
 	rm -rf $(OBJDIR) src/
 	rm -rf prebuilt/win64/capstone.dll
 	rm -rf prebuilt/win32/capstone.dll
-	python setup.py build -b $(OBJDIR) install
+	if test -n "${DESTDIR}"; then \
+		python setup.py build -b $(OBJDIR) install --root="${DESTDIR}"; \
+	else \
+		python setup.py build -b $(OBJDIR) install; \
+	fi
 
 install3:
 	rm -rf $(OBJDIR) src/
 	rm -rf prebuilt/win64/capstone.dll
 	rm -rf prebuilt/win32/capstone.dll
-	python3 setup.py build -b $(OBJDIR) install
+	if test -n "${DESTDIR}"; then \
+		python3 setup.py build -b $(OBJDIR) install --root="${DESTDIR}"; \
+	else \
+		python3 setup.py build -b $(OBJDIR) install; \
+	fi
 
 # NOTE: Newer cython can be installed by: sudo pip install --upgrade cython
 install_cython:


### PR DESCRIPTION
Without this patch, DESTDIR is ignored, so build systems that use a
staging sandbox prior to installing in real-root, such as Gentoo,
cannot build the python binding.

Caveats:

1) I wrote/tested this against the 3.0.2 release, not current HEAD.

2) It might be preferable to do DESTDIR ?= / at the top of the Makefile,
   so that the if/else/fi can be squashed back out.

3) The install_cython target probably needs a similar change; untested.

4) Other bindings might need something similar.