### PR TITLE
Resolve cmake project version policy warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,14 @@ if(POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW)
 endif(POLICY CMP0042)
 
+if (POLICY CMP0048)
+  # use old policy to honor version set using VERSION_* variables to preserve backwards
+  # compatibility. change OLD to NEW when minimum cmake version is updated to 3.* and
+  # set VERSION using project(capstone VERSION 4.0.0).
+  # http://www.cmake.org/cmake/help/v3.0/policy/CMP0048.html
+  cmake_policy (SET CMP0048 OLD)
+endif()
+
 # to configure the options specify them in in the command line or change them in the cmake UI.
 # Don't edit the makefile!
 option(CAPSTONE_BUILD_STATIC_RUNTIME "Embed static runtime" OFF)


### PR DESCRIPTION
For now use old policy behavior to preserve backwards compatibility, but I strongly recommend updating the minimum cmake version, since it's considered a best practice.
http://www.slideshare.net/DanielPfeifer1/cmake-48475415 (slide 21)