### PR TITLE
bugfix: removed leading ./ from OBJDIR to avoid corrupting setup.py i…

### DIFF
--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -1,5 +1,5 @@
 ifndef BUILDDIR
-OBJDIR = ./build
+OBJDIR = build
 else
 OBJDIR = $(abspath $(BUILDDIR))/obj/bindings/python
 endif


### PR DESCRIPTION
…nstall

Without the patch, installation will cut off the first two characters of the package directories and produce this:
```
ls -l /usr/local/lib/python2.7/dist-packages/capstone-4.0-py2.7.egg/
total 8
drwxr-sr-x 2 root staff 4096 Mar 25 22:23 G-INFO
drwxr-sr-x 2 root staff 4096 Mar 25 22:23 pstone
```