### PR TITLE
Add macro detection for current architecture

### DIFF
--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -389,6 +389,27 @@ CAPSTONE_EXPORT
 cs_err cs_open(cs_arch arch, cs_mode mode, csh *handle);
 
 /*
+ Initialize CS handle with the current system architecture.
+
+ NOTE: The definition is made available in capstone.h to allow users to define
+ CS_ARCH_CURRENT and CS_MODE_CURRENT in case the current architecture cannot be
+ detected with compiler macros.
+
+ @handle: pointer to handle, which will be updated at return time
+
+ @return CS_ERR_OK on success, or other value on failure (refer to cs_err enum
+ for detailed error).
+*/
+static inline cs_err cs_open_self_arch(csh *handle)
+{
+	if (CS_ARCH_CURRENT == -1)
+		return CS_ERR_ARCH;
+	if (CS_MODE_CURRENT == -1)
+		return CS_ERR_MODE;
+	return cs_open(CS_ARCH_CURRENT, CS_MODE_CURRENT, handle);
+}
+
+/*
  Close CS handle: MUST do to release the handle when it is not used anymore.
  NOTE: this must be only called when there is no longer usage of Capstone,
  not even access to cs_insn array. The reason is the this API releases some

--- a/include/capstone/platform.h
+++ b/include/capstone/platform.h
@@ -25,4 +25,108 @@ typedef unsigned char bool;
 #include <stdbool.h>
 #endif
 
+#if defined(CS_ARCH_CURRENT) && !defined(CS_MODE_CURRENT) \
+    || defined(CS_MODE_CURRENT) && !defined(CS_ARCH_CURRENT)
+# error \
+    You cannot define only one of CS_ARCH_CURRENT and CS_MODE_CURRENT:          \
+    both must be specified when providing the current architecture information  \
+    to capstone.
+#endif
+
+// Define the current endinanness
+#ifndef CS_MODE_CURRENT_ENDIAN
+// Big endian
+# if defined(__BIG_ENDIAN__) || defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AARCH64EB__) || defined(__MIPSEB) || __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#  define CS_MODE_CURRENT_ENDIAN CS_MODE_BIG_ENDIAN
+// Little endian
+# elif defined(__LITTLE_ENDIAN__) || defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__) || defined(__MIPSEL) || __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#  define CS_MODE_CURRENT_ENDIAN CS_MODE_LITTLE_ENDIAN
+# endif
+#endif
+
+// Define the current architecture & mode
+#if !defined(CS_ARCH_CURRENT) && !defined(CS_MODE_ARCH_CURRENT)
+
+// ARM-64 / AArch64
+#if defined(__aarch64__)
+# define CS_ARCH_CURRENT CS_ARCH_ARM64
+# define CS_MODE_ARCH_CURRENT CS_MODE_ARM
+
+// ARM
+#elif defined(__arm__) || defined(__thumb__) || defined(_M_ARM) || defined(_M_ARMT) || defined(__arm) || defined(_ARM)
+# define CS_ARCH_CURRENT CS_ARCH_ARM
+
+# if defined(__thumb__) || defined(_M_ARMT)
+#  define CS_MODE_ARCH_CURRENT CS_MODE_THUMB
+# else
+#  define CS_MODE_ARCH_CURRENT CS_MODE_ARM
+# endif
+
+// Mips
+#elif defined(__mips) || defined(__mips__)
+# define CS_ARCH_CURRENT CS_ARCH_MIPS
+
+# if defined(_MIPS_ISA_MIPS1) || __mips < 2
+#  define CS_MODE_ARCH_CURRENT CS_MODE_MIPS32
+# elif defined(_MIPS_ISA_MIPS2) || defined(__MIPS_ISA2__) || __mips == 2
+#  define CS_MODE_ARCH_CURRENT CS_MODE_MIPS32R6
+# elif defined(_MIPS_ISA_MIPS3) || defined(_MIPS_ISA_MIPS4) || __mips > 2 || defined(_R4000)
+#  define CS_MODE_ARCH_CURRENT CS_MODE_MIPS64
+# endif
+
+// x86
+#elif defined(_M_X64) || defined(__amd64) || defined(__i386) || defined(_M_IX86) || defined(_M_I86)
+# define CS_ARCH_CURRENT CS_ARCH_X86
+
+# if defined(_M_X64) || defined(__amd64)
+#  define CS_MODE_ARCH_CURRENT CS_MODE_64
+# elif defined(__i386) || defined(_M_IX86)
+#  define CS_MODE_ARCH_CURRENT CS_MODE_32
+# else
+#  define CS_MODE_ARCH_CURRENT CS_MODE_16
+# endif
+
+// PowerPC
+#elif defined(__ppc__) || defined(__ppc64__) || defined(_M_PPC) || defined(_ARCH_PPC64)
+# define CS_ARCH_CURRENT CS_ARCH_PPC
+
+# if defined(__ppc64__) || defined(_ARCH_PPC64) || _M_PPC >= 620
+#  define CS_MODE_ARCH_CURRENT CS_MODE_64
+# else
+#  define CS_MODE_ARCH_CURRENT CS_MODE_32
+# endif
+
+// Sparc
+#elif defined(__sparc__) || defined(__sparc)
+# define CS_ARCH_CURRENT CS_ARCH_SPARC
+
+# if defined(__sparc_v9__) || defined(__sparcv9)
+#  define CS_MODE_ARCH_CURRENT CS_MODE_V9
+# endif
+
+// SystemZ
+#elif defined(__s390__) || defined(__s390x__) || defined(__zarch__) || defined(__SYSC_ZARCH__)
+# define CS_ARCH_CURRENT CS_ARCH_SYSZ
+
+// XCore (no known preprocessor macro checks ATM)
+// Unsupported architectures
+#else
+# define CS_ARCH_CURRENT -1
+# define CS_MODE_CURRENT -1
+#endif
+
+#endif
+
+#ifndef CS_ARCH_CURRENT
+# define CS_ARCH_CURRENT -1
+#endif
+
+#ifndef CS_MODE_CURRENT
+# if !defined(CS_MODE_CURRENT_ENDIAN) || !defined(CS_MODE_ARCH_CURRENT)
+#  define CS_MODE_CURRENT -1
+# else
+#  define CS_MODE_CURRENT (CS_MODE_CURRENT_ENDIAN | CS_MODE_ARCH_CURRENT)
+# endif
+#endif
+
 #endif


### PR DESCRIPTION
Capstone seems to be lacking some kind of "current" architecture/mode value for cs_open, which makes it inconvenient and/or architecture specific to open the capstone handle when a process tries to disassemble itself.

The scope of this PR is to allow the disassembly of same-architecture binaries (or of the calling process itself) to be more convenient by adding the following macros:
* `CS_ARCH_CURRENT`, which expands to the current architecture,
* `CS_MODE_CURRENT`, which expands to the current mode.

Although I tried to be the most complete with the compiler-specific macros for the automatic architecture detection, it is of course incomplete, which is why the checks only define the above macros if they are not already defined by the user. This way, if the architecture cannot be inferred, one can use his/her build system to define the macros.

I also provide a `cs_open_self_arch` function, which is just a convenient wrapper over `cs_open` called with both `CS_ARCH_CURRENT` and `CS_MODE_CURRENT` with special error handling when the detection failed. This function happens to be defined in `capstone.h`, because it would not work when the user defines himself the macros otherwise (or rather he/she would need to recompile capstone itself, which would make the function not so convenient anymore).

Note: `CS_MODE_MICRO`, `CS_MODE_MCLASS` and `CS_MODE_V8` are *not* inferred in the attached commits, because there is currently no way to check those at compile time (to my understanding).

Reference used for the macro checks: [[1]](http://sourceforge.net/p/predef/wiki/Architectures/)