### PR TITLE
Fix setup.py to use setuptools and put the libcapstone.so in the right place.

### DIFF
--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include src *
+recursive-include capstone *
 recursive-include prebuilt *
 include LICENSE.TXT
 include README

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import glob
 import os
-import platform
 import shutil
 import stat
 import sys
@@ -9,8 +8,8 @@ import sys
 from distutils import log
 from distutils import dir_util
 from distutils.command.build_clib import build_clib
-from distutils.command.sdist import sdist
-from distutils.core import setup
+from setuptools.command.sdist import sdist
+from setuptools import setup
 from distutils.sysconfig import get_python_lib
 
 # prebuilt libraries for Windows - for sdist
@@ -35,8 +34,6 @@ if "--user" in sys.argv:
         pass
 
 
-SETUP_DATA_FILES = []
-
 # adapted from commit e504b81 of Nguyen Tan Cong
 # Reference: https://docs.python.org/2/library/platform.html#cross-platform
 is_64bits = sys.maxsize > 2**32
@@ -55,6 +52,8 @@ def copy_sources():
 
     dir_util.copy_tree("../../arch", "src/arch/")
     dir_util.copy_tree("../../include", "src/include/")
+    if SYSTEM == "win32":
+        dir_util.copy_tree("../../msvc/headers", "src/msvc/headers")
 
     src.extend(glob.glob("../../*.[ch]"))
     src.extend(glob.glob("../../*.mk"))
@@ -77,6 +76,14 @@ class custom_sdist(sdist):
     """Reshuffle files for distribution."""
 
     def run(self):
+        for filename in (glob.glob("capstone/*.dll")
+                         + glob.glob("capstone/*.so")
+                         + glob.glob("capstone/*.dylib")):
+            try:
+                os.unlink(filename)
+            except Exception:
+                pass
+
         # if prebuilt libraries are existent, then do not copy source
         if os.path.exists(PATH_LIB64) and os.path.exists(PATH_LIB32):
             return sdist.run(self)
@@ -108,52 +115,51 @@ class custom_build_clib(build_clib):
         if SYSTEM in ("win32", "cygwin"):
             # if Windows prebuilt library is available, then include it
             if is_64bits and os.path.exists(PATH_LIB64):
-                SETUP_DATA_FILES.append(PATH_LIB64)
+                shutil.copy(PATH_LIB64, "capstone")
                 return
             elif os.path.exists(PATH_LIB32):
-                SETUP_DATA_FILES.append(PATH_LIB32)
+                shutil.copy(PATH_LIB32, "capstone")
                 return
 
         # build library from source if src/ is existent
         if not os.path.exists('src'):
             return
 
-        try:
-            for (lib_name, build_info) in libraries:
-                log.info("building '%s' library", lib_name)
+        for (lib_name, build_info) in libraries:
+            log.info("building '%s' library", lib_name)
 
-                os.chdir("src")
+            os.chdir("src")
 
-                # platform description refers at https://docs.python.org/2/library/sys.html#sys.platform
-                if SYSTEM == "win32":
-                    # Windows build: this process requires few things:
-                    #    - CMake + MSVC installed
-                    #    - Run this command in an environment setup for MSVC
-                    os.mkdir("build")
-                    os.chdir("build")
-                    # Do not build tests & static library
-                    os.system('cmake -DCMAKE_BUILD_TYPE=RELEASE -DCAPSTONE_BUILD_TESTS=0 -DCAPSTONE_BUILD_STATIC=0 -G "NMake Makefiles" ..')
-                    os.system("nmake")
-                    os.chdir("..")
-                    SETUP_DATA_FILES.append("src/build/capstone.dll")
-                elif SYSTEM == "cygwin":
-                    os.chmod("make.sh", stat.S_IREAD|stat.S_IEXEC)
-                    if is_64bits:
-                        os.system("CAPSTONE_BUILD_CORE_ONLY=yes ./make.sh cygwin-mingw64")
-                    else:
-                        os.system("CAPSTONE_BUILD_CORE_ONLY=yes ./make.sh cygwin-mingw32")
-                    SETUP_DATA_FILES.append("src/capstone.dll")
-                else:   # Unix
-                    os.chmod("make.sh", stat.S_IREAD|stat.S_IEXEC)
-                    os.system("CAPSTONE_BUILD_CORE_ONLY=yes ./make.sh")
-                    if SYSTEM == "darwin":
-                        SETUP_DATA_FILES.append("src/libcapstone.dylib")
-                    else:   # Non-OSX
-                        SETUP_DATA_FILES.append("src/libcapstone.so")
-
+            # platform description refers at https://docs.python.org/2/library/sys.html#sys.platform
+            if SYSTEM == "win32":
+                # Windows build: this process requires few things:
+                #    - CMake + MSVC installed
+                #    - Run this command in an environment setup for MSVC
+                os.mkdir("build")
+                os.chdir("build")
+                # Do not build tests & static library
+                os.system('cmake -DCMAKE_BUILD_TYPE=RELEASE -DCAPSTONE_BUILD_TESTS=0 -DCAPSTONE_BUILD_STATIC=0 -G "NMake Makefiles" ..')
+                os.system("nmake")
                 os.chdir("..")
-        except:
-            pass
+                so = "src/build/capstone.dll"
+            elif SYSTEM == "cygwin":
+                os.chmod("make.sh", stat.S_IREAD|stat.S_IEXEC)
+                if is_64bits:
+                    os.system("CAPSTONE_BUILD_CORE_ONLY=yes ./make.sh cygwin-mingw64")
+                else:
+                    os.system("CAPSTONE_BUILD_CORE_ONLY=yes ./make.sh cygwin-mingw32")
+
+                so = "src/capstone.dll"
+            else:   # Unix
+                os.chmod("make.sh", stat.S_IREAD|stat.S_IEXEC)
+                os.system("CAPSTONE_BUILD_CORE_ONLY=yes ./make.sh")
+                if SYSTEM == "darwin":
+                    so = "src/libcapstone.dylib"
+                else:   # Non-OSX
+                    so = "src/libcapstone.so"
+
+            os.chdir("..")
+            shutil.copy(so, "capstone")
 
 
 def dummy_src():
@@ -186,6 +192,9 @@ setup(
             sources=dummy_src()
         ),
     )],
-
-    data_files=[(SITE_PACKAGES, SETUP_DATA_FILES)],
+    zip_safe=False,
+    include_package_data=True,
+    package_data={
+        "capstone": ["*.so", "*.dll", "*.dylib"],
+    }
 )


### PR DESCRIPTION
This fixes  #588 and possibly also #583. It seems that more recent setuptools do not like to place files outside the installed package with the data_files directive. So it is better to use the package_data directive to ensure the shared objects end up inside the package. 

This change also allows creating a wheel:
```
$ python setup.py bdist_wheel
....
Copying capstone.egg-info to build/bdist.linux-x86_64/wheel/capstone-3.0.4.data/purelib/capstone-3.0.4-py2.7.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/capstone-3.0.4.dist-info/WHEEL
$ ls dist/
capstone-3.0.4-cp27-none-linux_x86_64.whl  capstone-3.0.4-py2.7.egg  capstone-3.0.4.tar.gz
$ unzip -l dist/capstone-3.0.4-cp27-none-linux_x86_64.whl
Archive:  dist/capstone-3.0.4-cp27-none-linux_x86_64.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
     1036  2014-11-14 16:04   capstone-3.0.4.data/purelib/capstone/systemz.py
...
    22523  2015-10-23 23:04   capstone-3.0.4.data/purelib/capstone/arm64_const.py
  2914397  2016-02-11 17:19   capstone-3.0.4.data/purelib/capstone/libcapstone.so   <---- the so ends up here.
     9552  2015-10-23 23:04   capstone-3.0.4.data/purelib/capstone/sparc_const.py 
...
      416  2016-02-11 23:50   capstone-3.0.4.dist-info/METADATA
     4217  2016-02-11 23:50   capstone-3.0.4.dist-info/RECORD
---------                     -------
  3351047                     41 files
```

As you can see the .so or dll ends up in the binary wheel. You can now easily upload them to pypi:
```
$ pip install twine
$ twine upload dist/capstone-3.0.4-cp27-none-linux_x86_64.whl 
```

PyPi currently does not support linux wheels but windows and OSX wheels can be uploaded. This allows users of those systems to just use the binary dist without needing to build and maybe we dont need the capstone-windows package any more.
