### PR TITLE
Fix check for multi-string CC

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -68,8 +68,8 @@ function build {
 
 	${MAKE} clean
 
-	if [ ${CC}x != x ]; then
-		${MAKE} CC=$CC $*
+	if [ -n "$CC" ]; then
+		${MAKE} CC="$CC" $*
 	else
 		${MAKE} $*
 	fi
@@ -101,14 +101,14 @@ function install {
 		fi
 	else	# not OSX
 		if test -d /usr/lib64; then
-			if [ ${CC}x != x ]; then
-				${MAKE} LIBDIRARCH=lib64 CC=$CC install
+			if [ -n "$CC" ]; then
+				${MAKE} LIBDIRARCH=lib64 CC="$CC" install
 			else
 				${MAKE} LIBDIRARCH=lib64 install
 			fi
 		else
-			if [ ${CC}x != x ]; then
-				${MAKE} CC=$CC install
+			if [ -n "$CC" ]; then
+				${MAKE} CC="$CC" install
 			else
 				${MAKE} install
 			fi


### PR DESCRIPTION
When the CC variable has a multi-string value like when using ccache(CC="ccache gcc"), it currently throws a warning. Fix such issues, also when passing CC to make.