### PR TITLE
Python 3: CsError.__str__

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -319,8 +319,13 @@ class CsError(Exception):
     def __init__(self, errno):
         self.errno = errno
 
-    def __str__(self):
-        return _cs.cs_strerror(self.errno)
+    if _python2:
+        def __str__(self):
+            return _cs.cs_strerror(self.errno)
+
+    else:
+        def __str__(self):
+            return _cs.cs_strerror(self.errno).decode()
 
 
 # return the core's version


### PR DESCRIPTION
Choose `CsError.__str__` implementation based on Python version.

Momentarily forgot Python's indentation rules.