### PR TITLE
M68k fixup

### DIFF
--- a/arch/M68K/M68Kdasm.c
+++ b/arch/M68K/M68Kdasm.c
@@ -1067,20 +1067,22 @@ static void build_link(int disp, int size)
 
 static void build_cpush_cinv(int op_offset)
 {
-	cs_m68k* info = build_init_op(M68K_INS_ILLEGAL, 2, 0);
-	switch ((g_cpu_ir >> 3) & 3)
+	cs_m68k* info = build_init_op(M68K_INS_INVALID, 2, 0);
+	switch ((g_cpu_ir >> 3) & 3) // scope
 	{
-		case 0:
-			if(info) {
-				info->op_count = 0;
-			}
-			break;
+		// Invalid
+		case 0: 
+			d68000_invalid();
+			return;
+		// Line
 		case 1:
 			MCInst_setOpcode(g_inst, op_offset + 0);
 			break;
+		// Page
 		case 2:
 			MCInst_setOpcode(g_inst, op_offset + 1);
 			break;
+		// All
 		case 3:
 			if(info) {
 				info->op_count = 1;

--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -980,8 +980,7 @@ def debug():
 
     all_archs = ""
     keys = archs.keys()
-    keys.sort()
-    for k in keys:
+    for k in sorted(keys):
         if cs_support(archs[k]):
             all_archs += "-%s" % k
 

--- a/contrib/objdump/objdump-m68k.py
+++ b/contrib/objdump/objdump-m68k.py
@@ -5,7 +5,6 @@ import sys
 import bitstring
 from capstone import *
 from capstone.m68k import *
-from xprint import to_hex, to_x
 
 #
 # Objdump with the same output as his binary cousin


### PR DESCRIPTION
[contrib][objdump] remove un needed import
[binding][python] fixup python 3 compatibility
[M68K] CPUSH CINV should return INVALID opcode is case of error.
