### PR TITLE
Fix bug in option propagation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,11 @@ foreach(i RANGE ${count})
 endforeach(i)
 
 # propagate achitecture support variables to preprocessor
-foreach(supported_architecture SUPPORTED_ARCHITECTURES)
+foreach(supported_architecture ${SUPPORTED_ARCHITECTURES})
   set(option_name "CAPSTONE_${supported_architecture}_SUPPORT")
   if(${option_name})
-    add_definitions("-${option_name}")
+    message("Enabling ${option_name}")
+    add_definitions("-D${option_name}")
   endif()
 endforeach(supported_architecture)
 


### PR DESCRIPTION
cmake options can be used to disable certain architectures, which is very helpful for reducing the binary size. For instance cmake -DCAPSTONE_X86_SUPPORT=OFF can be used to exclude X86 related code from being compiled. At the same time tests like test.c, test_iter.c, etc reference all architectures, so they fail when one of the architectures is turned off. To avoid this, support options are propagated to the preprocessor, where they can be used to conditionally include architecture specific code.

Sorry about this. I did more testing this time and included diagnostic to make sure the issue is really resolved.