### PR TITLE
Improve the pkgconfig target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,6 +466,7 @@ endef
 
 
 define generate-pkgcfg
+	mkdir -p $(BLDIR)
 	echo 'Name: capstone' > $(PKGCFGF)
 	echo 'Description: Capstone disassembly engine' >> $(PKGCFGF)
 	echo 'Version: $(PKG_VERSION)' >> $(PKGCFGF)


### PR DESCRIPTION
The destination directory may not exist, so we need to mkdir just
in case.