### PR TITLE
Add support to embed Capstone 3.x branch into OS X kernel extensions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(CAPSTONE_XCORE_SUPPORT "XCore support" ON)
 option(CAPSTONE_X86_SUPPORT "x86 support" ON)
 option(CAPSTONE_X86_REDUCE "x86 with reduce instruction sets to minimize library" OFF)
 option(CAPSTONE_X86_ATT_DISABLE "Disable x86 AT&T syntax" OFF)
+option(CAPSTONE_OSXKERNEL_SUPPORT "Support to embed Capstone into OS X Kernel extensions" OFF)
 
 if (CAPSTONE_BUILD_DIET)
     add_definitions(-DCAPSTONE_DIET)
@@ -154,6 +155,10 @@ if (CAPSTONE_XCORE_SUPPORT)
 	arch/XCore/XCoreModule.c
         )
     set(TEST_SOURCES ${TEST_SOURCES} test_xcore.c)
+endif ()
+
+if (CAPSTONE_OSXKERNEL_SUPPORT)
+    add_definitions(-DCAPSTONE_HAS_OSXKERNEL)
 endif ()
 
 include_directories("${PROJECT_SOURCE_DIR}/include")

--- a/MCInst.c
+++ b/MCInst.c
@@ -1,8 +1,12 @@
 /* Capstone Disassembly Engine */
 /* By Nguyen Anh Quynh <aquynh@gmail.com>, 2013-2015 */
 
+#if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <libkern/libkern.h>
+#else
 #include <stdio.h>
 #include <stdlib.h>
+#endif
 #include <string.h>
 
 #include "MCInst.h"

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ ifeq ($(CAPSTONE_USE_SYS_DYN_MEM),yes)
 CFLAGS += -DCAPSTONE_USE_SYS_DYN_MEM
 endif
 
+ifeq ($(CAPSTONE_HAS_OSXKERNEL), yes)
+CFLAGS += -DCAPSTONE_HAS_OSXKERNEL
+endif
+
 CFLAGS += $(foreach arch,$(LIBARCHS),-arch $(arch))
 LDFLAGS += $(foreach arch,$(LIBARCHS),-arch $(arch))
 

--- a/SStream.c
+++ b/SStream.c
@@ -3,7 +3,11 @@
 
 #include <stdint.h>
 #include <stdarg.h>
+#if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <libkern/libkern.h>
+#else
 #include <stdio.h>
+#endif
 #include <string.h>
 
 #include "SStream.h"

--- a/arch/X86/X86ATTInstPrinter.c
+++ b/arch/X86/X86ATTInstPrinter.c
@@ -18,10 +18,17 @@
 // this code is only relevant when DIET mode is disable
 #if defined(CAPSTONE_HAS_X86) && !defined(CAPSTONE_DIET) && !defined(CAPSTONE_X86_ATT_DISABLE)
 
+#if !defined(CAPSTONE_HAS_OSXKERNEL)
 #include <ctype.h>
+#endif
 #include "../../myinttypes.h"
+#if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <libkern/libkern.h>
+#else
 #include <stdio.h>
 #include <stdlib.h>
+#endif
+
 #include <string.h>
 
 #include "../../utils.h"

--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -19,7 +19,11 @@
 #ifdef CAPSTONE_HAS_X86
 
 #include <stdarg.h>   /* for va_*()       */
+#if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <libkern/libkern.h>
+#else
 #include <stdlib.h>   /* for exit()       */
+#endif
 
 #include "../../cs_priv.h"
 #include "../../utils.h"

--- a/arch/X86/X86DisassemblerDecoder.h
+++ b/arch/X86/X86DisassemblerDecoder.h
@@ -19,7 +19,11 @@
 #ifndef CS_X86_DISASSEMBLERDECODER_H
 #define CS_X86_DISASSEMBLERDECODER_H
 
+#if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <libkern/libkern.h>
+#else
 #include <stdio.h>
+#endif
 #include <stdint.h>
 
 #include "X86DisassemblerDecoderCommon.h"

--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -17,10 +17,16 @@
 
 #ifdef CAPSTONE_HAS_X86
 
+#if !defined(CAPSTONE_HAS_OSXKERNEL)
 #include <ctype.h>
+#endif
 #include "../../myinttypes.h"
+#if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <libkern/libkern.h>
+#else
 #include <stdio.h>
 #include <stdlib.h>
+#endif
 #include <string.h>
 
 #include "../../utils.h"

--- a/cs.c
+++ b/cs.c
@@ -3,9 +3,14 @@
 #if defined (WIN32) || defined (WIN64) || defined (_WIN32) || defined (_WIN64)
 #pragma warning(disable:4996)
 #endif
+#if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <libkern/libkern.h>
+#else
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+#endif
+
 #include <string.h>
 #include <capstone/capstone.h>
 

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -10,7 +10,12 @@ extern "C" {
 
 #include <stdint.h>
 #include <stdarg.h>
+#if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <libkern/libkern.h>
+#else
 #include <stdlib.h>
+#include <stdio.h>
+#endif
 
 #include "platform.h"
 

--- a/myinttypes.h
+++ b/myinttypes.h
@@ -1,5 +1,7 @@
 #if defined(_MSC_VER) && _MSC_VER <= 1700
 #include "msvc/headers/inttypes.h"
+#elif defined(CAPSTONE_HAS_OSXKERNEL)
+#include "osxkernel_inttypes.h" /* this is a trimmed copy of system inttypes.h that doesn't exit in kernel framework headers */
 #else
 #include <inttypes.h>
 #endif

--- a/osxkernel_inttypes.h
+++ b/osxkernel_inttypes.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2000-2004, 2013 Apple Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+/*
+ * <inttypes.h> -- Standard C header, defined in ISO/IEC 9899:1999
+ * (aka "C99"), section 7.8.   This defines format string conversion
+ * specifiers suitable for use within arguments to fprintf and fscanf
+ * and their ilk.
+ */
+
+#if !defined(_INTTYPES_H_)
+#define _INTTYPES_H_
+
+#  define __PRI_8_LENGTH_MODIFIER__ "hh"
+#  define __PRI_64_LENGTH_MODIFIER__ "ll"
+#  define __SCN_64_LENGTH_MODIFIER__ "ll"
+#  define __PRI_MAX_LENGTH_MODIFIER__ "j"
+#  define __SCN_MAX_LENGTH_MODIFIER__ "j"
+
+#  define PRId8         __PRI_8_LENGTH_MODIFIER__ "d"
+#  define PRIi8         __PRI_8_LENGTH_MODIFIER__ "i"
+#  define PRIo8         __PRI_8_LENGTH_MODIFIER__ "o"
+#  define PRIu8         __PRI_8_LENGTH_MODIFIER__ "u"
+#  define PRIx8         __PRI_8_LENGTH_MODIFIER__ "x"
+#  define PRIX8         __PRI_8_LENGTH_MODIFIER__ "X"
+
+#  define PRId16        "hd"
+#  define PRIi16        "hi"
+#  define PRIo16        "ho"
+#  define PRIu16        "hu"
+#  define PRIx16        "hx"
+#  define PRIX16        "hX"
+
+#  define PRId32        "d"
+#  define PRIi32        "i"
+#  define PRIo32        "o"
+#  define PRIu32        "u"
+#  define PRIx32        "x"
+#  define PRIX32        "X"
+
+#  define PRId64        __PRI_64_LENGTH_MODIFIER__ "d"
+#  define PRIi64        __PRI_64_LENGTH_MODIFIER__ "i"
+#  define PRIo64        __PRI_64_LENGTH_MODIFIER__ "o"
+#  define PRIu64        __PRI_64_LENGTH_MODIFIER__ "u"
+#  define PRIx64        __PRI_64_LENGTH_MODIFIER__ "x"
+#  define PRIX64        __PRI_64_LENGTH_MODIFIER__ "X"
+
+#  define PRIdLEAST8    PRId8
+#  define PRIiLEAST8    PRIi8
+#  define PRIoLEAST8    PRIo8
+#  define PRIuLEAST8    PRIu8
+#  define PRIxLEAST8    PRIx8
+#  define PRIXLEAST8    PRIX8
+
+#  define PRIdLEAST16   PRId16
+#  define PRIiLEAST16   PRIi16
+#  define PRIoLEAST16   PRIo16
+#  define PRIuLEAST16   PRIu16
+#  define PRIxLEAST16   PRIx16
+#  define PRIXLEAST16   PRIX16
+
+#  define PRIdLEAST32   PRId32
+#  define PRIiLEAST32   PRIi32
+#  define PRIoLEAST32   PRIo32
+#  define PRIuLEAST32   PRIu32
+#  define PRIxLEAST32   PRIx32
+#  define PRIXLEAST32   PRIX32
+
+#  define PRIdLEAST64   PRId64
+#  define PRIiLEAST64   PRIi64
+#  define PRIoLEAST64   PRIo64
+#  define PRIuLEAST64   PRIu64
+#  define PRIxLEAST64   PRIx64
+#  define PRIXLEAST64   PRIX64
+
+#  define PRIdFAST8     PRId8
+#  define PRIiFAST8     PRIi8
+#  define PRIoFAST8     PRIo8
+#  define PRIuFAST8     PRIu8
+#  define PRIxFAST8     PRIx8
+#  define PRIXFAST8     PRIX8
+
+#  define PRIdFAST16    PRId16
+#  define PRIiFAST16    PRIi16
+#  define PRIoFAST16    PRIo16
+#  define PRIuFAST16    PRIu16
+#  define PRIxFAST16    PRIx16
+#  define PRIXFAST16    PRIX16
+
+#  define PRIdFAST32    PRId32
+#  define PRIiFAST32    PRIi32
+#  define PRIoFAST32    PRIo32
+#  define PRIuFAST32    PRIu32
+#  define PRIxFAST32    PRIx32
+#  define PRIXFAST32    PRIX32
+
+#  define PRIdFAST64    PRId64
+#  define PRIiFAST64    PRIi64
+#  define PRIoFAST64    PRIo64
+#  define PRIuFAST64    PRIu64
+#  define PRIxFAST64    PRIx64
+#  define PRIXFAST64    PRIX64
+
+/* int32_t is 'int', but intptr_t is 'long'.  */
+#  define PRIdPTR       "ld"
+#  define PRIiPTR       "li"
+#  define PRIoPTR       "lo"
+#  define PRIuPTR       "lu"
+#  define PRIxPTR       "lx"
+#  define PRIXPTR       "lX"
+
+#  define PRIdMAX        __PRI_MAX_LENGTH_MODIFIER__ "d"
+#  define PRIiMAX        __PRI_MAX_LENGTH_MODIFIER__ "i"
+#  define PRIoMAX        __PRI_MAX_LENGTH_MODIFIER__ "o"
+#  define PRIuMAX        __PRI_MAX_LENGTH_MODIFIER__ "u"
+#  define PRIxMAX        __PRI_MAX_LENGTH_MODIFIER__ "x"
+#  define PRIXMAX        __PRI_MAX_LENGTH_MODIFIER__ "X"
+
+#  define SCNd8         __PRI_8_LENGTH_MODIFIER__ "d"
+#  define SCNi8         __PRI_8_LENGTH_MODIFIER__ "i"
+#  define SCNo8         __PRI_8_LENGTH_MODIFIER__ "o"
+#  define SCNu8         __PRI_8_LENGTH_MODIFIER__ "u"
+#  define SCNx8         __PRI_8_LENGTH_MODIFIER__ "x"
+
+#  define SCNd16        "hd"
+#  define SCNi16        "hi"
+#  define SCNo16        "ho"
+#  define SCNu16        "hu"
+#  define SCNx16        "hx"
+
+#  define SCNd32        "d"
+#  define SCNi32        "i"
+#  define SCNo32        "o"
+#  define SCNu32        "u"
+#  define SCNx32        "x"
+
+#  define SCNd64        __SCN_64_LENGTH_MODIFIER__ "d"
+#  define SCNi64        __SCN_64_LENGTH_MODIFIER__ "i"
+#  define SCNo64        __SCN_64_LENGTH_MODIFIER__ "o"
+#  define SCNu64        __SCN_64_LENGTH_MODIFIER__ "u"
+#  define SCNx64        __SCN_64_LENGTH_MODIFIER__ "x"
+
+#  define SCNdLEAST8    SCNd8
+#  define SCNiLEAST8    SCNi8
+#  define SCNoLEAST8    SCNo8
+#  define SCNuLEAST8    SCNu8
+#  define SCNxLEAST8    SCNx8
+
+#  define SCNdLEAST16   SCNd16
+#  define SCNiLEAST16   SCNi16
+#  define SCNoLEAST16   SCNo16
+#  define SCNuLEAST16   SCNu16
+#  define SCNxLEAST16   SCNx16
+
+#  define SCNdLEAST32   SCNd32
+#  define SCNiLEAST32   SCNi32
+#  define SCNoLEAST32   SCNo32
+#  define SCNuLEAST32   SCNu32
+#  define SCNxLEAST32   SCNx32
+
+#  define SCNdLEAST64   SCNd64
+#  define SCNiLEAST64   SCNi64
+#  define SCNoLEAST64   SCNo64
+#  define SCNuLEAST64   SCNu64
+#  define SCNxLEAST64   SCNx64
+
+#  define SCNdFAST8     SCNd8
+#  define SCNiFAST8     SCNi8
+#  define SCNoFAST8     SCNo8
+#  define SCNuFAST8     SCNu8
+#  define SCNxFAST8     SCNx8
+
+#  define SCNdFAST16    SCNd16
+#  define SCNiFAST16    SCNi16
+#  define SCNoFAST16    SCNo16
+#  define SCNuFAST16    SCNu16
+#  define SCNxFAST16    SCNx16
+
+#  define SCNdFAST32    SCNd32
+#  define SCNiFAST32    SCNi32
+#  define SCNoFAST32    SCNo32
+#  define SCNuFAST32    SCNu32
+#  define SCNxFAST32    SCNx32
+
+#  define SCNdFAST64    SCNd64
+#  define SCNiFAST64    SCNi64
+#  define SCNoFAST64    SCNo64
+#  define SCNuFAST64    SCNu64
+#  define SCNxFAST64    SCNx64
+
+#  define SCNdPTR       "ld"
+#  define SCNiPTR       "li"
+#  define SCNoPTR       "lo"
+#  define SCNuPTR       "lu"
+#  define SCNxPTR       "lx"
+
+#  define SCNdMAX       __SCN_MAX_LENGTH_MODIFIER__ "d"
+#  define SCNiMAX       __SCN_MAX_LENGTH_MODIFIER__ "i"
+#  define SCNoMAX       __SCN_MAX_LENGTH_MODIFIER__ "o"
+#  define SCNuMAX       __SCN_MAX_LENGTH_MODIFIER__ "u"
+#  define SCNxMAX       __SCN_MAX_LENGTH_MODIFIER__ "x"
+
+#endif /* !_INTTYPES_H_ */

--- a/utils.c
+++ b/utils.c
@@ -1,7 +1,11 @@
 /* Capstone Disassembly Engine */
 /* By Nguyen Anh Quynh <aquynh@gmail.com>, 2013-2015 */
 
+#if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <libkern/libkern.h>
+#else
 #include <stdlib.h>
+#endif
 #include <string.h>
 
 #include "utils.h"


### PR DESCRIPTION
Capstone 3.0.x branch doesn't work with OS X kernel extensions due to some include files that do not exist in OS X kernel framework headers.
This patch adds a new option that includes libkern/libkern.h, replacing the includes that do not exist.

It now works out of the box (I always copy and include full Capstone source code into my kexts). Might need some minor changes in the configuration scripts.

Pedro
