### PR TITLE
Fix error when _cs is None during teardown

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -728,7 +728,7 @@ class Cs(object):
 
     # destructor to be called automatically when object is destroyed.
     def __del__(self):
-        if self.csh:
+        if self.csh and _cs is not None:
             status = _cs.cs_close(ctypes.byref(self.csh))
             if status != CS_ERR_OK:
                 raise CsError(status)


### PR DESCRIPTION
During cleanup, it's possible that the _cs object is None on the line below, which throws the error.

```
Exception AttributeError: "'NoneType' object has no attribute 'cs_close'" in <bound method Cs.__del__ of <capstone.Cs object at 0x1d0cb10>> ignored
```

https://github.com/aquynh/capstone/blob/b238628e37b09c2fba09b0209ecafa2c73b35031/bindings/python/capstone/__init__.py#L694

```py
    # destructor to be called automatically when object is destroyed.
    def __del__(self):
        if self.csh:
            status = _cs.cs_close(ctypes.byref(self.csh))
            if status != CS_ERR_OK:
                raise CsError(status)
```