### PR TITLE
Align thumb BLX immediate by discarding low bits (for issue #580)

### DIFF
--- a/arch/ARM/ARMInstPrinter.c
+++ b/arch/ARM/ARMInstPrinter.c
@@ -841,9 +841,7 @@ static void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 				imm += (int32_t)MI->address + 4;
 				if (ARM_blx_to_arm_mode(MI->csh, opc)) {
 					// here need to align down to the nearest 4-byte address
-#define _ALIGN_DOWN(v, align_width) ((v/align_width)*align_width)
-					imm = _ALIGN_DOWN(imm, 4);
-#undef _ALIGN_DOWN
+					imm &= ~3;
 				}
 			} else {
 				imm += (int32_t)MI->address + 8;


### PR DESCRIPTION
This is for the bug reported in issue #580, see the attachment there for a test case. The problem does occur in the "next" branch.