### PR TITLE
Add modrm_offset to cs_x86

### DIFF
--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -869,6 +869,7 @@ static void update_pub_insn(cs_insn *pub, InternalInstruction *inter, uint8_t *p
 	pub->detail->x86.addr_size = inter->addressSize;
 
 	pub->detail->x86.modrm = inter->orgModRM;
+	pub->detail->x86.modrm_offset = (inter->modRMLocation != 0) ? (inter->modRMLocation - inter->startLocation) : 0;
 	pub->detail->x86.sib = inter->sib;
 	pub->detail->x86.disp = inter->displacement;
 

--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -1478,6 +1478,8 @@ static int readModRM(struct InternalInstruction *insn)
 	if (insn->consumedModRM)
 		return 0;
 
+	insn->modRMLocation = insn->readerCursor;
+
 	if (consumeByte(insn, &insn->modRM))
 		return -1;
 

--- a/arch/X86/X86DisassemblerDecoder.h
+++ b/arch/X86/X86DisassemblerDecoder.h
@@ -665,6 +665,8 @@ typedef struct InternalInstruction {
   /* The ModR/M byte, which contains most register operands and some portion of
      all memory operands */
   uint8_t                       modRM;
+  /* contains the location (for use with the reader) of the modRM byte */
+  uint64_t                      modRMLocation;
 
   // special data to handle MOVcr, MOVdr, MOVrc, MOVrd
   uint8_t                       firstByte;     // save the first byte in stream

--- a/include/capstone/x86.h
+++ b/include/capstone/x86.h
@@ -284,6 +284,8 @@ typedef struct cs_x86 {
 
 	// ModR/M byte
 	uint8_t modrm;
+	// ModR/M offset, or 0 when irrelevant.
+	uint8_t modrm_offset;
 
 	// SIB value, or 0 when irrelevant.
 	uint8_t sib;


### PR DESCRIPTION
Example use-case is applications that would like to rewrite RIP-relative
64-bit instructions without knowing the modrm offset of every instruction
with a modrm byte. Here's how we use it in Frida:

https://github.com/frida/frida-gum/blob/e41ef422229f2943e81e554282a4af9a1195b746/gum/arch-x86/gumx86relocator.c#L553