### PR TITLE
Fixed register types

### DIFF
--- a/include/capstone/arm.h
+++ b/include/capstone/arm.h
@@ -249,67 +249,6 @@ typedef enum arm_vectordata_type {
 	ARM_VECTORDATA_F64U32,	// f64.u32
 } arm_vectordata_type;
 
-// Instruction's operand referring to memory
-// This is associated with ARM_OP_MEM operand type above
-typedef struct arm_op_mem {
-	unsigned int base;	// base register
-	unsigned int index;	// index register
-	int scale;	// scale for index register (can be 1, or -1)
-	int disp;	// displacement/offset value
-	int lshift;	// left-shift on index register, or 0 if irrelevant.
-} arm_op_mem;
-
-// Instruction operand
-typedef struct cs_arm_op {
-	int vector_index;	// Vector Index for some vector operands (or -1 if irrelevant)
-
-	struct {
-		arm_shifter type;
-		unsigned int value;
-	} shift;
-
-	arm_op_type type;	// operand type
-
-	union {
-		unsigned int reg;	// register value for REG/SYSREG operand
-		int32_t imm;			// immediate value for C-IMM, P-IMM or IMM operand
-		double fp;			// floating point value for FP operand
-		arm_op_mem mem;		// base/index/scale/disp value for MEM operand
-		arm_setend_type setend; // SETEND instruction's operand type
-	};
-
-	// in some instructions, an operand can be subtracted or added to
-	// the base register,
-	bool subtracted; // if TRUE, this operand is subtracted. otherwise, it is added.
-
-	// How is this operand accessed? (READ, WRITE or READ|WRITE)
-	// This field is combined of cs_ac_type.
-	// NOTE: this field is irrelevant if engine is compiled in DIET mode.
-	uint8_t access;
-
-	// Neon lane index for NEON instructions (or -1 if irrelevant)
-	int8_t neon_lane;
-} cs_arm_op;
-
-// Instruction structure
-typedef struct cs_arm {
-	bool usermode;	// User-mode registers to be loaded (for LDM/STM instructions)
-	int vector_size; 	// Scalar size for vector instructions
-	arm_vectordata_type vector_data; // Data type for elements of vector instructions
-	arm_cpsmode_type cps_mode;	// CPS mode for CPS instruction
-	arm_cpsflag_type cps_flag;	// CPS mode for CPS instruction
-	arm_cc cc;			// conditional code for this insn
-	bool update_flags;	// does this insn update flags?
-	bool writeback;		// does this insn write-back?
-	arm_mem_barrier mem_barrier;	// Option for some memory barrier instructions
-
-	// Number of operands of this instruction, 
-	// or 0 when instruction has no operand.
-	uint8_t op_count;
-
-	cs_arm_op operands[36];	// operands for this instruction.
-} cs_arm;
-
 //> ARM registers
 typedef enum arm_reg {
 	ARM_REG_INVALID = 0,
@@ -436,6 +375,67 @@ typedef enum arm_reg {
 	ARM_REG_FP = ARM_REG_R11,
 	ARM_REG_IP = ARM_REG_R12,
 } arm_reg;
+
+// Instruction's operand referring to memory
+// This is associated with ARM_OP_MEM operand type above
+typedef struct arm_op_mem {
+	arm_reg base;	// base register
+	arm_reg index;	// index register
+	int scale;	// scale for index register (can be 1, or -1)
+	int disp;	// displacement/offset value
+	int lshift;	// left-shift on index register, or 0 if irrelevant.
+} arm_op_mem;
+
+// Instruction operand
+typedef struct cs_arm_op {
+	int vector_index;	// Vector Index for some vector operands (or -1 if irrelevant)
+
+	struct {
+		arm_shifter type;
+		unsigned int value;
+	} shift;
+
+	arm_op_type type;	// operand type
+
+	union {
+		arm_reg reg;	// register value for REG/SYSREG operand
+		int32_t imm;			// immediate value for C-IMM, P-IMM or IMM operand
+		double fp;			// floating point value for FP operand
+		arm_op_mem mem;		// base/index/scale/disp value for MEM operand
+		arm_setend_type setend; // SETEND instruction's operand type
+	};
+
+	// in some instructions, an operand can be subtracted or added to
+	// the base register,
+	bool subtracted; // if TRUE, this operand is subtracted. otherwise, it is added.
+
+	// How is this operand accessed? (READ, WRITE or READ|WRITE)
+	// This field is combined of cs_ac_type.
+	// NOTE: this field is irrelevant if engine is compiled in DIET mode.
+	uint8_t access;
+
+	// Neon lane index for NEON instructions (or -1 if irrelevant)
+	int8_t neon_lane;
+} cs_arm_op;
+
+// Instruction structure
+typedef struct cs_arm {
+	bool usermode;	// User-mode registers to be loaded (for LDM/STM instructions)
+	int vector_size; 	// Scalar size for vector instructions
+	arm_vectordata_type vector_data; // Data type for elements of vector instructions
+	arm_cpsmode_type cps_mode;	// CPS mode for CPS instruction
+	arm_cpsflag_type cps_flag;	// CPS mode for CPS instruction
+	arm_cc cc;			// conditional code for this insn
+	bool update_flags;	// does this insn update flags?
+	bool writeback;		// does this insn write-back?
+	arm_mem_barrier mem_barrier;	// Option for some memory barrier instructions
+
+	// Number of operands of this instruction, 
+	// or 0 when instruction has no operand.
+	uint8_t op_count;
+
+	cs_arm_op operands[36];	// operands for this instruction.
+} cs_arm;
 
 //> ARM instruction
 typedef enum arm_insn {

--- a/include/capstone/arm64.h
+++ b/include/capstone/arm64.h
@@ -343,54 +343,6 @@ typedef enum arm64_prefetch_op {
 	ARM64_PRFM_PSTL3STRM = 0x15 + 1,
 } arm64_prefetch_op;
 
-// Instruction's operand referring to memory
-// This is associated with ARM64_OP_MEM operand type above
-typedef struct arm64_op_mem {
-	unsigned int base;	// base register
-	unsigned int index;	// index register
-	int32_t disp;	// displacement/offset value
-} arm64_op_mem;
-
-// Instruction operand
-typedef struct cs_arm64_op {
-	int vector_index;	// Vector Index for some vector operands (or -1 if irrelevant)
-	arm64_vas vas;		// Vector Arrangement Specifier
-	arm64_vess vess;	// Vector Element Size Specifier
-	struct {
-		arm64_shifter type;	// shifter type of this operand
-		unsigned int value;	// shifter value of this operand
-	} shift;
-	arm64_extender ext;		// extender type of this operand
-	arm64_op_type type;	// operand type
-	union {
-		unsigned int reg;	// register value for REG operand
-		int64_t imm;		// immediate value, or index for C-IMM or IMM operand
-		double fp;			// floating point value for FP operand
-		arm64_op_mem mem;		// base/index/scale/disp value for MEM operand
-		arm64_pstate pstate;		// PState field of MSR instruction.
-		unsigned int sys;  // IC/DC/AT/TLBI operation (see arm64_ic_op, arm64_dc_op, arm64_at_op, arm64_tlbi_op)
-		arm64_prefetch_op prefetch;  // PRFM operation.
-		arm64_barrier_op barrier;  // Memory barrier operation (ISB/DMB/DSB instructions).
-	};
-
-	// How is this operand accessed? (READ, WRITE or READ|WRITE)
-	// This field is combined of cs_ac_type.
-	// NOTE: this field is irrelevant if engine is compiled in DIET mode.
-	cs_ac_type access;
-} cs_arm64_op;
-
-// Instruction structure
-typedef struct cs_arm64 {
-	arm64_cc cc;	// conditional code for this insn
-	bool update_flags;	// does this insn update flags?
-	bool writeback;	// does this insn request writeback? 'True' means 'yes'
-
-	// Number of operands of this instruction,
-	// or 0 when instruction has no operand.
-	uint8_t op_count;
-
-	cs_arm64_op operands[8]; // operands for this instruction.
-} cs_arm64;
 
 //> ARM64 registers
 typedef enum arm64_reg {
@@ -666,6 +618,55 @@ typedef enum arm64_reg {
 	ARM64_REG_FP = ARM64_REG_X29,
 	ARM64_REG_LR = ARM64_REG_X30,
 } arm64_reg;
+
+// Instruction's operand referring to memory
+// This is associated with ARM64_OP_MEM operand type above
+typedef struct arm64_op_mem {
+	arm64_reg base;	// base register
+	arm64_reg index;	// index register
+	int32_t disp;	// displacement/offset value
+} arm64_op_mem;
+
+// Instruction operand
+typedef struct cs_arm64_op {
+	int vector_index;	// Vector Index for some vector operands (or -1 if irrelevant)
+	arm64_vas vas;		// Vector Arrangement Specifier
+	arm64_vess vess;	// Vector Element Size Specifier
+	struct {
+		arm64_shifter type;	// shifter type of this operand
+		unsigned int value;	// shifter value of this operand
+	} shift;
+	arm64_extender ext;		// extender type of this operand
+	arm64_op_type type;	// operand type
+	union {
+		arm64_reg reg;	// register value for REG operand
+		int64_t imm;		// immediate value, or index for C-IMM or IMM operand
+		double fp;			// floating point value for FP operand
+		arm64_op_mem mem;		// base/index/scale/disp value for MEM operand
+		arm64_pstate pstate;		// PState field of MSR instruction.
+		unsigned int sys;  // IC/DC/AT/TLBI operation (see arm64_ic_op, arm64_dc_op, arm64_at_op, arm64_tlbi_op)
+		arm64_prefetch_op prefetch;  // PRFM operation.
+		arm64_barrier_op barrier;  // Memory barrier operation (ISB/DMB/DSB instructions).
+	};
+
+	// How is this operand accessed? (READ, WRITE or READ|WRITE)
+	// This field is combined of cs_ac_type.
+	// NOTE: this field is irrelevant if engine is compiled in DIET mode.
+	cs_ac_type access;
+} cs_arm64_op;
+
+// Instruction structure
+typedef struct cs_arm64 {
+	arm64_cc cc;	// conditional code for this insn
+	bool update_flags;	// does this insn update flags?
+	bool writeback;	// does this insn request writeback? 'True' means 'yes'
+
+	// Number of operands of this instruction,
+	// or 0 when instruction has no operand.
+	uint8_t op_count;
+
+	cs_arm64_op operands[8]; // operands for this instruction.
+} cs_arm64;
 
 //> ARM64 instruction
 typedef enum arm64_insn {

--- a/include/capstone/mips.h
+++ b/include/capstone/mips.h
@@ -27,31 +27,6 @@ typedef enum mips_op_type {
 	MIPS_OP_MEM, // = CS_OP_MEM (Memory operand).
 } mips_op_type;
 
-// Instruction's operand referring to memory
-// This is associated with MIPS_OP_MEM operand type above
-typedef struct mips_op_mem {
-	unsigned int base;	// base register
-	int64_t disp;	// displacement/offset value
-} mips_op_mem;
-
-// Instruction operand
-typedef struct cs_mips_op {
-	mips_op_type type;	// operand type
-	union {
-		unsigned int reg;	// register value for REG operand
-		int64_t imm;		// immediate value for IMM operand
-		mips_op_mem mem;	// base/index/scale/disp value for MEM operand
-	};
-} cs_mips_op;
-
-// Instruction structure
-typedef struct cs_mips {
-	// Number of operands of this instruction, 
-	// or 0 when instruction has no operand.
-	uint8_t op_count;
-	cs_mips_op operands[8]; // operands for this instruction.
-} cs_mips;
-
 //> MIPS registers
 typedef enum mips_reg {
 	MIPS_REG_INVALID = 0,
@@ -254,6 +229,31 @@ typedef enum mips_reg {
 	MIPS_REG_LO2 = MIPS_REG_HI2,
 	MIPS_REG_LO3 = MIPS_REG_HI3,
 } mips_reg;
+
+// Instruction's operand referring to memory
+// This is associated with MIPS_OP_MEM operand type above
+typedef struct mips_op_mem {
+	mips_reg base;	// base register
+	int64_t disp;	// displacement/offset value
+} mips_op_mem;
+
+// Instruction operand
+typedef struct cs_mips_op {
+	mips_op_type type;	// operand type
+	union {
+		mips_reg reg;		// register value for REG operand
+		int64_t imm;		// immediate value for IMM operand
+		mips_op_mem mem;	// base/index/scale/disp value for MEM operand
+	};
+} cs_mips_op;
+
+// Instruction structure
+typedef struct cs_mips {
+	// Number of operands of this instruction, 
+	// or 0 when instruction has no operand.
+	uint8_t op_count;
+	cs_mips_op operands[8]; // operands for this instruction.
+} cs_mips;
 
 //> MIPS instruction
 typedef enum mips_insn {

--- a/include/capstone/ppc.h
+++ b/include/capstone/ppc.h
@@ -48,47 +48,6 @@ typedef enum ppc_op_type {
 	PPC_OP_CRX = 64,	// Condition Register field
 } ppc_op_type;
 
-// Instruction's operand referring to memory
-// This is associated with PPC_OP_MEM operand type above
-typedef struct ppc_op_mem {
-	unsigned int base;	// base register
-	int32_t disp;	// displacement/offset value
-} ppc_op_mem;
-
-typedef struct ppc_op_crx {
-	unsigned int scale;
-	unsigned int reg;
-	ppc_bc cond;
-} ppc_op_crx;
-
-// Instruction operand
-typedef struct cs_ppc_op {
-	ppc_op_type type;	// operand type
-	union {
-		unsigned int reg;	// register value for REG operand
-		int64_t imm;		// immediate value for IMM operand
-		ppc_op_mem mem;		// base/disp value for MEM operand
-		ppc_op_crx crx;		// operand with condition register
-	};
-} cs_ppc_op;
-
-// Instruction structure
-typedef struct cs_ppc {
-	// branch code for branch instructions
-	ppc_bc bc;
-
-	// branch hint for branch instructions
-	ppc_bh bh;
-
-	// if update_cr0 = True, then this 'dot' insn updates CR0
-	bool update_cr0;
-
-	// Number of operands of this instruction, 
-	// or 0 when instruction has no operand.
-	uint8_t op_count;
-	cs_ppc_op operands[8]; // operands for this instruction.
-} cs_ppc;
-
 //> PPC registers
 typedef enum ppc_reg {
 	PPC_REG_INVALID = 0,
@@ -307,6 +266,47 @@ typedef enum ppc_reg {
 
 	PPC_REG_ENDING,   // <-- mark the end of the list of registers
 } ppc_reg;
+
+// Instruction's operand referring to memory
+// This is associated with PPC_OP_MEM operand type above
+typedef struct ppc_op_mem {
+	ppc_reg base;	// base register
+	int32_t disp;	// displacement/offset value
+} ppc_op_mem;
+
+typedef struct ppc_op_crx {
+	unsigned int scale;
+	ppc_reg reg;
+	ppc_bc cond;
+} ppc_op_crx;
+
+// Instruction operand
+typedef struct cs_ppc_op {
+	ppc_op_type type;	// operand type
+	union {
+		ppc_reg reg;	// register value for REG operand
+		int64_t imm;		// immediate value for IMM operand
+		ppc_op_mem mem;		// base/disp value for MEM operand
+		ppc_op_crx crx;		// operand with condition register
+	};
+} cs_ppc_op;
+
+// Instruction structure
+typedef struct cs_ppc {
+	// branch code for branch instructions
+	ppc_bc bc;
+
+	// branch hint for branch instructions
+	ppc_bh bh;
+
+	// if update_cr0 = True, then this 'dot' insn updates CR0
+	bool update_cr0;
+
+	// Number of operands of this instruction, 
+	// or 0 when instruction has no operand.
+	uint8_t op_count;
+	cs_ppc_op operands[8]; // operands for this instruction.
+} cs_ppc;
 
 //> PPC instruction
 typedef enum ppc_insn {

--- a/include/capstone/sparc.h
+++ b/include/capstone/sparc.h
@@ -179,8 +179,10 @@ typedef enum sparc_reg {
 // Instruction's operand referring to memory
 // This is associated with SPARC_OP_MEM operand type above
 typedef struct sparc_op_mem {
-	sparc_reg base;		// base register
-	sparc_reg index;	// index register
+	uint8_t base;		// base register, can be safely interpreted as
+                                // a value of type `sparc_reg`, but it is only
+				// one byte wide
+	uint8_t index;		// index register, same conditions apply here
 	int32_t disp;		// displacement/offset value
 } sparc_op_mem;
 

--- a/include/capstone/sparc.h
+++ b/include/capstone/sparc.h
@@ -75,34 +75,6 @@ typedef enum sparc_op_type {
 	SPARC_OP_MEM, // = CS_OP_MEM (Memory operand).
 } sparc_op_type;
 
-// Instruction's operand referring to memory
-// This is associated with SPARC_OP_MEM operand type above
-typedef struct sparc_op_mem {
-	uint8_t base;	// base register
-	uint8_t index;	// index register
-	int32_t disp;	// displacement/offset value
-} sparc_op_mem;
-
-// Instruction operand
-typedef struct cs_sparc_op {
-	sparc_op_type type;	// operand type
-	union {
-		unsigned int reg;	// register value for REG operand
-		int32_t imm;		// immediate value for IMM operand
-		sparc_op_mem mem;		// base/disp value for MEM operand
-	};
-} cs_sparc_op;
-
-// Instruction structure
-typedef struct cs_sparc {
-	sparc_cc cc;	// code condition for this insn
-	sparc_hint hint;	// branch hint: encoding as bitwise OR of sparc_hint.
-	// Number of operands of this instruction, 
-	// or 0 when instruction has no operand.
-	uint8_t op_count;
-	cs_sparc_op operands[4]; // operands for this instruction.
-} cs_sparc;
-
 //> SPARC registers
 typedef enum sparc_reg {
 	SPARC_REG_INVALID = 0,
@@ -203,6 +175,34 @@ typedef enum sparc_reg {
 	SPARC_REG_O6 = SPARC_REG_SP,
 	SPARC_REG_I6 = SPARC_REG_FP,
 } sparc_reg;
+
+// Instruction's operand referring to memory
+// This is associated with SPARC_OP_MEM operand type above
+typedef struct sparc_op_mem {
+	sparc_reg base;		// base register
+	sparc_reg index;	// index register
+	int32_t disp;		// displacement/offset value
+} sparc_op_mem;
+
+// Instruction operand
+typedef struct cs_sparc_op {
+	sparc_op_type type;	// operand type
+	union {
+		sparc_reg reg;	// register value for REG operand
+		int32_t imm;		// immediate value for IMM operand
+		sparc_op_mem mem;		// base/disp value for MEM operand
+	};
+} cs_sparc_op;
+
+// Instruction structure
+typedef struct cs_sparc {
+	sparc_cc cc;	// code condition for this insn
+	sparc_hint hint;	// branch hint: encoding as bitwise OR of sparc_hint.
+	// Number of operands of this instruction, 
+	// or 0 when instruction has no operand.
+	uint8_t op_count;
+	cs_sparc_op operands[4]; // operands for this instruction.
+} cs_sparc;
 
 //> SPARC instruction
 typedef enum sparc_insn {

--- a/include/capstone/sparc.h
+++ b/include/capstone/sparc.h
@@ -180,7 +180,7 @@ typedef enum sparc_reg {
 // This is associated with SPARC_OP_MEM operand type above
 typedef struct sparc_op_mem {
 	uint8_t base;		// base register, can be safely interpreted as
-                                // a value of type `sparc_reg`, but it is only
+				// a value of type `sparc_reg`, but it is only
 				// one byte wide
 	uint8_t index;		// index register, same conditions apply here
 	int32_t disp;		// displacement/offset value

--- a/include/capstone/systemz.h
+++ b/include/capstone/systemz.h
@@ -90,8 +90,10 @@ typedef enum sysz_reg {
 // Instruction's operand referring to memory
 // This is associated with SYSZ_OP_MEM operand type above
 typedef struct sysz_op_mem {
-	sysz_reg base;		// base register
-	sysz_reg index;		// index register
+	uint8_t base;		// base register, can be safely interpreted as
+                                // a value of type `sysz_reg`, but it is only
+				// one byte wide
+	uint8_t index;		// index register, same conditions apply here
 	uint64_t length;	// BDLAddr operand
 	int64_t disp;	// displacement/offset value
 } sysz_op_mem;

--- a/include/capstone/systemz.h
+++ b/include/capstone/systemz.h
@@ -44,34 +44,6 @@ typedef enum sysz_op_type {
 	SYSZ_OP_ACREG = 64,	// Access register operand.
 } sysz_op_type;
 
-// Instruction's operand referring to memory
-// This is associated with SYSZ_OP_MEM operand type above
-typedef struct sysz_op_mem {
-	uint8_t base;	// base register
-	uint8_t index;	// index register
-	uint64_t length;	// BDLAddr operand
-	int64_t disp;	// displacement/offset value
-} sysz_op_mem;
-
-// Instruction operand
-typedef struct cs_sysz_op {
-	sysz_op_type type;	// operand type
-	union {
-		unsigned int reg;	// register value for REG operand
-		int64_t imm;		// immediate value for IMM operand
-		sysz_op_mem mem;		// base/disp value for MEM operand
-	};
-} cs_sysz_op;
-
-// Instruction structure
-typedef struct cs_sysz {
-	sysz_cc cc;		// Code condition
-	// Number of operands of this instruction, 
-	// or 0 when instruction has no operand.
-	uint8_t op_count;
-	cs_sysz_op operands[6]; // operands for this instruction.
-} cs_sysz;
-
 //> SystemZ registers
 typedef enum sysz_reg {
 	SYSZ_REG_INVALID = 0,
@@ -114,6 +86,34 @@ typedef enum sysz_reg {
 
 	SYSZ_REG_ENDING,
 } sysz_reg;
+
+// Instruction's operand referring to memory
+// This is associated with SYSZ_OP_MEM operand type above
+typedef struct sysz_op_mem {
+	sysz_reg base;		// base register
+	sysz_reg index;		// index register
+	uint64_t length;	// BDLAddr operand
+	int64_t disp;	// displacement/offset value
+} sysz_op_mem;
+
+// Instruction operand
+typedef struct cs_sysz_op {
+	sysz_op_type type;	// operand type
+	union {
+		sysz_reg reg;		// register value for REG operand
+		int64_t imm;		// immediate value for IMM operand
+		sysz_op_mem mem;	// base/disp value for MEM operand
+	};
+} cs_sysz_op;
+
+// Instruction structure
+typedef struct cs_sysz {
+	sysz_cc cc;		// Code condition
+	// Number of operands of this instruction, 
+	// or 0 when instruction has no operand.
+	uint8_t op_count;
+	cs_sysz_op operands[6]; // operands for this instruction.
+} cs_sysz;
 
 //> SystemZ instruction
 typedef enum sysz_insn {

--- a/include/capstone/systemz.h
+++ b/include/capstone/systemz.h
@@ -91,7 +91,7 @@ typedef enum sysz_reg {
 // This is associated with SYSZ_OP_MEM operand type above
 typedef struct sysz_op_mem {
 	uint8_t base;		// base register, can be safely interpreted as
-                                // a value of type `sysz_reg`, but it is only
+				// a value of type `sysz_reg`, but it is only
 				// one byte wide
 	uint8_t index;		// index register, same conditions apply here
 	uint64_t length;	// BDLAddr operand

--- a/include/capstone/xcore.h
+++ b/include/capstone/xcore.h
@@ -64,8 +64,10 @@ typedef enum xcore_reg {
 // Instruction's operand referring to memory
 // This is associated with XCORE_OP_MEM operand type above
 typedef struct xcore_op_mem {
-	xcore_reg base;		// base register
-	xcore_reg index;	// index register
+	uint8_t base;		// base register, can be safely interpreted as
+				// a value of type `xcore_reg`, but it is only
+				// one byte wide
+	uint8_t index;		// index register, same conditions apply here
 	int32_t disp;	// displacement/offset value
 	int     direct;	// +1: forward, -1: backward
 } xcore_op_mem;

--- a/include/capstone/xcore.h
+++ b/include/capstone/xcore.h
@@ -23,33 +23,6 @@ typedef enum xcore_op_type {
 	XCORE_OP_MEM, // = CS_OP_MEM (Memory operand).
 } xcore_op_type;
 
-// Instruction's operand referring to memory
-// This is associated with XCORE_OP_MEM operand type above
-typedef struct xcore_op_mem {
-	uint8_t base;	// base register
-	uint8_t index;	// index register
-	int32_t disp;	// displacement/offset value
-	int     direct;	// +1: forward, -1: backward
-} xcore_op_mem;
-
-// Instruction operand
-typedef struct cs_xcore_op {
-	xcore_op_type type;	// operand type
-	union {
-		unsigned int reg;	// register value for REG operand
-		int32_t imm;		// immediate value for IMM operand
-		xcore_op_mem mem;		// base/disp value for MEM operand
-	};
-} cs_xcore_op;
-
-// Instruction structure
-typedef struct cs_xcore {
-	// Number of operands of this instruction, 
-	// or 0 when instruction has no operand.
-	uint8_t op_count;
-	cs_xcore_op operands[8]; // operands for this instruction.
-} cs_xcore;
-
 //> XCore registers
 typedef enum xcore_reg {
 	XCORE_REG_INVALID = 0,
@@ -87,6 +60,33 @@ typedef enum xcore_reg {
 
 	XCORE_REG_ENDING,	// <-- mark the end of the list of registers
 } xcore_reg;
+
+// Instruction's operand referring to memory
+// This is associated with XCORE_OP_MEM operand type above
+typedef struct xcore_op_mem {
+	xcore_reg base;		// base register
+	xcore_reg index;	// index register
+	int32_t disp;	// displacement/offset value
+	int     direct;	// +1: forward, -1: backward
+} xcore_op_mem;
+
+// Instruction operand
+typedef struct cs_xcore_op {
+	xcore_op_type type;	// operand type
+	union {
+		xcore_reg reg;	// register value for REG operand
+		int32_t imm;		// immediate value for IMM operand
+		xcore_op_mem mem;		// base/disp value for MEM operand
+	};
+} cs_xcore_op;
+
+// Instruction structure
+typedef struct cs_xcore {
+	// Number of operands of this instruction, 
+	// or 0 when instruction has no operand.
+	uint8_t op_count;
+	cs_xcore_op operands[8]; // operands for this instruction.
+} cs_xcore;
 
 //> XCore instruction
 typedef enum xcore_insn {


### PR DESCRIPTION
In some architecture headers, register values were
represented as `unsigned int`/`uint8_t` or other types
instead of the corresponding enums. This commit fixes most (all)
occurences of this problem.

Fixes the second part of issue #619.