### PR TITLE
Fix classification of ARM jump instructions

### DIFF
--- a/arch/ARM/ARMMappingInsn.inc
+++ b/arch/ARM/ARMMappingInsn.inc
@@ -148,55 +148,55 @@
 {
 	ARM_BL, ARM_INS_BL,
 #ifndef CAPSTONE_DIET
-	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_CALL, ARM_GRP_ARM, 0 }, 0, 0
+	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_CALL, ARM_GRP_ARM, 0 }, 1, 0
 #endif
 },
 {
 	ARM_BLX, ARM_INS_BLX,
 #ifndef CAPSTONE_DIET
-	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_CALL, ARM_GRP_V5T, 0 }, 0, 0
+	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_CALL, ARM_GRP_V5T, 0 }, 0, 1
 #endif
 },
 {
 	ARM_BLX_pred, ARM_INS_BLX,
 #ifndef CAPSTONE_DIET
-	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_CALL, ARM_GRP_ARM, ARM_GRP_V5T, 0 }, 0, 0
+	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_CALL, ARM_GRP_ARM, ARM_GRP_V5T, 0 }, 0, 1
 #endif
 },
 {
 	ARM_BLXi, ARM_INS_BLX,
 #ifndef CAPSTONE_DIET
-	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_CALL, ARM_GRP_ARM, ARM_GRP_V5T, 0 }, 0, 0
+	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_CALL, ARM_GRP_ARM, ARM_GRP_V5T, 0 }, 1, 0
 #endif
 },
 {
 	ARM_BL_pred, ARM_INS_BL,
 #ifndef CAPSTONE_DIET
-	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_CALL, ARM_GRP_ARM, 0 }, 0, 0
+	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_CALL, ARM_GRP_ARM, 0 }, 1, 0
 #endif
 },
 {
 	ARM_BX, ARM_INS_BX,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { ARM_GRP_ARM, ARM_GRP_V4T, 0 }, 1, 1
+	{ 0 }, { 0 }, { ARM_GRP_ARM, ARM_GRP_V4T, 0 }, 0, 1
 #endif
 },
 {
 	ARM_BXJ, ARM_INS_BXJ,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { ARM_GRP_ARM, 0 }, 1, 1
+	{ 0 }, { 0 }, { ARM_GRP_ARM, 0 }, 0, 1
 #endif
 },
 {
 	ARM_BX_RET, ARM_INS_BX,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { ARM_GRP_ARM, ARM_GRP_V4T, 0 }, 1, 1
+	{ 0 }, { 0 }, { ARM_GRP_ARM, ARM_GRP_V4T, 0 }, 0, 1
 #endif
 },
 {
 	ARM_BX_pred, ARM_INS_BX,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { ARM_GRP_ARM, ARM_GRP_V4T, 0 }, 1, 1
+	{ 0 }, { 0 }, { ARM_GRP_ARM, ARM_GRP_V4T, 0 }, 0, 1
 #endif
 },
 {
@@ -10768,7 +10768,7 @@
 {
 	ARM_t2BXJ, ARM_INS_BXJ,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { ARM_GRP_THUMB2, ARM_GRP_NOTMCLASS, ARM_GRP_PREV8, 0 }, 1, 1
+	{ 0 }, { 0 }, { ARM_GRP_THUMB2, ARM_GRP_NOTMCLASS, ARM_GRP_PREV8, 0 }, 0, 1
 #endif
 },
 {
@@ -12574,13 +12574,13 @@
 {
 	ARM_t2TBB, ARM_INS_TBB,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { ARM_GRP_THUMB2, 0 }, 1, 1
+	{ 0 }, { 0 }, { ARM_GRP_THUMB2, 0 }, 0, 1
 #endif
 },
 {
 	ARM_t2TBH, ARM_INS_TBH,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { ARM_GRP_THUMB2, 0 }, 1, 1
+	{ 0 }, { 0 }, { ARM_GRP_THUMB2, 0 }, 0, 1
 #endif
 },
 {
@@ -12922,25 +12922,25 @@
 {
 	ARM_tBL, ARM_INS_BL,
 #ifndef CAPSTONE_DIET
-	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_THUMB, ARM_GRP_CALL, 0 }, 0, 0
+	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_THUMB, ARM_GRP_CALL, 0 }, 1, 0
 #endif
 },
 {
 	ARM_tBLXi, ARM_INS_BLX,
 #ifndef CAPSTONE_DIET
-	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_THUMB, ARM_GRP_V5T, ARM_GRP_NOTMCLASS, ARM_GRP_CALL, 0 }, 0, 0
+	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_THUMB, ARM_GRP_V5T, ARM_GRP_NOTMCLASS, ARM_GRP_CALL, 0 }, 1, 0
 #endif
 },
 {
 	ARM_tBLXr, ARM_INS_BLX,
 #ifndef CAPSTONE_DIET
-	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_THUMB, ARM_GRP_V5T, ARM_GRP_CALL, 0 }, 0, 0
+	{ ARM_REG_PC, 0 }, { ARM_REG_LR, 0 }, { ARM_GRP_THUMB, ARM_GRP_V5T, ARM_GRP_CALL, 0 }, 0, 1
 #endif
 },
 {
 	ARM_tBX, ARM_INS_BX,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { ARM_GRP_THUMB, 0 }, 1, 1
+	{ 0 }, { 0 }, { ARM_GRP_THUMB, 0 }, 0, 1
 #endif
 },
 {


### PR DESCRIPTION
All jump instructions have been classified based on the direct
and indirect_branch flags.