### PR TITLE
[next] Virtualenv support for Python binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 
 # python
 bindings/python/build/
+bindings/python/capstone.egg-info/
 *.pyc
 
 # java

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -6,7 +6,6 @@ import shutil
 import stat
 import sys
 
-from site import getusersitepackages
 from distutils import log
 from distutils import dir_util
 from distutils.command.build_clib import build_clib
@@ -26,10 +25,14 @@ if os.path.exists(PATH_LIB64) and os.path.exists(PATH_LIB32):
 SYSTEM = sys.platform
 VERSION = '4.0'
 
+# virtualenv breaks import, but get_python_lib() will work.
+SITE_PACKAGES = os.path.join(get_python_lib(), "capstone")
 if "--user" in sys.argv:
-    SITE_PACKAGES = os.path.join(getusersitepackages(), "capstone")
-else:
-    SITE_PACKAGES = os.path.join(get_python_lib(), "capstone")
+    try:
+        from site import getusersitepackages
+        SITE_PACKAGES = os.path.join(getusersitepackages(), "capstone")
+    except ImportError:
+        pass
 
 
 SETUP_DATA_FILES = []


### PR DESCRIPTION
**In a [virtualenv] (http://pypi.python.org/pypi/virtualenv):**
* `site.getusersitepackages` won't import
* `distutils.sysconfig.get_python_lib` will return the directory inside the virtualenv
* the `--user` option can therefore be safely ignored.

I also added the generated capstone.egg-info directory to the .gitignore list.