### PR TITLE
make.sh: Fix warning due to check

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -68,7 +68,7 @@ function build {
 
 	${MAKE} clean
 
-	if [ ${CC}x != x ]; then
+	if [ -z "${CC}" ]; then
 		${MAKE} CC=$CC $*
 	else
 		${MAKE} $*


### PR DESCRIPTION
We get the following warning caused by checking an environment variable being null:

./make.sh: line 71: [: too many arguments

Fix by checking for null variable using '-z'.