### PR TITLE
fix setting cross compilation variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ AR ?= ar
 RANLIB ?= ranlib
 STRIP ?= strip
 else
-CC ?= $(CROSS)gcc
-AR ?= $(CROSS)ar
-RANLIB ?= $(CROSS)ranlib
-STRIP ?= $(CROSS)strip
+CC = $(CROSS)gcc
+AR = $(CROSS)ar
+RANLIB = $(CROSS)ranlib
+STRIP = $(CROSS)strip
 endif
 
 ifneq (,$(findstring yes,$(CAPSTONE_DIET)))


### PR DESCRIPTION
this change is apparently already on master
it is needed for ./make.sh cross* to work