### PR TITLE
file.write() need bytes when file is opened in binary mode

### DIFF
--- a/bindings/const_generator.py
+++ b/bindings/const_generator.py
@@ -71,7 +71,7 @@ def gen(lang):
     for target in include:
         prefix = templ[target]
         outfile = open(templ['out_file'] %(prefix), 'wb')   # open as binary prevents windows newlines
-        outfile.write(templ['header'] % (prefix))
+        outfile.write((templ['header'] % (prefix)).encode("utf-8"))
 
         lines = open(INCL_DIR + target).readlines()
 
@@ -80,8 +80,9 @@ def gen(lang):
             line = line.strip()
 
             if line.startswith(MARKUP):  # markup for comments
-                outfile.write("\n%s%s%s\n" %(templ['comment_open'], \
-                            line.replace(MARKUP, ''), templ['comment_close']))
+                outfile.write(("\n%s%s%s\n" %(templ['comment_open'], \
+                                              line.replace(MARKUP, ''), \
+                                              templ['comment_close']) ).encode("utf-8"))
                 continue
 
             if line == '' or line.startswith('//'):
@@ -122,7 +123,7 @@ def gen(lang):
                     try:
                         count = int(rhs) + 1
                         if (count == 1):
-                            outfile.write("\n")
+                            outfile.write(("\n").encode("utf-8"))
                     except ValueError:
                         if lang == 'ocaml':
                             # ocaml uses lsl for '<<', lor for '|'
@@ -132,9 +133,9 @@ def gen(lang):
                             if rhs[0].isalpha():
                                 rhs = '_' + rhs
 
-                    outfile.write(templ['line_format'] %(f[0].strip(), rhs))
+                    outfile.write((templ['line_format'] %(f[0].strip(), rhs)).encode("utf-8"))
 
-        outfile.write(templ['footer'])
+        outfile.write((templ['footer']).encode("utf-8"))
         outfile.close()
 
 def main():


### PR DESCRIPTION
Avoid "TypeError: a bytes-like object is required, not 'str'" error during
write().
As the outfile need to be opened in binary mode, so python 3 require bytes
stream as argument in outfile.write().
Fixed by set all output string write to utf-8 encoding.

Signed-off-by: Nicolas PLANEL <nplanel@gmail.com>