### PR TITLE
Make PowerPC imm 64 bit (instad 32 bit)

### DIFF
--- a/arch/PowerPC/PPCInstPrinter.c
+++ b/arch/PowerPC/PPCInstPrinter.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "PPCInstPrinter.h"
 #include "PPCPredicates.h"
@@ -710,17 +711,17 @@ static void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 	}
 
 	if (MCOperand_isImm(Op)) {
-		int32_t imm = (int32_t)MCOperand_getImm(Op);
+		uint64_t imm = MCOperand_getImm(Op);
 		if (imm >= 0) {
 			if (imm > HEX_THRESHOLD)
-				SStream_concat(O, "0x%x", imm);
+				SStream_concat(O, "0x%" PRIx64, imm);
 			else
-				SStream_concat(O, "%u", imm);
+				SStream_concat(O, "%" PRIu64 , imm);
 		} else {
 			if (imm < -HEX_THRESHOLD)
-				SStream_concat(O, "-0x%x", -imm);
+				SStream_concat(O, "-0x%" PRIx64 , -imm);
 			else
-				SStream_concat(O, "-%u", -imm);
+				SStream_concat(O, "-%" PRIu64 , -imm);
 		}
 
 		if (MI->csh->detail) {

--- a/bindings/java/capstone/Ppc.java
+++ b/bindings/java/capstone/Ppc.java
@@ -36,7 +36,7 @@ public class Ppc {
 
   public static class OpValue extends Union {
     public int reg;
-    public int imm;
+    public long imm;
     public MemType mem;
     public CrxType crx;
   }

--- a/bindings/java/capstone/X86.java
+++ b/bindings/java/capstone/X86.java
@@ -116,6 +116,7 @@ public class X86 {
     public int sibIndex;
     public byte sibScale;
     public int sibBase;
+    public int xopCC;
     public int sseCC;
     public int avxCC;
     public boolean avxSae;

--- a/include/capstone/ppc.h
+++ b/include/capstone/ppc.h
@@ -66,7 +66,7 @@ typedef struct cs_ppc_op {
 	ppc_op_type type;	// operand type
 	union {
 		unsigned int reg;	// register value for REG operand
-		int32_t imm;		// immediate value for IMM operand
+		int64_t imm;		// immediate value for IMM operand
 		ppc_op_mem mem;		// base/disp value for MEM operand
 		ppc_op_crx crx;		// operand with condition register
 	};

--- a/tests/test_ppc.c
+++ b/tests/test_ppc.c
@@ -79,7 +79,7 @@ static void print_insn_detail(cs_insn *ins)
 				printf("\t\toperands[%u].type: REG = %s\n", i, cs_reg_name(handle, op->reg));
 				break;
 			case PPC_OP_IMM:
-				printf("\t\toperands[%u].type: IMM = 0x%x\n", i, op->imm);
+				printf("\t\toperands[%u].type: IMM = 0x%" PRIx64 "\n", i, op->imm);
 				break;
 			case PPC_OP_MEM:
 				printf("\t\toperands[%u].type: MEM\n", i);


### PR DESCRIPTION
The imm variant of an instruction is defined as as int32_t. Indeed, an
immediate cannot be wider than that in a PowerPC instruction.

However, for branching instruction with AA=0, the field contains the
real target address (offset + CIA) instead of the offset: the real
target address might be outside of the 32 bit address space.