### PR TITLE
MSVC related fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,9 +192,9 @@ if (CAPSTONE_BUILD_SHARED)
     set_property(TARGET capstone-shared PROPERTY OUTPUT_NAME capstone)
     set_property(TARGET capstone-shared PROPERTY COMPILE_FLAGS -DCAPSTONE_SHARED)
 
-    if(MSVC)
+    if (MSVC)
         set_target_properties(capstone-shared PROPERTIES IMPORT_SUFFIX _dll.lib)
-    endif()
+    endif ()
 
     if(NOT DEFINED default-target)      # honor `capstone-static` for tests first.
 	set(default-target capstone-shared)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,10 @@ if (CAPSTONE_BUILD_SHARED)
     set_property(TARGET capstone-shared PROPERTY OUTPUT_NAME capstone)
     set_property(TARGET capstone-shared PROPERTY COMPILE_FLAGS -DCAPSTONE_SHARED)
 
+    if(MSVC)
+        set_target_properties(capstone-shared PROPERTIES IMPORT_SUFFIX _dll.lib)
+    endif()
+
     if(NOT DEFINED default-target)      # honor `capstone-static` for tests first.
 	set(default-target capstone-shared)
 	add_definitions(-DCAPSTONE_SHARED)

--- a/arch/Mips/MipsDisassembler.c
+++ b/arch/Mips/MipsDisassembler.c
@@ -409,6 +409,7 @@ static DecodeStatus Mips64Disassembler_getInstruction(int mode, MCInst *instr,
 		uint64_t Address, bool isBigEndian, MCRegisterInfo *MRI)
 {
 	uint32_t Insn;
+	DecodeStatus Result;
 
 	if (code_len < 4)
 		// not enough data
@@ -418,7 +419,7 @@ static DecodeStatus Mips64Disassembler_getInstruction(int mode, MCInst *instr,
 		memset(instr->flat_insn->detail, 0, sizeof(cs_detail));
 	}
 
-	DecodeStatus Result = readInstruction32((unsigned char*)code, &Insn, isBigEndian, false);
+	Result = readInstruction32((unsigned char*)code, &Insn, isBigEndian, false);
 	if (Result == MCDisassembler_Fail)
 		return MCDisassembler_Fail;
 


### PR DESCRIPTION
Fix nmake build,
give msvc + cmake a different target for the .lib file,
otherwise the shared target .lib will be overwritten by the static target .lib