### PR TITLE
Fix setup.py to use setuptools and put the libcapstone.so in the right place.

### DIFF
--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include src *
+recursive-include capstone *
 recursive-include prebuilt *
 include LICENSE.TXT
 include README


### PR DESCRIPTION
This fixes  #588 and possibly also #583. It seems that more recent setuptools do not like to place files outside the installed package with the data_files directive. So it is better to use the package_data directive to ensure the shared objects end up inside the package. 

This change also allows creating a wheel:
```
$ python setup.py bdist_wheel
....
Copying capstone.egg-info to build/bdist.linux-x86_64/wheel/capstone-3.0.4.data/purelib/capstone-3.0.4-py2.7.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/capstone-3.0.4.dist-info/WHEEL
$ ls dist/
capstone-3.0.4-cp27-none-linux_x86_64.whl  capstone-3.0.4-py2.7.egg  capstone-3.0.4.tar.gz
$ unzip -l dist/capstone-3.0.4-cp27-none-linux_x86_64.whl
Archive:  dist/capstone-3.0.4-cp27-none-linux_x86_64.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
     1036  2014-11-14 16:04   capstone-3.0.4.data/purelib/capstone/systemz.py
...
    22523  2015-10-23 23:04   capstone-3.0.4.data/purelib/capstone/arm64_const.py
  2914397  2016-02-11 17:19   capstone-3.0.4.data/purelib/capstone/libcapstone.so   <---- the so ends up here.
     9552  2015-10-23 23:04   capstone-3.0.4.data/purelib/capstone/sparc_const.py 
...
      416  2016-02-11 23:50   capstone-3.0.4.dist-info/METADATA
     4217  2016-02-11 23:50   capstone-3.0.4.dist-info/RECORD
---------                     -------
  3351047                     41 files
```

As you can see the .so or dll ends up in the binary wheel. You can now easily upload them to pypi:
```
$ pip install twine
$ twine upload dist/capstone-3.0.4-cp27-none-linux_x86_64.whl 
```

PyPi currently does not support linux wheels but windows and OSX wheels can be uploaded. This allows users of those systems to just use the binary dist without needing to build and maybe we dont need the capstone-windows package any more.

