### PR TITLE
Fix spelling nits

### DIFF
--- a/include/capstone.h
+++ b/include/capstone.h
@@ -118,7 +118,7 @@ typedef struct cs_opt_mem {
 
 // Runtime option for the disassembled engine
 typedef enum cs_opt_type {
-	CS_OPT_SYNTAX = 1,	// Asssembly output syntax
+	CS_OPT_SYNTAX = 1,	// Assembly output syntax
 	CS_OPT_DETAIL,	// Break down instruction structure into details
 	CS_OPT_MODE,	// Change engine's mode at run-time
 	CS_OPT_MEM,	// User-defined dynamic memory related functions
@@ -408,7 +408,7 @@ const char *cs_strerror(cs_err code);
 /*
  Disassemble binary code, given the code buffer, size, address and number
  of instructions to be decoded.
- This API dynamicly allocate memory to contain disassembled instruction.
+ This API dynamically allocate memory to contain disassembled instruction.
  Resulted instructions will be put into @*insn
 
  NOTE 1: this API will automatically determine memory needed to contain
@@ -421,7 +421,7 @@ const char *cs_strerror(cs_err code);
  cs_disasm(). The reason is that with cs_disasm(), based on limited available
  memory, we have to calculate in advance how many instructions to be disassembled,
  which complicates things. This is especially troublesome for the case @count=0,
- when cs_disasm() runs uncontrolly (until either end of input buffer, or
+ when cs_disasm() runs uncontrollably (until either end of input buffer, or
  when it encounters an invalid instruction).
  
  @handle: handle returned by cs_open()
@@ -431,9 +431,9 @@ const char *cs_strerror(cs_err code);
  @insn: array of instructions filled in by this API.
 	   NOTE: @insn will be allocated by this function, and should be freed
 	   with cs_free() API.
- @count: number of instrutions to be disassembled, or 0 to get all of them
+ @count: number of instructions to be disassembled, or 0 to get all of them
 
- @return: the number of succesfully disassembled instructions,
+ @return: the number of successfully disassembled instructions,
  or 0 if this function failed to disassemble the given code
 
  On failure, call cs_errno() for error code.
@@ -486,7 +486,7 @@ cs_insn *cs_malloc(csh handle);
  See tests/test_iter.c for sample code demonstrating this API.
 
  NOTE 1: this API will update @code, @size & @address to point to the next
- instruction in the input buffer. Therefore, it is covenient to use
+ instruction in the input buffer. Therefore, it is convenient to use
  cs_disasm_iter() inside a loop to quickly iterate all the instructions.
  While decoding one instruction at a time can also be achieved with
  cs_disasm(count=1), some benchmarks shown that cs_disasm_iter() can be 30%
@@ -500,7 +500,7 @@ cs_insn *cs_malloc(csh handle);
  The reason is that with cs_disasm(), based on limited available memory,
  we have to calculate in advance how many instructions to be disassembled,
  which complicates things. This is especially troublesome for the case
- @count=0, when cs_disasm() runs uncontrolly (until either end of input
+ @count=0, when cs_disasm() runs uncontrollably (until either end of input
  buffer, or when it encounters an invalid instruction).
  
  @handle: handle returned by cs_open()
@@ -520,7 +520,7 @@ bool cs_disasm_iter(csh handle,
 	uint64_t *address, cs_insn *insn);
 
 /*
- Return friendly name of regiser in a string.
+ Return friendly name of register in a string.
  Find the instruction id from header file of corresponding architecture (arm.h for ARM,
  x86.h for X86, ...)
 


### PR DESCRIPTION
I was playing with this awesome disassembly engine and while reading the awesome code documentation, I made a few minor spelling fixes along the way and since I follow the Boy Scout rule, wanted to contribute them back.

Thank you for this engine!