### PR TITLE
[M68K] Coverity fixup : remove old/dead code.

### DIFF
--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -1048,9 +1048,7 @@ static void build_cpush_cinv(m68k_info *info, int op_offset)
 			break;
 			// All
 		case 3:
-			if (info) {
-				ext->op_count = 1;
-			}
+			ext->op_count = 1;
 			MCInst_setOpcode(info->inst, op_offset + 2);
 			break;
 	}


### PR DESCRIPTION
if(info) should be removed as it's an old part of the code that has been forgotten before merging.

Didn't cause any Bug as info is always true.
Related to issue #494

Signed-off-by: Nicolas PLANEL <nplanel@gmail.com>