### PR TITLE
Fix handling of cmpxchg16b with lock prefix

### DIFF
--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -2112,6 +2112,7 @@ static bool checkPrefix(struct InternalInstruction *insn)
 			case X86_BTS64mr:
 
 			// CMPXCHG
+			case X86_CMPXCHG16B:
 			case X86_CMPXCHG16rm:
 			case X86_CMPXCHG32rm:
 			case X86_CMPXCHG64rm:


### PR DESCRIPTION
This was discovered when Frida's Stalker encountered the following
x86-64 instruction while tracing code in ntdll: `f0 49 0f c7 0a`.