### PR TITLE
Support compile Capstone and run tests for drivers in Visual Studio

### DIFF
--- a/arch/AArch64/AArch64BaseInfo.c
+++ b/arch/AArch64/AArch64BaseInfo.c
@@ -642,7 +642,7 @@ void A64SysRegMapper_toString(A64SysRegMapper *S, uint32_t Bits, bool *Valid, ch
 	Op2S = utostr(Op2, false);
 
 	//printf("Op1S: %s, CRnS: %s, CRmS: %s, Op2S: %s\n", Op1S, CRnS, CRmS, Op2S);
-	dummy = sprintf(result, "s3_%s_c%s_c%s_%s", Op1S, CRnS, CRmS, Op2S);
+	dummy = cs_snprintf(result, 128, "s3_%s_c%s_c%s_%s", Op1S, CRnS, CRmS, Op2S);
 	(void)dummy;
 
 	cs_mem_free(Op1S);

--- a/cs.c
+++ b/cs.c
@@ -110,7 +110,7 @@ cs_vsnprintf_t cs_vsnprintf = NULL;
 #endif
 
 CAPSTONE_EXPORT
-unsigned int cs_version(int *major, int *minor)
+unsigned int CAPSTONE_API cs_version(int *major, int *minor)
 {
 	archs_enable();
 
@@ -123,7 +123,7 @@ unsigned int cs_version(int *major, int *minor)
 }
 
 CAPSTONE_EXPORT
-bool cs_support(int query)
+bool CAPSTONE_API cs_support(int query)
 {
 	archs_enable();
 
@@ -157,7 +157,7 @@ bool cs_support(int query)
 }
 
 CAPSTONE_EXPORT
-cs_err cs_errno(csh handle)
+cs_err CAPSTONE_API cs_errno(csh handle)
 {
 	struct cs_struct *ud;
 	if (!handle)
@@ -169,7 +169,7 @@ cs_err cs_errno(csh handle)
 }
 
 CAPSTONE_EXPORT
-const char *cs_strerror(cs_err code)
+const char * CAPSTONE_API cs_strerror(cs_err code)
 {
 	switch(code) {
 		default:
@@ -202,7 +202,7 @@ const char *cs_strerror(cs_err code)
 }
 
 CAPSTONE_EXPORT
-cs_err cs_open(cs_arch arch, cs_mode mode, csh *handle)
+cs_err CAPSTONE_API cs_open(cs_arch arch, cs_mode mode, csh *handle)
 {
 	cs_err err;
 	struct cs_struct *ud;
@@ -247,7 +247,7 @@ cs_err cs_open(cs_arch arch, cs_mode mode, csh *handle)
 }
 
 CAPSTONE_EXPORT
-cs_err cs_close(csh *handle)
+cs_err CAPSTONE_API cs_close(csh *handle)
 {
 	struct cs_struct *ud;
 
@@ -358,7 +358,7 @@ static uint8_t skipdata_size(cs_struct *handle)
 }
 
 CAPSTONE_EXPORT
-cs_err cs_option(csh ud, cs_opt_type type, size_t value)
+cs_err CAPSTONE_API cs_option(csh ud, cs_opt_type type, size_t value)
 {
 	struct cs_struct *handle;
 	archs_enable();
@@ -411,25 +411,34 @@ static void skipdata_opstr(char *opstr, const uint8_t *buffer, size_t size)
 	char *p = opstr;
 	int len;
 	size_t i;
+	size_t available = sizeof(((cs_insn*)NULL)->op_str);
 
 	if (!size) {
 		opstr[0] = '\0';
 		return;
 	}
 
-	len = sprintf(p, "0x%02x", buffer[0]);
+	len = cs_snprintf(p, available, "0x%02x", buffer[0]);
 	p+= len;
+	available -= len;
 
 	for(i = 1; i < size; i++) {
-		len = sprintf(p, ", 0x%02x", buffer[i]);
+		len = cs_snprintf(p, available, ", 0x%02x", buffer[i]);
+		if (len < 0) {
+			break;
+		}
+		if ((size_t)len > available - 1) {
+			break;
+		}
 		p+= len;
+		available -= len;
 	}
 }
 
 // dynamicly allocate memory to contain disasm insn
 // NOTE: caller must free() the allocated memory itself to avoid memory leaking
 CAPSTONE_EXPORT
-size_t cs_disasm(csh ud, const uint8_t *buffer, size_t size, uint64_t offset, size_t count, cs_insn **insn)
+size_t CAPSTONE_API cs_disasm(csh ud, const uint8_t *buffer, size_t size, uint64_t offset, size_t count, cs_insn **insn)
 {
 	struct cs_struct *handle;
 	MCInst mci;
@@ -627,13 +636,13 @@ size_t cs_disasm(csh ud, const uint8_t *buffer, size_t size, uint64_t offset, si
 
 CAPSTONE_EXPORT
 CAPSTONE_DEPRECATED
-size_t cs_disasm_ex(csh ud, const uint8_t *buffer, size_t size, uint64_t offset, size_t count, cs_insn **insn)
+size_t CAPSTONE_API cs_disasm_ex(csh ud, const uint8_t *buffer, size_t size, uint64_t offset, size_t count, cs_insn **insn)
 {
 	return cs_disasm(ud, buffer, size, offset, count, insn);
 }
 
 CAPSTONE_EXPORT
-void cs_free(cs_insn *insn, size_t count)
+void CAPSTONE_API cs_free(cs_insn *insn, size_t count)
 {
 	size_t i;
 
@@ -646,7 +655,7 @@ void cs_free(cs_insn *insn, size_t count)
 }
 
 CAPSTONE_EXPORT
-cs_insn *cs_malloc(csh ud)
+cs_insn * CAPSTONE_API cs_malloc(csh ud)
 {
 	cs_insn *insn;
 	struct cs_struct *handle = (struct cs_struct *)(uintptr_t)ud;
@@ -674,7 +683,7 @@ cs_insn *cs_malloc(csh ud)
 
 // iterator for instruction "single-stepping"
 CAPSTONE_EXPORT
-bool cs_disasm_iter(csh ud, const uint8_t **code, size_t *size,
+bool CAPSTONE_API cs_disasm_iter(csh ud, const uint8_t **code, size_t *size,
 		uint64_t *address, cs_insn *insn)
 {
 	struct cs_struct *handle;
@@ -761,7 +770,7 @@ bool cs_disasm_iter(csh ud, const uint8_t **code, size_t *size,
 
 // return friendly name of regiser in a string
 CAPSTONE_EXPORT
-const char *cs_reg_name(csh ud, unsigned int reg)
+const char * CAPSTONE_API cs_reg_name(csh ud, unsigned int reg)
 {
 	struct cs_struct *handle = (struct cs_struct *)(uintptr_t)ud;
 
@@ -773,7 +782,7 @@ const char *cs_reg_name(csh ud, unsigned int reg)
 }
 
 CAPSTONE_EXPORT
-const char *cs_insn_name(csh ud, unsigned int insn)
+const char * CAPSTONE_API cs_insn_name(csh ud, unsigned int insn)
 {
 	struct cs_struct *handle = (struct cs_struct *)(uintptr_t)ud;
 
@@ -785,7 +794,7 @@ const char *cs_insn_name(csh ud, unsigned int insn)
 }
 
 CAPSTONE_EXPORT
-const char *cs_group_name(csh ud, unsigned int group)
+const char * CAPSTONE_API cs_group_name(csh ud, unsigned int group)
 {
 	struct cs_struct *handle = (struct cs_struct *)(uintptr_t)ud;
 
@@ -809,7 +818,7 @@ static bool arr_exist(unsigned char *arr, unsigned char max, unsigned int id)
 }
 
 CAPSTONE_EXPORT
-bool cs_insn_group(csh ud, const cs_insn *insn, unsigned int group_id)
+bool CAPSTONE_API cs_insn_group(csh ud, const cs_insn *insn, unsigned int group_id)
 {
 	struct cs_struct *handle;
 	if (!ud)
@@ -836,7 +845,7 @@ bool cs_insn_group(csh ud, const cs_insn *insn, unsigned int group_id)
 }
 
 CAPSTONE_EXPORT
-bool cs_reg_read(csh ud, const cs_insn *insn, unsigned int reg_id)
+bool CAPSTONE_API cs_reg_read(csh ud, const cs_insn *insn, unsigned int reg_id)
 {
 	struct cs_struct *handle;
 	if (!ud)
@@ -863,7 +872,7 @@ bool cs_reg_read(csh ud, const cs_insn *insn, unsigned int reg_id)
 }
 
 CAPSTONE_EXPORT
-bool cs_reg_write(csh ud, const cs_insn *insn, unsigned int reg_id)
+bool CAPSTONE_API cs_reg_write(csh ud, const cs_insn *insn, unsigned int reg_id)
 {
 	struct cs_struct *handle;
 	if (!ud)
@@ -890,7 +899,7 @@ bool cs_reg_write(csh ud, const cs_insn *insn, unsigned int reg_id)
 }
 
 CAPSTONE_EXPORT
-int cs_op_count(csh ud, const cs_insn *insn, unsigned int op_type)
+int CAPSTONE_API cs_op_count(csh ud, const cs_insn *insn, unsigned int op_type)
 {
 	struct cs_struct *handle;
 	unsigned int count = 0, i;
@@ -966,7 +975,7 @@ int cs_op_count(csh ud, const cs_insn *insn, unsigned int op_type)
 }
 
 CAPSTONE_EXPORT
-int cs_op_index(csh ud, const cs_insn *insn, unsigned int op_type,
+int CAPSTONE_API cs_op_index(csh ud, const cs_insn *insn, unsigned int op_type,
 		unsigned int post)
 {
 	struct cs_struct *handle;

--- a/include/arm.h
+++ b/include/arm.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include "../myinttypes.h"
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/arm64.h
+++ b/include/arm64.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include "../myinttypes.h"
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/capstone.h
+++ b/include/capstone.h
@@ -101,11 +101,11 @@ typedef enum cs_mode {
 	CS_MODE_MIPS64 = CS_MODE_64,	// Mips64 ISA (Mips)
 } cs_mode;
 
-typedef void* (CAPSTONE_API*cs_malloc_t)(size_t size);
-typedef void* (CAPSTONE_API*cs_calloc_t)(size_t nmemb, size_t size);
-typedef void* (CAPSTONE_API*cs_realloc_t)(void *ptr, size_t size);
-typedef void (CAPSTONE_API*cs_free_t)(void *ptr);
-typedef int (CAPSTONE_API*cs_vsnprintf_t)(char *str, size_t size, const char *format, va_list ap);
+typedef void* (CAPSTONE_API *cs_malloc_t)(size_t size);
+typedef void* (CAPSTONE_API *cs_calloc_t)(size_t nmemb, size_t size);
+typedef void* (CAPSTONE_API *cs_realloc_t)(void *ptr, size_t size);
+typedef void (CAPSTONE_API *cs_free_t)(void *ptr);
+typedef int (CAPSTONE_API *cs_vsnprintf_t)(char *str, size_t size, const char *format, va_list ap);
 
 
 // User-defined dynamic memory related functions: malloc/calloc/realloc/free/vsnprintf()
@@ -172,7 +172,7 @@ typedef enum cs_group_type {
 
  @return: return number of bytes to skip, or 0 to immediately stop disassembling.
 */
-typedef size_t (CAPSTONE_API*cs_skipdata_cb_t)(const uint8_t *code, size_t code_size, size_t offset, void *user_data);
+typedef size_t (CAPSTONE_API *cs_skipdata_cb_t)(const uint8_t *code, size_t code_size, size_t offset, void *user_data);
 
 // User-customized setup for SKIPDATA option
 typedef struct cs_opt_skipdata {

--- a/include/capstone.h
+++ b/include/capstone.h
@@ -22,8 +22,7 @@ extern "C" {
 #ifdef _MSC_VER
 #pragma warning(disable:4201)
 #pragma warning(disable:4100)
-#define CAPSTONE_API __stdcall
-#define CAPSTONE_CDECL __cdecl
+#define CAPSTONE_API __cdecl
 #ifdef CAPSTONE_SHARED
 #define CAPSTONE_EXPORT __declspec(dllexport)
 #else    // defined(CAPSTONE_STATIC)
@@ -31,7 +30,6 @@ extern "C" {
 #endif
 #else
 #define CAPSTONE_API
-#define CAPSTONE_CDECL
 #ifdef __GNUC__
 #define CAPSTONE_EXPORT __attribute__((visibility("default")))
 #else
@@ -103,11 +101,11 @@ typedef enum cs_mode {
 	CS_MODE_MIPS64 = CS_MODE_64,	// Mips64 ISA (Mips)
 } cs_mode;
 
-typedef void* (CAPSTONE_CDECL*cs_malloc_t)(size_t size);
-typedef void* (CAPSTONE_CDECL*cs_calloc_t)(size_t nmemb, size_t size);
-typedef void* (CAPSTONE_CDECL*cs_realloc_t)(void *ptr, size_t size);
-typedef void (CAPSTONE_CDECL*cs_free_t)(void *ptr);
-typedef int (CAPSTONE_CDECL*cs_vsnprintf_t)(char *str, size_t size, const char *format, va_list ap);
+typedef void* (CAPSTONE_API*cs_malloc_t)(size_t size);
+typedef void* (CAPSTONE_API*cs_calloc_t)(size_t nmemb, size_t size);
+typedef void* (CAPSTONE_API*cs_realloc_t)(void *ptr, size_t size);
+typedef void (CAPSTONE_API*cs_free_t)(void *ptr);
+typedef int (CAPSTONE_API*cs_vsnprintf_t)(char *str, size_t size, const char *format, va_list ap);
 
 
 // User-defined dynamic memory related functions: malloc/calloc/realloc/free/vsnprintf()

--- a/include/capstone.h
+++ b/include/capstone.h
@@ -172,7 +172,7 @@ typedef enum cs_group_type {
 
  @return: return number of bytes to skip, or 0 to immediately stop disassembling.
 */
-typedef size_t (*cs_skipdata_cb_t)(const uint8_t *code, size_t code_size, size_t offset, void *user_data);
+typedef size_t (CAPSTONE_API*cs_skipdata_cb_t)(const uint8_t *code, size_t code_size, size_t offset, void *user_data);
 
 // User-customized setup for SKIPDATA option
 typedef struct cs_opt_skipdata {

--- a/include/capstone.h
+++ b/include/capstone.h
@@ -120,7 +120,7 @@ typedef struct cs_opt_mem {
 
 // Runtime option for the disassembled engine
 typedef enum cs_opt_type {
-	CS_OPT_NONE = 0,	// No opetion specified
+	CS_OPT_INVALID = 0,	// No opetion specified
 	CS_OPT_SYNTAX,	// Assembly output syntax
 	CS_OPT_DETAIL,	// Break down instruction structure into details
 	CS_OPT_MODE,	// Change engine's mode at run-time
@@ -172,7 +172,7 @@ typedef enum cs_group_type {
 
  @return: return number of bytes to skip, or 0 to immediately stop disassembling.
 */
-typedef size_t (CAPSTONE_API*cs_skipdata_cb_t)(const uint8_t *code, size_t code_size, size_t offset, void *user_data);
+typedef size_t (*cs_skipdata_cb_t)(const uint8_t *code, size_t code_size, size_t offset, void *user_data);
 
 // User-customized setup for SKIPDATA option
 typedef struct cs_opt_skipdata {

--- a/include/capstone.h
+++ b/include/capstone.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include "../myinttypes.h"
 #include <stdarg.h>
 #if defined(CAPSTONE_HAS_OSXKERNEL)
 #include <libkern/libkern.h>
@@ -22,12 +22,16 @@ extern "C" {
 #ifdef _MSC_VER
 #pragma warning(disable:4201)
 #pragma warning(disable:4100)
+#define CAPSTONE_API __stdcall
+#define CAPSTONE_CDECL __cdecl
 #ifdef CAPSTONE_SHARED
 #define CAPSTONE_EXPORT __declspec(dllexport)
 #else    // defined(CAPSTONE_STATIC)
 #define CAPSTONE_EXPORT
 #endif
 #else
+#define CAPSTONE_API
+#define CAPSTONE_CDECL
 #ifdef __GNUC__
 #define CAPSTONE_EXPORT __attribute__((visibility("default")))
 #else
@@ -99,11 +103,11 @@ typedef enum cs_mode {
 	CS_MODE_MIPS64 = CS_MODE_64,	// Mips64 ISA (Mips)
 } cs_mode;
 
-typedef void* (*cs_malloc_t)(size_t size);
-typedef void* (*cs_calloc_t)(size_t nmemb, size_t size);
-typedef void* (*cs_realloc_t)(void *ptr, size_t size);
-typedef void (*cs_free_t)(void *ptr);
-typedef int (*cs_vsnprintf_t)(char *str, size_t size, const char *format, va_list ap);
+typedef void* (CAPSTONE_CDECL*cs_malloc_t)(size_t size);
+typedef void* (CAPSTONE_CDECL*cs_calloc_t)(size_t nmemb, size_t size);
+typedef void* (CAPSTONE_CDECL*cs_realloc_t)(void *ptr, size_t size);
+typedef void (CAPSTONE_CDECL*cs_free_t)(void *ptr);
+typedef int (CAPSTONE_CDECL*cs_vsnprintf_t)(char *str, size_t size, const char *format, va_list ap);
 
 
 // User-defined dynamic memory related functions: malloc/calloc/realloc/free/vsnprintf()
@@ -118,7 +122,8 @@ typedef struct cs_opt_mem {
 
 // Runtime option for the disassembled engine
 typedef enum cs_opt_type {
-	CS_OPT_SYNTAX = 1,	// Assembly output syntax
+	CS_OPT_NONE = 0,	// No opetion specified
+	CS_OPT_SYNTAX,	// Assembly output syntax
 	CS_OPT_DETAIL,	// Break down instruction structure into details
 	CS_OPT_MODE,	// Change engine's mode at run-time
 	CS_OPT_MEM,	// User-defined dynamic memory related functions
@@ -316,7 +321,7 @@ typedef enum cs_err {
  set both @major & @minor arguments to NULL.
 */
 CAPSTONE_EXPORT
-unsigned int cs_version(int *major, int *minor);
+unsigned int CAPSTONE_API cs_version(int *major, int *minor);
 
 
 /*
@@ -333,7 +338,7 @@ unsigned int cs_version(int *major, int *minor);
  @return True if this library supports the given arch, or in 'diet' mode.
 */
 CAPSTONE_EXPORT
-bool cs_support(int query);
+bool CAPSTONE_API cs_support(int query);
 
 /*
  Initialize CS handle: this must be done before any usage of CS.
@@ -346,7 +351,7 @@ bool cs_support(int query);
  for detailed error).
 */
 CAPSTONE_EXPORT
-cs_err cs_open(cs_arch arch, cs_mode mode, csh *handle);
+cs_err CAPSTONE_API cs_open(cs_arch arch, cs_mode mode, csh *handle);
 
 /*
  Close CS handle: MUST do to release the handle when it is not used anymore.
@@ -363,7 +368,7 @@ cs_err cs_open(cs_arch arch, cs_mode mode, csh *handle);
  for detailed error).
 */
 CAPSTONE_EXPORT
-cs_err cs_close(csh *handle);
+cs_err CAPSTONE_API cs_close(csh *handle);
 
 /*
  Set option for disassembling engine at runtime
@@ -380,7 +385,7 @@ cs_err cs_close(csh *handle);
  even before cs_open()
 */
 CAPSTONE_EXPORT
-cs_err cs_option(csh handle, cs_opt_type type, size_t value);
+cs_err CAPSTONE_API cs_option(csh handle, cs_opt_type type, size_t value);
 
 /*
  Report the last error number when some API function fail.
@@ -391,7 +396,7 @@ cs_err cs_option(csh handle, cs_opt_type type, size_t value);
  @return: error code of cs_err enum type (CS_ERR_*, see above)
 */
 CAPSTONE_EXPORT
-cs_err cs_errno(csh handle);
+cs_err CAPSTONE_API cs_errno(csh handle);
 
 
 /*
@@ -403,7 +408,7 @@ cs_err cs_errno(csh handle);
 	passed in the argument @code
 */
 CAPSTONE_EXPORT
-const char *cs_strerror(cs_err code);
+const char * CAPSTONE_API cs_strerror(cs_err code);
 
 /*
  Disassemble binary code, given the code buffer, size, address and number
@@ -439,7 +444,7 @@ const char *cs_strerror(cs_err code);
  On failure, call cs_errno() for error code.
 */
 CAPSTONE_EXPORT
-size_t cs_disasm(csh handle,
+size_t CAPSTONE_API cs_disasm(csh handle,
 		const uint8_t *code, size_t code_size,
 		uint64_t address,
 		size_t count,
@@ -451,7 +456,7 @@ size_t cs_disasm(csh handle,
 */
 CAPSTONE_EXPORT
 CAPSTONE_DEPRECATED
-size_t cs_disasm_ex(csh handle,
+size_t CAPSTONE_API cs_disasm_ex(csh handle,
 		const uint8_t *code, size_t code_size,
 		uint64_t address,
 		size_t count,
@@ -465,7 +470,7 @@ size_t cs_disasm_ex(csh handle,
      to free memory allocated by cs_malloc().
 */
 CAPSTONE_EXPORT
-void cs_free(cs_insn *insn, size_t count);
+void CAPSTONE_API cs_free(cs_insn *insn, size_t count);
 
 
 /*
@@ -477,7 +482,7 @@ void cs_free(cs_insn *insn, size_t count);
  this instruction with cs_free(insn, 1)
 */
 CAPSTONE_EXPORT
-cs_insn *cs_malloc(csh handle);
+cs_insn * CAPSTONE_API cs_malloc(csh handle);
 
 /*
  Fast API to disassemble binary code, given the code buffer, size, address
@@ -515,7 +520,7 @@ cs_insn *cs_malloc(csh handle);
  On failure, call cs_errno() for error code.
 */
 CAPSTONE_EXPORT
-bool cs_disasm_iter(csh handle,
+bool CAPSTONE_API cs_disasm_iter(csh handle,
 	const uint8_t **code, size_t *size,
 	uint64_t *address, cs_insn *insn);
 
@@ -533,7 +538,7 @@ bool cs_disasm_iter(csh handle,
  @return: string name of the register, or NULL if @reg_id is invalid.
 */
 CAPSTONE_EXPORT
-const char *cs_reg_name(csh handle, unsigned int reg_id);
+const char * CAPSTONE_API cs_reg_name(csh handle, unsigned int reg_id);
 
 /*
  Return friendly name of an instruction in a string.
@@ -548,7 +553,7 @@ const char *cs_reg_name(csh handle, unsigned int reg_id);
  @return: string name of the instruction, or NULL if @insn_id is invalid.
 */
 CAPSTONE_EXPORT
-const char *cs_insn_name(csh handle, unsigned int insn_id);
+const char * CAPSTONE_API cs_insn_name(csh handle, unsigned int insn_id);
 
 /*
  Return friendly name of a group id (that an instruction can belong to)
@@ -563,7 +568,7 @@ const char *cs_insn_name(csh handle, unsigned int insn_id);
  @return: string name of the group, or NULL if @group_id is invalid.
 */
 CAPSTONE_EXPORT
-const char *cs_group_name(csh handle, unsigned int group_id);
+const char * CAPSTONE_API cs_group_name(csh handle, unsigned int group_id);
 
 /*
  Check if a disassembled instruction belong to a particular group.
@@ -582,7 +587,7 @@ const char *cs_group_name(csh handle, unsigned int group_id);
  @return: true if this instruction indeed belongs to aboved group, or false otherwise.
 */
 CAPSTONE_EXPORT
-bool cs_insn_group(csh handle, const cs_insn *insn, unsigned int group_id);
+bool CAPSTONE_API cs_insn_group(csh handle, const cs_insn *insn, unsigned int group_id);
 
 /*
  Check if a disassembled instruction IMPLICITLY used a particular register.
@@ -600,7 +605,7 @@ bool cs_insn_group(csh handle, const cs_insn *insn, unsigned int group_id);
  @return: true if this instruction indeed implicitly used aboved register, or false otherwise.
 */
 CAPSTONE_EXPORT
-bool cs_reg_read(csh handle, const cs_insn *insn, unsigned int reg_id);
+bool CAPSTONE_API cs_reg_read(csh handle, const cs_insn *insn, unsigned int reg_id);
 
 /*
  Check if a disassembled instruction IMPLICITLY modified a particular register.
@@ -618,7 +623,7 @@ bool cs_reg_read(csh handle, const cs_insn *insn, unsigned int reg_id);
  @return: true if this instruction indeed implicitly modified aboved register, or false otherwise.
 */
 CAPSTONE_EXPORT
-bool cs_reg_write(csh handle, const cs_insn *insn, unsigned int reg_id);
+bool CAPSTONE_API cs_reg_write(csh handle, const cs_insn *insn, unsigned int reg_id);
 
 /*
  Count the number of operands of a given type.
@@ -634,7 +639,7 @@ bool cs_reg_write(csh handle, const cs_insn *insn, unsigned int reg_id);
  or -1 on failure.
 */
 CAPSTONE_EXPORT
-int cs_op_count(csh handle, const cs_insn *insn, unsigned int op_type);
+int CAPSTONE_API cs_op_count(csh handle, const cs_insn *insn, unsigned int op_type);
 
 /*
  Retrieve the position of operand of given type in <arch>.operands[] array.
@@ -653,7 +658,7 @@ int cs_op_count(csh handle, const cs_insn *insn, unsigned int op_type);
  in instruction @insn, or -1 on failure.
 */
 CAPSTONE_EXPORT
-int cs_op_index(csh handle, const cs_insn *insn, unsigned int op_type,
+int CAPSTONE_API cs_op_index(csh handle, const cs_insn *insn, unsigned int op_type,
 		unsigned int position);
 
 #ifdef __cplusplus

--- a/include/mips.h
+++ b/include/mips.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include "../myinttypes.h"
 #include "platform.h"
 
 // GCC MIPS toolchain has a default macro called "mips" which breaks

--- a/include/platform.h
+++ b/include/platform.h
@@ -9,7 +9,7 @@
 // MSVC
 
 // stdbool.h
-#if (_MSC_VER < 1800)
+#if (_MSC_VER < 1800) || defined(_KERNEL_MODE)
 #ifndef __cplusplus
 typedef unsigned char bool;
 #define false 0

--- a/include/ppc.h
+++ b/include/ppc.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include "../myinttypes.h"
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/sparc.h
+++ b/include/sparc.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include "../myinttypes.h"
 #include "platform.h"
 
 // GCC SPARC toolchain has a default macro called "sparc" which breaks

--- a/include/systemz.h
+++ b/include/systemz.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include "../myinttypes.h"
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/x86.h
+++ b/include/x86.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include "../myinttypes.h"
 
 // Calculate relative address for X86-64, given cs_insn structure
 #define X86_REL_ADDR(insn) (insn.address + insn.size + insn.detail->x86.disp)

--- a/include/xcore.h
+++ b/include/xcore.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include "../myinttypes.h"
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/msvc/capstone_static/capstone_static.vcxproj
+++ b/msvc/capstone_static/capstone_static.vcxproj
@@ -1,12 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug_WDK|Win32">
+      <Configuration>Debug_WDK</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug_WDK|x64">
+      <Configuration>Debug_WDK</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release_WDK|Win32">
+      <Configuration>Release_WDK</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release_WDK|x64">
+      <Configuration>Release_WDK</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
@@ -67,29 +83,58 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>capstonewin32</RootNamespace>
     <ProjectName>capstone_static</ProjectName>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_WDK|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_WDK|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_WDK|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_WDK|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -97,26 +142,50 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_WDK|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_WDK|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_WDK|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_WDK|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>capstone</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_WDK|Win32'">
+    <TargetName>capstone</TargetName>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>capstone</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_WDK|Win32'">
     <TargetName>capstone</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>capstone</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_WDK|x64'">
+    <TargetName>capstone</TargetName>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>capstone</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_WDK|x64'">
     <TargetName>capstone</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -135,6 +204,25 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_WDK|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary />
+      <AdditionalOptions>/kernel</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>
@@ -145,6 +233,25 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_WDK|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary />
+      <AdditionalOptions>/kernel</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -171,6 +278,28 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_WDK|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>
+      </RuntimeLibrary>
+      <AdditionalOptions>/kernel</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -183,6 +312,28 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_WDK|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>
+      </RuntimeLibrary>
+      <AdditionalOptions>/kernel</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/myinttypes.h
+++ b/myinttypes.h
@@ -4,10 +4,10 @@
 #ifndef CS_MYINTTYPES_H
 #define CS_MYINTTYPES_H
 
-#if defined(CAPSTONE_HAS_OSXKERNEL) || (defined(_MSC_VER) && _MSC_VER <= 1700)
+#if defined(CAPSTONE_HAS_OSXKERNEL) || (defined(_MSC_VER) && (_MSC_VER <= 1700 || defined(_KERNEL_MODE)))
 // this system does not have inttypes.h
 
-#if defined(_MSC_VER) && _MSC_VER <= 1700
+#if defined(_MSC_VER) && (_MSC_VER <= 1700 || defined(_KERNEL_MODE))
 typedef signed char  int8_t;
 typedef signed short int16_t;
 typedef signed int   int32_t;

--- a/tests/test.c
+++ b/tests/test.c
@@ -245,12 +245,12 @@ static void test()
 			printf("Disasm:\n");
 
 			for (j = 0; j < count; j++) {
-				printf("0x%"PRIx64":\t%s\t\t%s\n",
+				printf("0x%" PRIx64 ":\t%s\t\t%s\n",
 						insn[j].address, insn[j].mnemonic, insn[j].op_str);
 			}
 
 			// print out the next offset, after the last insn
-			printf("0x%"PRIx64":\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm()
 			cs_free(insn, count);

--- a/tests/test_arm.c
+++ b/tests/test_arm.c
@@ -269,10 +269,10 @@ static void test()
 			printf("Disasm:\n");
 
 			for (j = 0; j < count; j++) {
-				printf("0x%"PRIx64":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIx64 ":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(&insn[j]);
 			}
-			printf("0x%"PRIx64":\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm()
 			cs_free(insn, count);

--- a/tests/test_arm64.c
+++ b/tests/test_arm64.c
@@ -51,7 +51,7 @@ static void print_insn_detail(cs_insn *ins)
 				printf("\t\toperands[%u].type: REG = %s\n", i, cs_reg_name(handle, op->reg));
 				break;
 			case ARM64_OP_IMM:
-				printf("\t\toperands[%u].type: IMM = 0x%"PRIx64 "\n", i, op->imm);
+				printf("\t\toperands[%u].type: IMM = 0x%" PRIx64 "\n", i, op->imm);
 				break;
 			case ARM64_OP_FP:
 				printf("\t\toperands[%u].type: FP = %f\n", i, op->fp);
@@ -211,10 +211,10 @@ static void test()
 			printf("Disasm:\n");
 
 			for (j = 0; j < count; j++) {
-				printf("0x%"PRIx64":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIx64 ":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(&insn[j]);
 			}
-			printf("0x%"PRIx64":\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm()
 			cs_free(insn, count);

--- a/tests/test_detail.c
+++ b/tests/test_detail.c
@@ -240,13 +240,13 @@ static void test()
 			printf("Disasm:\n");
 
 			for (j = 0; j < count; j++) {
-				cs_insn *i = &(all_insn[j]);
-				printf("0x%"PRIx64":\t%s\t\t%s // insn-ID: %u, insn-mnem: %s\n",
-						i->address, i->mnemonic, i->op_str,
-						i->id, cs_insn_name(handle, i->id));
+				cs_insn *ins = &(all_insn[j]);
+				printf("0x%" PRIx64 ":\t%s\t\t%s // insn-ID: %u, insn-mnem: %s\n",
+						ins->address, ins->mnemonic, ins->op_str,
+						ins->id, cs_insn_name(handle, ins->id));
 
 				// print implicit registers used by this instruction
-				detail = i->detail;
+				detail = ins->detail;
 
 				if (detail->regs_read_count > 0) {
 					printf("\tImplicit registers read: ");
@@ -276,7 +276,7 @@ static void test()
 			}
 
 			// print out the next offset, after the last insn
-			printf("0x%"PRIx64":\n", all_insn[j-1].address + all_insn[j-1].size);
+			printf("0x%" PRIx64 ":\n", all_insn[j-1].address + all_insn[j-1].size);
 
 			// free memory allocated by cs_disasm()
 			cs_free(all_insn, count);

--- a/tests/test_iter.c
+++ b/tests/test_iter.c
@@ -213,7 +213,7 @@ static void test()
 		while(cs_disasm_iter(handle, &code, &size, &address, insn)) {
 			int n;
 
-			printf("0x%"PRIx64":\t%s\t\t%s // insn-ID: %u, insn-mnem: %s\n",
+			printf("0x%" PRIx64 ":\t%s\t\t%s // insn-ID: %u, insn-mnem: %s\n",
 					insn->address, insn->mnemonic, insn->op_str,
 					insn->id, cs_insn_name(handle, insn->id));
 

--- a/tests/test_mips.c
+++ b/tests/test_mips.c
@@ -51,7 +51,7 @@ static void print_insn_detail(cs_insn *ins)
 				printf("\t\toperands[%u].type: REG = %s\n", i, cs_reg_name(handle, op->reg));
 				break;
 			case MIPS_OP_IMM:
-				printf("\t\toperands[%u].type: IMM = 0x%"PRIx64 "\n", i, op->imm);
+				printf("\t\toperands[%u].type: IMM = 0x%" PRIx64 "\n", i, op->imm);
 				break;
 			case MIPS_OP_MEM:
 				printf("\t\toperands[%u].type: MEM\n", i);
@@ -138,10 +138,10 @@ static void test()
 			printf("Disasm:\n");
 
 			for (j = 0; j < count; j++) {
-				printf("0x%"PRIx64":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIx64 ":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(&insn[j]);
 			}
-			printf("0x%"PRIx64":\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm()
 			cs_free(insn, count);

--- a/tests/test_ppc.c
+++ b/tests/test_ppc.c
@@ -149,10 +149,10 @@ static void test()
 			printf("Disasm:\n");
 
 			for (j = 0; j < count; j++) {
-				printf("0x%"PRIx64":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIx64 ":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(&insn[j]);
 			}
-			printf("0x%"PRIx64":\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm()
 			cs_free(insn, count);

--- a/tests/test_skipdata.c
+++ b/tests/test_skipdata.c
@@ -30,7 +30,7 @@ static void print_string_hex(unsigned char *str, size_t len)
 	printf("\n");
 }
 
-static size_t CAPSTONE_API mycallback(const uint8_t *buffer, size_t buffer_size, size_t offset, void *p)
+static size_t mycallback(const uint8_t *buffer, size_t buffer_size, size_t offset, void *p)
 {
 	// always skip 2 bytes when encountering data
 	return 2;
@@ -72,7 +72,7 @@ static void test()
 			(unsigned char*)X86_CODE32,
 			sizeof(X86_CODE32) - 1,
 			"X86 32 (Intel syntax) - Skip data with custom mnemonic",
-			CS_OPT_NONE,
+			CS_OPT_INVALID,
 			CS_OPT_OFF,
 			CS_OPT_SKIPDATA_SETUP,
 			(size_t) &skipdata,
@@ -83,7 +83,7 @@ static void test()
 			(unsigned char*)RANDOM_CODE,
 			sizeof(RANDOM_CODE) - 1,
 			"Arm - Skip data with callback",
-			CS_OPT_NONE,
+			CS_OPT_INVALID,
 			CS_OPT_OFF,
 			CS_OPT_SKIPDATA_SETUP,
 			(size_t) &skipdata_callback,

--- a/tests/test_skipdata.c
+++ b/tests/test_skipdata.c
@@ -30,7 +30,7 @@ static void print_string_hex(unsigned char *str, size_t len)
 	printf("\n");
 }
 
-static size_t mycallback(const uint8_t *buffer, size_t buffer_size, size_t offset, void *p)
+static size_t CAPSTONE_API mycallback(const uint8_t *buffer, size_t buffer_size, size_t offset, void *p)
 {
 	// always skip 2 bytes when encountering data
 	return 2;

--- a/tests/test_skipdata.c
+++ b/tests/test_skipdata.c
@@ -72,7 +72,8 @@ static void test()
 			(unsigned char*)X86_CODE32,
 			sizeof(X86_CODE32) - 1,
 			"X86 32 (Intel syntax) - Skip data with custom mnemonic",
-			0, 0,
+			CS_OPT_NONE,
+			CS_OPT_OFF,
 			CS_OPT_SKIPDATA_SETUP,
 			(size_t) &skipdata,
 		},
@@ -82,7 +83,8 @@ static void test()
 			(unsigned char*)RANDOM_CODE,
 			sizeof(RANDOM_CODE) - 1,
 			"Arm - Skip data with callback",
-			0, 0,
+			CS_OPT_NONE,
+			CS_OPT_OFF,
 			CS_OPT_SKIPDATA_SETUP,
 			(size_t) &skipdata_callback,
 		},
@@ -119,12 +121,12 @@ static void test()
 			printf("Disasm:\n");
 
 			for (j = 0; j < count; j++) {
-				printf("0x%"PRIx64":\t%s\t\t%s\n",
+				printf("0x%" PRIx64 ":\t%s\t\t%s\n",
 						insn[j].address, insn[j].mnemonic, insn[j].op_str);
 			}
 
 			// print out the next offset, after the last insn
-			printf("0x%"PRIx64":\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm()
 			cs_free(insn, count);

--- a/tests/test_sparc.c
+++ b/tests/test_sparc.c
@@ -123,10 +123,10 @@ static void test()
 			printf("Disasm:\n");
 
 			for (j = 0; j < count; j++) {
-				printf("0x%"PRIx64":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIx64 ":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(&insn[j]);
 			}
-			printf("0x%"PRIx64":\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm()
 			cs_free(insn, count);

--- a/tests/test_systemz.c
+++ b/tests/test_systemz.c
@@ -53,7 +53,7 @@ static void print_insn_detail(cs_insn *ins)
 				printf("\t\toperands[%u].type: ACREG = %u\n", i, op->reg);
 				break;
 			case SYSZ_OP_IMM:
-				printf("\t\toperands[%u].type: IMM = 0x%"PRIx64"\n", i, op->imm);
+				printf("\t\toperands[%u].type: IMM = 0x%" PRIx64 "\n", i, op->imm);
 				break;
 			case SYSZ_OP_MEM:
 				printf("\t\toperands[%u].type: MEM\n", i);
@@ -64,9 +64,9 @@ static void print_insn_detail(cs_insn *ins)
 					printf("\t\t\toperands[%u].mem.index: REG = %s\n",
 							i, cs_reg_name(handle, op->mem.index));
 				if (op->mem.length != 0)
-					printf("\t\t\toperands[%u].mem.length: 0x%"PRIx64"\n", i, op->mem.length);
+					printf("\t\t\toperands[%u].mem.length: 0x%" PRIx64 "\n", i, op->mem.length);
 				if (op->mem.disp != 0)
-					printf("\t\t\toperands[%u].mem.disp: 0x%"PRIx64"\n", i, op->mem.disp);
+					printf("\t\t\toperands[%u].mem.disp: 0x%" PRIx64 "\n", i, op->mem.disp);
 
 				break;
 		}
@@ -116,10 +116,10 @@ static void test()
 			printf("Disasm:\n");
 
 			for (j = 0; j < count; j++) {
-				printf("0x%"PRIx64":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIx64 ":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(&insn[j]);
 			}
-			printf("0x%"PRIx64":\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm()
 			cs_free(insn, count);

--- a/tests/test_x86.c
+++ b/tests/test_x86.c
@@ -88,7 +88,7 @@ static void print_insn_detail(csh ud, cs_mode mode, cs_insn *ins)
 		printf("\timm_count: %u\n", count);
 		for (i = 1; i < count + 1; i++) {
 			int index = cs_op_index(ud, ins, X86_OP_IMM, i);
-			printf("\t\timms[%u]: 0x%"PRIx64 "\n", i, x86->operands[index].imm);
+			printf("\t\timms[%u]: 0x%" PRIx64 "\n", i, x86->operands[index].imm);
 		}
 	}
 
@@ -102,7 +102,7 @@ static void print_insn_detail(csh ud, cs_mode mode, cs_insn *ins)
 				printf("\t\toperands[%u].type: REG = %s\n", i, cs_reg_name(handle, op->reg));
 				break;
 			case X86_OP_IMM:
-				printf("\t\toperands[%u].type: IMM = 0x%"PRIx64 "\n", i, op->imm);
+				printf("\t\toperands[%u].type: IMM = 0x%" PRIx64 "\n", i, op->imm);
 				break;
 			case X86_OP_FP:
 				printf("\t\toperands[%u].type: FP = %f\n", i, op->fp);
@@ -226,10 +226,10 @@ static void test()
 			printf("Disasm:\n");
 
 			for (j = 0; j < count; j++) {
-				printf("0x%"PRIx64":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIx64 ":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(handle, platforms[i].mode, &insn[j]);
 			}
-			printf("0x%"PRIx64":\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm()
 			cs_free(insn, count);

--- a/tests/test_xcore.c
+++ b/tests/test_xcore.c
@@ -111,10 +111,10 @@ static void test()
 			printf("Disasm:\n");
 
 			for (j = 0; j < count; j++) {
-				printf("0x%"PRIx64":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
+				printf("0x%" PRIx64 ":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(&insn[j]);
 			}
-			printf("0x%"PRIx64":\n", insn[j-1].address + insn[j-1].size);
+			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
 
 			// free memory allocated by cs_disasm()
 			cs_free(insn, count);


### PR DESCRIPTION
Those changes are to compile Capstone and run existing all regression tests for Windows drivers in Visual Studio 2015. Details of changes are explained in this page.
https://github.com/tandasat/cs_driver

Note that changes in capstone_static.vcxproj will be a breaking change since it was converted into a new version of a project file.
 
It is my first time to create a pull request, so let me know anything I can do for smooth code merge 