### PR TITLE
Added support for building binaries for Windows CE 7 and Windows CE 8 on ARMv7

### DIFF
--- a/COMPILE.TXT
+++ b/COMPILE.TXT
@@ -7,6 +7,8 @@ To compile using CMake, see COMPILE_CMAKE.TXT.
 
 To compile using XCode on MacOSX, see xcode/README.md.
 
+To compile for Windows CE (a.k.a, Windows Embedded Compact), see windowsce/COMPILE.md.
+
                         *-*-*-*-*-*
 
 Capstone requires no prerequisite packages, so it is easy to compile & install.

--- a/CREDITS.TXT
+++ b/CREDITS.TXT
@@ -61,3 +61,4 @@ Adel Gadllah, Francisco Alonso & Stefan Cornelius: RPM package.
 Felix Gröbert (Google): fuzz testing harness.
 Daniel Collin & Nicolas Planel: M68K architecture.
 Pranith Kumar: Explicit registers accessed for Arm64.
+Koutheir Attouchi: Support for Windows CE.

--- a/LEB128.h
+++ b/LEB128.h
@@ -18,7 +18,7 @@
 #ifndef CS_LLVM_SUPPORT_LEB128_H
 #define CS_LLVM_SUPPORT_LEB128_H
 
-#include <stdint.h>
+#include "include/capstone/capstone.h"
 
 /// Utility function to decode a ULEB128 value.
 static inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n)

--- a/MCInst.h
+++ b/MCInst.h
@@ -19,8 +19,6 @@
 #ifndef CS_MCINST_H
 #define CS_MCINST_H
 
-#include <stdint.h>
-
 #include "include/capstone/capstone.h"
 
 typedef struct MCInst MCInst;

--- a/MCInstrDesc.h
+++ b/MCInstrDesc.h
@@ -18,7 +18,6 @@
 #ifndef CS_LLVM_MC_MCINSTRDESC_H
 #define CS_LLVM_MC_MCINSTRDESC_H
 
-#include <stdint.h>
 #include "capstone/platform.h"
 
 //===----------------------------------------------------------------------===//

--- a/MCRegisterInfo.h
+++ b/MCRegisterInfo.h
@@ -19,7 +19,6 @@
 #ifndef CS_LLVM_MC_MCREGISTERINFO_H
 #define CS_LLVM_MC_MCREGISTERINFO_H
 
-#include <stdint.h>
 #include "capstone/platform.h"
 
 /// An unsigned integer type large enough to represent all physical registers,

--- a/MathExtras.h
+++ b/MathExtras.h
@@ -17,9 +17,9 @@
 #ifndef CS_LLVM_SUPPORT_MATHEXTRAS_H
 #define CS_LLVM_SUPPORT_MATHEXTRAS_H
 
-#include <stdint.h>
-
-#ifdef _MSC_VER
+#if defined(_WIN32_WCE) && (_WIN32_WCE < 0x800)
+#include "windowsce/intrin.h"
+#elif defined(_MSC_VER)
 # include <intrin.h>
 #endif
 

--- a/SStream.c
+++ b/SStream.c
@@ -1,7 +1,6 @@
 /* Capstone Disassembly Engine */
 /* By Nguyen Anh Quynh <aquynh@gmail.com>, 2013-2015 */
 
-#include <stdint.h>
 #include <stdarg.h>
 #if defined(CAPSTONE_HAS_OSXKERNEL)
 #include <libkern/libkern.h>

--- a/SStream.h
+++ b/SStream.h
@@ -4,6 +4,8 @@
 #ifndef CS_SSTREAM_H_
 #define CS_SSTREAM_H_
 
+#include "include/capstone/platform.h"
+
 typedef struct SStream {
 	char buffer[512];
 	int index;

--- a/arch/AArch64/AArch64BaseInfo.h
+++ b/arch/AArch64/AArch64BaseInfo.h
@@ -21,7 +21,6 @@
 #define CS_LLVM_AARCH64_BASEINFO_H
 
 #include <ctype.h>
-#include <stdint.h>
 #include <string.h>
 
 #ifndef __cplusplus

--- a/arch/AArch64/AArch64Disassembler.h
+++ b/arch/AArch64/AArch64Disassembler.h
@@ -4,8 +4,6 @@
 #ifndef CS_AARCH64_DISASSEMBLER_H
 #define CS_AARCH64_DISASSEMBLER_H
 
-#include <stdint.h>
-
 #include "capstone/capstone.h"
 #include "../../MCRegisterInfo.h"
 #include "../../MCInst.h"

--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -1642,9 +1642,12 @@ static void printSystemPStateField(MCInst *MI, unsigned OpNo, SStream *O)
 			MI->flat_insn->detail->arm64.op_count++;
 		}
 	} else {
+#ifndef CAPSTONE_DIET
+		unsigned char access;
+#endif
 		printInt32Bang(O, Val);
 #ifndef CAPSTONE_DIET
-		unsigned char access = get_op_access(MI->csh, MCInst_getOpcode(MI), MI->ac_idx);
+		access = get_op_access(MI->csh, MCInst_getOpcode(MI), MI->ac_idx);
 		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].access = access;
 		MI->ac_idx++;
 #endif

--- a/arch/M68K/M68KDisassembler.h
+++ b/arch/M68K/M68KDisassembler.h
@@ -5,7 +5,6 @@
 #define CS_M68KDISASSEMBLER_H
 
 #include "../../MCInst.h"
-#include <stdint.h>
 
 /* Private, For internal use only */
 typedef struct m68k_info {

--- a/arch/M68K/M68KInstPrinter.h
+++ b/arch/M68K/M68KInstPrinter.h
@@ -4,8 +4,6 @@
 #ifndef CS_M68KINSTPRINTER_H
 #define CS_M68KINSTPRINTER_H
 
-#include <stdint.h>
-
 #include "capstone/capstone.h"
 #include "../../MCRegisterInfo.h"
 #include "../../MCInst.h"

--- a/arch/PowerPC/PPCDisassembler.h
+++ b/arch/PowerPC/PPCDisassembler.h
@@ -4,8 +4,6 @@
 #ifndef CS_PPCDISASSEMBLER_H
 #define CS_PPCDISASSEMBLER_H
 
-#include <stdint.h>
-
 #include "capstone/capstone.h"
 #include "../../MCRegisterInfo.h"
 #include "../../MCInst.h"

--- a/arch/Sparc/SparcDisassembler.h
+++ b/arch/Sparc/SparcDisassembler.h
@@ -4,8 +4,6 @@
 #ifndef CS_SPARCDISASSEMBLER_H
 #define CS_SPARCDISASSEMBLER_H
 
-#include <stdint.h>
-
 #include "capstone/capstone.h"
 #include "../../MCRegisterInfo.h"
 #include "../../MCInst.h"

--- a/arch/SystemZ/SystemZDisassembler.h
+++ b/arch/SystemZ/SystemZDisassembler.h
@@ -4,8 +4,6 @@
 #ifndef CS_SYSZDISASSEMBLER_H
 #define CS_SYSZDISASSEMBLER_H
 
-#include <stdint.h>
-
 #include "capstone/capstone.h"
 #include "../../MCRegisterInfo.h"
 #include "../../MCInst.h"

--- a/arch/X86/X86Disassembler.h
+++ b/arch/X86/X86Disassembler.h
@@ -77,8 +77,6 @@
 #ifndef CS_X86_DISASSEMBLER_H
 #define CS_X86_DISASSEMBLER_H
 
-#include <stdint.h>
-
 #include "capstone/capstone.h"
 
 #include "../../MCInst.h"

--- a/arch/X86/X86DisassemblerDecoder.h
+++ b/arch/X86/X86DisassemblerDecoder.h
@@ -24,7 +24,6 @@
 #else
 #include <stdio.h>
 #endif
-#include <stdint.h>
 
 #include "X86DisassemblerDecoderCommon.h"
 

--- a/arch/X86/X86DisassemblerDecoderCommon.h
+++ b/arch/X86/X86DisassemblerDecoderCommon.h
@@ -25,8 +25,6 @@
 #ifndef CS_X86_DISASSEMBLERDECODERCOMMON_H
 #define CS_X86_DISASSEMBLERDECODERCOMMON_H
 
-#include <stdint.h>
-
 #define INSTRUCTIONS_SYM  x86DisassemblerInstrSpecifiers
 #define CONTEXTS_SYM      x86DisassemblerContexts
 #define ONEBYTE_SYM       x86DisassemblerOneByteOpcodes

--- a/arch/XCore/XCoreDisassembler.h
+++ b/arch/XCore/XCoreDisassembler.h
@@ -4,8 +4,6 @@
 #ifndef CS_XCOREDISASSEMBLER_H
 #define CS_XCOREDISASSEMBLER_H
 
-#include <stdint.h>
-
 #include "capstone/capstone.h"
 #include "../../MCRegisterInfo.h"
 #include "../../MCInst.h"

--- a/cs.c
+++ b/cs.c
@@ -88,7 +88,11 @@ cs_malloc_t cs_mem_malloc = malloc;
 cs_calloc_t cs_mem_calloc = calloc;
 cs_realloc_t cs_mem_realloc = realloc;
 cs_free_t cs_mem_free = free;
+#if defined(_WIN32_WCE)
+cs_vsnprintf_t cs_vsnprintf = _vsnprintf;
+#else // !_WIN32_WCE
 cs_vsnprintf_t cs_vsnprintf = vsnprintf;
+#endif // _WIN32_WCE
 #else
 extern void* kern_os_malloc(size_t size);
 extern void kern_os_free(void* addr);

--- a/include/capstone/arm.h
+++ b/include/capstone/arm.h
@@ -8,7 +8,6 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/capstone/arm64.h
+++ b/include/capstone/arm64.h
@@ -8,7 +8,6 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -8,7 +8,6 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include <stdarg.h>
 #if defined(CAPSTONE_HAS_OSXKERNEL)
 #include <libkern/libkern.h>

--- a/include/capstone/m68k.h
+++ b/include/capstone/m68k.h
@@ -8,7 +8,6 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/capstone/mips.h
+++ b/include/capstone/mips.h
@@ -8,7 +8,6 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include "platform.h"
 
 // GCC MIPS toolchain has a default macro called "mips" which breaks

--- a/include/capstone/platform.h
+++ b/include/capstone/platform.h
@@ -5,6 +5,12 @@
 #ifndef CAPSTONE_PLATFORM_H
 #define CAPSTONE_PLATFORM_H
 
+#if defined(_WIN32_WCE) && (_WIN32_WCE < 0x800)
+#include "windowsce/stdint.h"
+#else // Platforms where stdint.h is provided
+#include <stdint.h>
+#endif
+
 #if !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__) && (defined (WIN32) || defined (WIN64) || defined (_WIN32) || defined (_WIN64))
 // MSVC
 

--- a/include/capstone/ppc.h
+++ b/include/capstone/ppc.h
@@ -8,7 +8,6 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/capstone/sparc.h
+++ b/include/capstone/sparc.h
@@ -8,7 +8,6 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include "platform.h"
 
 // GCC SPARC toolchain has a default macro called "sparc" which breaks

--- a/include/capstone/systemz.h
+++ b/include/capstone/systemz.h
@@ -8,7 +8,6 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/capstone/x86.h
+++ b/include/capstone/x86.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include "platform.h"
 
 // Calculate relative address for X86-64, given cs_insn structure
 #define X86_REL_ADDR(insn) (insn.address + insn.size + insn.detail->x86.disp)

--- a/include/capstone/xcore.h
+++ b/include/capstone/xcore.h
@@ -8,7 +8,6 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/windowsce/intrin.h
+++ b/include/windowsce/intrin.h
@@ -1,0 +1,12 @@
+
+#if defined(_MSC_VER) && defined(_WIN32_WCE) && (_WIN32_WCE < 0x800) && !defined(__INTRIN_H_) && !defined(_INTRIN)
+#define _STDINT
+
+#ifdef _M_ARM
+#include <armintr.h>
+#if (_WIN32_WCE >= 0x700) && defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__)
+#include <arm_neon.h>
+#endif
+#endif // _M_ARM
+
+#endif

--- a/include/windowsce/stdint.h
+++ b/include/windowsce/stdint.h
@@ -1,0 +1,133 @@
+
+#if defined(_MSC_VER) && defined(_WIN32_WCE) && (_WIN32_WCE < 0x800) && !defined(_STDINT_H_) && !defined(_STDINT)
+#define _STDINT
+
+typedef __int8
+	int8_t,
+	int_least8_t;
+
+typedef __int16
+	int16_t,
+	int_least16_t;
+
+typedef __int32
+	int32_t,
+	int_least32_t,
+	int_fast8_t,
+	int_fast16_t,
+	int_fast32_t;
+	
+typedef __int64
+	int64_t,
+	intmax_t,
+	int_least64_t,
+	int_fast64_t;
+
+typedef unsigned __int8
+	uint8_t,
+	uint_least8_t;
+	
+typedef unsigned __int16
+	uint16_t,
+	uint_least16_t;
+	
+typedef unsigned __int32
+	uint32_t,
+	uint_least32_t,
+	uint_fast8_t,
+	uint_fast16_t,
+	uint_fast32_t;
+	
+typedef unsigned __int64
+	uint64_t,
+	uintmax_t,
+	uint_least64_t,
+	uint_fast64_t;
+
+#ifndef _INTPTR_T_DEFINED
+#define _INTPTR_T_DEFINED
+typedef __int32	intptr_t;
+#endif
+
+#ifndef _UINTPTR_T_DEFINED
+#define _UINTPTR_T_DEFINED
+typedef unsigned __int32	uintptr_t;
+#endif
+
+#define INT8_MIN         (-127i8 - 1)
+#define INT16_MIN        (-32767i16 - 1)
+#define INT32_MIN        (-2147483647i32 - 1)
+#define INT64_MIN        (-9223372036854775807i64 - 1)
+#define INT8_MAX         127i8
+#define INT16_MAX        32767i16
+#define INT32_MAX        2147483647i32
+#define INT64_MAX        9223372036854775807i64
+#define UINT8_MAX        0xffui8
+#define UINT16_MAX       0xffffui16
+#define UINT32_MAX       0xffffffffui32
+#define UINT64_MAX       0xffffffffffffffffui64
+
+#define INT_LEAST8_MIN   INT8_MIN
+#define INT_LEAST16_MIN  INT16_MIN
+#define INT_LEAST32_MIN  INT32_MIN
+#define INT_LEAST64_MIN  INT64_MIN
+#define INT_LEAST8_MAX   INT8_MAX
+#define INT_LEAST16_MAX  INT16_MAX
+#define INT_LEAST32_MAX  INT32_MAX
+#define INT_LEAST64_MAX  INT64_MAX
+#define UINT_LEAST8_MAX  UINT8_MAX
+#define UINT_LEAST16_MAX UINT16_MAX
+#define UINT_LEAST32_MAX UINT32_MAX
+#define UINT_LEAST64_MAX UINT64_MAX
+
+#define INT_FAST8_MIN    INT8_MIN
+#define INT_FAST16_MIN   INT32_MIN
+#define INT_FAST32_MIN   INT32_MIN
+#define INT_FAST64_MIN   INT64_MIN
+#define INT_FAST8_MAX    INT8_MAX
+#define INT_FAST16_MAX   INT32_MAX
+#define INT_FAST32_MAX   INT32_MAX
+#define INT_FAST64_MAX   INT64_MAX
+#define UINT_FAST8_MAX   UINT8_MAX
+#define UINT_FAST16_MAX  UINT32_MAX
+#define UINT_FAST32_MAX  UINT32_MAX
+#define UINT_FAST64_MAX  UINT64_MAX
+
+#define INTPTR_MIN      INT32_MIN
+#define INTPTR_MAX      INT32_MAX
+#define UINTPTR_MAX     UINT32_MAX
+
+#define INTMAX_MIN       INT64_MIN
+#define INTMAX_MAX       INT64_MAX
+#define UINTMAX_MAX      UINT64_MAX
+
+#define PTRDIFF_MIN      INTPTR_MIN
+#define PTRDIFF_MAX      INTPTR_MAX
+
+#ifndef SIZE_MAX
+#define SIZE_MAX        UINTPTR_MAX
+#endif
+
+#define SIG_ATOMIC_MIN   INT32_MIN
+#define SIG_ATOMIC_MAX   INT32_MAX
+
+#define WCHAR_MIN        0x0000
+#define WCHAR_MAX        0xffff
+
+#define WINT_MIN         0x0000
+#define WINT_MAX         0xffff
+
+#define INT8_C(x)    (x)
+#define INT16_C(x)   (x)
+#define INT32_C(x)   (x)
+#define INT64_C(x)   (x ## LL)
+
+#define UINT8_C(x)   (x)
+#define UINT16_C(x)  (x)
+#define UINT32_C(x)  (x ## U)
+#define UINT64_C(x)  (x ## ULL)
+
+#define INTMAX_C(x)  INT64_C(x)
+#define UINTMAX_C(x) UINT64_C(x)
+
+#endif

--- a/windowsce/.gitignore
+++ b/windowsce/.gitignore
@@ -1,0 +1,13 @@
+# Object files
+*.obj
+
+# Libraries
+*.lib
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+
+# VisualStudio
+*.exp
+*.map
+*.pdb

--- a/windowsce/COMPILE.md
+++ b/windowsce/COMPILE.md
@@ -1,0 +1,124 @@
+This documentation explains how to compile Capstone for:
+- Windows CE 7, a.k.a, [Windows Embedded Compact 7](https://www.microsoft.com/windowsembedded/en-us/windows-embedded-compact-7.aspx), on [ARMv7](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0406c/index.html).
+- Windows CE 8, a.k.a, [Windows Embedded Compact 2013](https://www.microsoft.com/windowsembedded/en-us/windows-embedded-compact-2013.aspx), on [ARMv7](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0406c/index.html).
+
+To build Capstone for a different platform, please refer to `COMPILE.TXT`.
+
+# Prerequisites
+
+We support the following scenario regarding the build machine:
+- Build running on Microsoft Windows.
+- The C Software Develepment Kit of the target Windows CE **device** installed.
+- Only for Windows CE 7:
+  - C compiler toolchain installed, targetting **Windows Embedded Compact 7** on **ARMv7**.  We recommend the toolchain provided with [Windows Embedded Compact 7 toolkit](https://msdn.microsoft.com/en-us/library/jj200349%28v=winembedded.70%29.aspx), as the toolchain originally provided with **Visual Studio 2008** is relatively old.
+
+Before building Capstone for Windows CE 7 (respectively, Windows CE 8), the build script `windowsce/make_windowsce7-armv7.bat` (respectively, `windowsce/make_windowsce8-armv7.bat`) needs to be modified. The variables specified in the rest of this section are set in this script file.
+
+# Toolchain specification
+
+The following information need to be specified in the build script in order to perform the build:
+- `set WINCE_TOOLCHAIN_ROOT=` is the path of the root directory of the Windows CE toolchain. To build for Windows CE 7, this should be set to the Windows Embedded Compact 7 toolchain. To build for Windows CE 8, this should be set to the device toolchain.
+Examples:
+  - For Windows CE 7:
+  ```bat
+  set WINCE_TOOLCHAIN_ROOT=C:\WINCE700\sdk
+  ```
+  - For Windows CE 8:
+  ```bat
+  set WINCE_TOOLCHAIN_ROOT=C:\Windows_CE_Tools\SDKs\SDK_HW90270\Sdk
+  ```
+
+- `set TOOLCHAIN=` is a semicolon-separated list of the paths of the directories containing the binaries of the Windows CE toolchain.
+For example:
+```bat
+set TOOLCHAIN=%WINCE_TOOLCHAIN_ROOT%\Bin\i386\Arm;%WINCE_TOOLCHAIN_ROOT%\Bin\i386
+```
+
+- `set INCLUDE=` is a semicolon-separated list of the paths of the directories containing the C header files of the Windows CE device SDK. To build for Windows CE 7, this should also include the directories containing the C header files of the Windows Embedded Compact 7 toolchain.
+Examples:
+  - For Windows CE 7:
+  ```bat
+  set INCLUDE=C:\Program Files (x86)\Windows CE Tools\SDKs\Symbol MC3200c70 Windows CE 7.0 PSDK\Include\Armv4i;C:\WINCE700\public\common\sdk\inc
+  ```
+  - For Windows CE 8:
+  ```bat
+  set INCLUDE=%WINCE_TOOLCHAIN_ROOT%\Inc;%WINCE_TOOLCHAIN_ROOT%\crt\Include
+  ```
+
+- `set LIBPATH=` is a semicolon-separated list of the paths of the directories containing the library (i.e., `.LIB`) files of the Windows CE 7 device SDK.
+Examples:
+  - For Windows CE 7:
+  ```bat
+  set LIBPATH=C:\Program Files (x86)\Windows CE Tools\SDKs\Symbol MC3200c70 Windows CE 7.0 PSDK\Lib\ARMv4I
+  ```
+  - For Windows CE 8:
+  ```bat
+  set LIBPATH=%WINCE_TOOLCHAIN_ROOT%\Lib\ARMV7\retail;%WINCE_TOOLCHAIN_ROOT%\Crt\Lib\ARM
+  ```
+
+- `set LIBS=` is a space-separated list of linker directives controlling library search.
+Examples:
+  - For Windows CE 7:
+  ```bat
+  set LIBS=-nodefaultlib:oldnames.lib -nodefaultlib:libcmtd.lib -nodefaultlib:libcmt.lib coredll.lib corelibc.lib
+  ```
+  - For Windows CE 8:
+  ```bat
+  set LIBS=coredll.lib
+  ```
+
+# Capstone binary format
+
+By default, the build script produces a **dynamic link library** (i.e., `.DLL`). In order to produce a **static library** (i.e., `.LIB`) instead, the `SHARED` variable needs to be set to `0`, i.e.:
+```bat
+set SHARED=0
+```
+
+# Architectures supported at runtime
+
+Capstone supports the following architectures: ARM, ARM64 (AArch64), M68K, MIPS, PowerPC, Sparc, SystemZ, x86 and XCore. However, Capstone can be configured in order to select which architectures need to be supported **at runtime**. This is controlled via the variable `DISASM_ARCH_LIST`, which is a space-separated list that is a combination of the following names:
+- `ARM`
+- `ARM64`
+- `M68K`
+- `MIPS`
+- `POWERPC`
+- `SPARC`
+- `SYSZ`
+- `X86`
+- `XCORE`.
+
+By default, `DISASM_ARCH_LIST` includes support for **all** architectures supported by Capstone.
+For example:
+```bat
+set DISASM_ARCH_LIST=ARM ARM64 X86
+```
+will produce a Capstone binary that supports the following architectures: ARM, ARM64 and x86.
+
+## Features customization
+
+Capstone has a list of features that can be controlled when needed. Each feature is controlled through setting a variable from the following list:
+
+- In order to produce a smaller binary that provides a **subset** of the features of Capstone, but still supports all the selected architectures, please specify the following:
+  ```bat
+  set DIET_MODE=1
+  ```
+  By default, this variable is set to `0`.
+
+- By default, Capstone uses the default system-provided **dynamic memory management** functions (e.g., `malloc()`, `realloc()`, `free()`) for its internal memory management. However, Capstone can instead be configured to call **custom** memory management functions provided by client applications. In order to enable this behavior, set the following:
+  ```bat
+  set USE_SYS_DYN_MEM=0
+  ```
+
+- In order to produce a **smaller** Capstone binary, support for the `x86` architecture can be more **limited**. In order to do so, set the following:
+  ```bat
+  set X86_REDUCE=1
+  ```
+  By default, this is set to `0`.
+
+- If the **AT&T** disassembly style of the `x86` architecture is never needed at runtime, then disabling support for it can produce a **smaller** Capstone binary. To do this, please set the following:
+  ```bat
+  set X86_ATT_DISABLE=1
+  ```
+  By default, this is set to `0`.
+
+Please refer to `docs/README` for more details on these features.

--- a/windowsce/make_windowsce7-armv7.bat
+++ b/windowsce/make_windowsce7-armv7.bat
@@ -16,13 +16,10 @@ rem ***************************************************************************
 
 set SHARED=1
 set DIET_MODE=0
+set USE_SYS_DYN_MEM=1
 set X86_REDUCE=0
 set X86_ATT_DISABLE=0
-set USE_SYS_DYN_MEM=0
 set DISASM_ARCH_LIST=ARM ARM64 M68K MIPS POWERPC SPARC SYSZ X86 XCORE
-set DISASM_ARCH_DIRS=ARM AARCH64 M68K MIPS POWERPC SPARC SystemZ X86 XCORE
-rem set DISASM_ARCH_LIST=ARM
-rem set DISASM_ARCH_DIRS=ARM
 
 rem ***************************************************************************
 rem *                              SANITY CHECKS                              *
@@ -126,7 +123,7 @@ set ARFLAGS=-nologo -machine:%MACH% -subsystem:WINDOWSCE,%OS_VERSION% %LIBPATH% 
 
 set SOURCES=
 for %%f in (%SOURCES_ROOT%\*.c) do set SOURCES=!SOURCES! %%f
-for %%a in (%DISASM_ARCH_DIRS%) do for %%f in (%SOURCES_ROOT%\arch\%%a\*.c) do set SOURCES=!SOURCES! %%f
+for /d %%a in (%SOURCES_ROOT%\arch\*) do for %%f in (%%a\*.c) do set SOURCES=!SOURCES! %%f
 
 rem ***************************************************************************
 rem *                           COMPILATION COMMANDS                          *

--- a/windowsce/make_windowsce7-armv7.bat
+++ b/windowsce/make_windowsce7-armv7.bat
@@ -1,0 +1,182 @@
+@echo off
+
+rem ***************************************************************************
+rem *                       VARIABLES TO SET FOR BUILDING                     *
+rem ***************************************************************************
+
+set WINCE_TOOLCHAIN_ROOT=C:\WINCE700\sdk
+set TOOLCHAIN=%WINCE_TOOLCHAIN_ROOT%\Bin\i386\Arm;%WINCE_TOOLCHAIN_ROOT%\Bin\i386
+set INCLUDE=C:\Program Files (x86)\Windows CE Tools\SDKs\Symbol MC3200c70 Windows CE 7.0 PSDK\Include\Armv4i;C:\WINCE700\public\common\sdk\inc
+set LIBPATH=C:\Program Files (x86)\Windows CE Tools\SDKs\Symbol MC3200c70 Windows CE 7.0 PSDK\Lib\ARMv4I
+set LIBS=-nodefaultlib:oldnames.lib -nodefaultlib:libcmtd.lib -nodefaultlib:libcmt.lib coredll.lib corelibc.lib
+
+rem ***************************************************************************
+rem *                           CAPSTONE CONFIGURATION                        *
+rem ***************************************************************************
+
+set SHARED=1
+set DIET_MODE=0
+set X86_REDUCE=0
+set X86_ATT_DISABLE=0
+set USE_SYS_DYN_MEM=0
+set DISASM_ARCH_LIST=ARM ARM64 M68K MIPS POWERPC SPARC SYSZ X86 XCORE
+set DISASM_ARCH_DIRS=ARM AARCH64 M68K MIPS POWERPC SPARC SystemZ X86 XCORE
+rem set DISASM_ARCH_LIST=ARM
+rem set DISASM_ARCH_DIRS=ARM
+
+rem ***************************************************************************
+rem *                              SANITY CHECKS                              *
+rem ***************************************************************************
+
+setlocal ENABLEDELAYEDEXPANSION
+
+if "%WINCE_TOOLCHAIN_ROOT%"=="" goto check_dir_exist_WINCE_TOOLCHAIN_ROOT
+if not exist "%WINCE_TOOLCHAIN_ROOT%" goto check_dir_exist_WINCE_TOOLCHAIN_ROOT
+
+if "%TOOLCHAIN%"=="" goto check_dir_exist_TOOLCHAIN
+
+set CC=
+set LD=
+set AR=
+for /f "tokens=1-8 delims=;" %%a in ("%TOOLCHAIN%") do (
+  for %%i in (%%a %%b %%c %%d %%e %%f %%g %%h) do (
+    if not "%%i"=="" (
+      if not exist "%%i" goto check_dir_exist_TOOLCHAIN
+      if "%CC%"=="" if exist "%%i\cl.exe" set CC=%%i\cl.exe
+      if "%LD%"=="" if exist "%%i\link.exe" set LD=%%i\link.exe
+      if "%AR%"=="" if exist "%%i\lib.exe" set AR=%%i\lib.exe
+    )
+  )
+)
+
+if "%CC%"=="" goto check_dir_exist_CC_LD_AR
+if "%LD%"=="" goto check_dir_exist_CC_LD_AR
+if "%AR%"=="" goto check_dir_exist_CC_LD_AR
+
+if "%INCLUDE%"=="" goto check_dir_exist_INCLUDE
+
+set WINDOWS_H=
+
+set INCLUDE_SC=%INCLUDE%
+set INCLUDE=
+for /f "tokens=1-8 delims=;" %%a in ("%INCLUDE_SC%") do (
+  for %%i in ("%%a" "%%b" "%%c" "%%d" "%%e" "%%f" "%%g" "%%h") do (
+    if not %%i=="" (
+      set INCLUDE=!INCLUDE! -I %%i
+    )
+  )
+)
+
+if "%LIBPATH%"=="" goto check_dir_exist_LIBPATH
+
+set LIBPATH_SC=%LIBPATH%
+set LIBPATH=
+for /f "tokens=1-8 delims=;" %%a in ("%LIBPATH_SC%") do (
+  for %%i in ("%%a" "%%b" "%%c" "%%d" "%%e" "%%f" "%%g" "%%h") do (
+    if not %%i=="" (
+      set LIBPATH=!LIBPATH! -libpath:%%i
+    )
+  )
+)
+
+rem ***************************************************************************
+rem *                            COMPILATION OPTIONS                          *
+rem ***************************************************************************
+
+set OS=windowsce
+set OS_VERSION=7.0
+set OS_VERSION_NUMBER=0x700
+set LIBARCH=arm
+set MACH=THUMB
+
+for /f "delims=" %%i in ('cd') do set THIS_DIR=%%i
+
+set SOURCES_ROOT=%THIS_DIR%\..
+set TARGET_DIR=%THIS_DIR%\bin\%OS%_%OS_VERSION%_%LIBARCH%
+
+for /f "tokens=3" %%i in ('findstr /c:"#define CS_API_MAJOR" "%SOURCES_ROOT%\include\capstone\capstone.h"') do set CS_API_MAJOR=%%i
+for /f "tokens=3" %%i in ('findstr /c:"#define CS_API_MINOR" "%SOURCES_ROOT%\include\capstone\capstone.h"') do set CS_API_MINOR=%%i
+
+set TARGET_VERSION=%CS_API_MAJOR%.%CS_API_MINOR%
+set TAREGET_NAME=capstone-%TARGET_VERSION%
+
+set CPPFLAGS=-D LIBARCH_%LIBARCH% -D LIBARCH=L\"%LIBARCH%\"
+set CPPFLAGS=%CPPFLAGS% -D _CRT_SECURE_NO_DEPRECATE -D _WINDOWS -D WINVER=%OS_VERSION_NUMBER% -D UNDER_CE=%OS_VERSION_NUMBER% -D _WIN32_WCE=%OS_VERSION_NUMBER% -D WINCE -D _UNICODE -D UNICODE -D STANDARDSHELL_UI_MODEL -D _USE_MATH_DEFINES -D ARM -D _ARM -D _ARM_ -D __ARM_ARCH_7__ -D __ARM_ARCH_7A__ -D __VFP_FP__=1
+
+for %%a in (%DISASM_ARCH_LIST%) do set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_HAS_%%a
+
+if %SHARED%==0 (
+  set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_STATIC -D LIB_EXT=L\".lib\"
+) else (
+  set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_SHARED -D LIB_EXT=L\".dll\"
+)
+
+if not %USE_SYS_DYN_MEM%==0 ( set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_USE_SYS_DYN_MEM )
+if not %DIET_MODE%==0 ( set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_DIET )
+if not %X86_REDUCE%==0 ( set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_X86_REDUCE )
+if not %X86_ATT_DISABLE%==0 ( set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_X86_ATT_DISABLE )
+
+set INCLUDE=-I %SOURCES_ROOT%\include -I %SOURCES_ROOT% %INCLUDE%
+
+set CFLAGS=%CPPFLAGS% %INCLUDE% -nologo -Zi -MT -Oi -GS -GF -QRarch7 -arch:VFPv3-D32 -QRfpe- -fp:fast -Oy- -W3 -WX
+
+set LDFLAGS=-nologo -debug -incremental:no -manifest:no -version:%TARGET_VERSION% -machine:%MACH% -subsystem:WINDOWSCE,%OS_VERSION% %LIBPATH% %LIBS%
+
+set ARFLAGS=-nologo -machine:%MACH% -subsystem:WINDOWSCE,%OS_VERSION% %LIBPATH% %LIBS%
+
+set SOURCES=
+for %%f in (%SOURCES_ROOT%\*.c) do set SOURCES=!SOURCES! %%f
+for %%a in (%DISASM_ARCH_DIRS%) do for %%f in (%SOURCES_ROOT%\arch\%%a\*.c) do set SOURCES=!SOURCES! %%f
+
+rem ***************************************************************************
+rem *                           COMPILATION COMMANDS                          *
+rem ***************************************************************************
+
+rd /q /s "%TARGET_DIR%"
+md "%TARGET_DIR%"
+
+set PATH=%TOOLCHAIN%;%PATH%
+
+rem %CC% -c %CFLAGS% -D DEBUG -D _DEBUG -Od -Fo"%TARGET_DIR%\\" -Fd"%TARGET_DIR%\%TAREGET_NAME%.pdb" %SOURCES%
+%CC% -c %CFLAGS% -D NDEBUG -Ox -Fo"%TARGET_DIR%\\" -Fd"%TARGET_DIR%\%TAREGET_NAME%.pdb" %SOURCES%
+if errorlevel 1 goto compilation_failed
+
+if %SHARED%==0 (
+  %AR% -out:%TARGET_DIR%\%TAREGET_NAME%.lib %ARFLAGS% %TARGET_DIR%\*.obj
+) else (
+  %LD% -dll -out:%TARGET_DIR%\%TAREGET_NAME%.dll -map:"%TARGET_DIR%\%TAREGET_NAME%.map" -pdb:"%TARGET_DIR%\%TAREGET_NAME%.pdb" %LDFLAGS% -opt:REF -opt:ICF %TARGET_DIR%\*.obj
+)
+
+endlocal
+goto done
+
+rem ***************************************************************************
+rem *                             ERROR REPORTING                             *
+rem ***************************************************************************
+
+:check_dir_exist_WINCE_TOOLCHAIN_ROOT
+echo ERROR: WINCE_TOOLCHAIN_ROOT does not specify an existing directory.
+goto done
+
+:check_dir_exist_TOOLCHAIN
+echo ERROR: TOOLCHAIN does not specify an existing directory.
+goto done
+
+:check_dir_exist_CC_LD_AR
+echo ERROR: TOOLCHAIN does not specify a valid toolchain directory.
+goto done
+
+:check_dir_exist_INCLUDE
+echo ERROR: INCLUDE does not specify an existing directory.
+goto done
+
+:check_dir_exist_LIBPATH
+echo ERROR: LIBPATH does not specify an existing directory.
+goto done
+
+:compilation_failed
+echo ERROR: Compilation failed.
+goto done
+
+:done
+pause

--- a/windowsce/make_windowsce8-armv7.bat
+++ b/windowsce/make_windowsce8-armv7.bat
@@ -1,0 +1,182 @@
+@echo off
+
+rem ***************************************************************************
+rem *                       VARIABLES TO SET FOR BUILDING                     *
+rem ***************************************************************************
+
+set WINCE_TOOLCHAIN_ROOT=C:\Windows_CE_Tools\SDKs\SDK_HW90270\Sdk
+set TOOLCHAIN=%WINCE_TOOLCHAIN_ROOT%\Bin\i386\Arm;%WINCE_TOOLCHAIN_ROOT%\Bin\i386
+set INCLUDE=%WINCE_TOOLCHAIN_ROOT%\Inc;%WINCE_TOOLCHAIN_ROOT%\crt\Include
+set LIBPATH=%WINCE_TOOLCHAIN_ROOT%\Lib\ARMV7\retail;%WINCE_TOOLCHAIN_ROOT%\Crt\Lib\ARM
+set LIBS=coredll.lib
+
+rem ***************************************************************************
+rem *                           CAPSTONE CONFIGURATION                        *
+rem ***************************************************************************
+
+set SHARED=1
+set DIET_MODE=0
+set X86_REDUCE=0
+set X86_ATT_DISABLE=0
+set USE_SYS_DYN_MEM=0
+set DISASM_ARCH_LIST=ARM ARM64 M68K MIPS POWERPC SPARC SYSZ X86 XCORE
+set DISASM_ARCH_DIRS=ARM AARCH64 M68K MIPS POWERPC SPARC SystemZ X86 XCORE
+rem set DISASM_ARCH_LIST=ARM
+rem set DISASM_ARCH_DIRS=ARM
+
+rem ***************************************************************************
+rem *                              SANITY CHECKS                              *
+rem ***************************************************************************
+
+setlocal ENABLEDELAYEDEXPANSION
+
+if "%WINCE_TOOLCHAIN_ROOT%"=="" goto check_dir_exist_WINCE_TOOLCHAIN_ROOT
+if not exist "%WINCE_TOOLCHAIN_ROOT%" goto check_dir_exist_WINCE_TOOLCHAIN_ROOT
+
+if "%TOOLCHAIN%"=="" goto check_dir_exist_TOOLCHAIN
+
+set CC=
+set LD=
+set AR=
+for /f "tokens=1-8 delims=;" %%a in ("%TOOLCHAIN%") do (
+  for %%i in (%%a %%b %%c %%d %%e %%f %%g %%h) do (
+    if not "%%i"=="" (
+      if not exist "%%i" goto check_dir_exist_TOOLCHAIN
+      if "%CC%"=="" if exist "%%i\cl.exe" set CC=%%i\cl.exe
+      if "%LD%"=="" if exist "%%i\link.exe" set LD=%%i\link.exe
+      if "%AR%"=="" if exist "%%i\lib.exe" set AR=%%i\lib.exe
+    )
+  )
+)
+
+if "%CC%"=="" goto check_dir_exist_CC_LD_AR
+if "%LD%"=="" goto check_dir_exist_CC_LD_AR
+if "%AR%"=="" goto check_dir_exist_CC_LD_AR
+
+if "%INCLUDE%"=="" goto check_dir_exist_INCLUDE
+
+set WINDOWS_H=
+
+set INCLUDE_SC=%INCLUDE%
+set INCLUDE=
+for /f "tokens=1-8 delims=;" %%a in ("%INCLUDE_SC%") do (
+  for %%i in ("%%a" "%%b" "%%c" "%%d" "%%e" "%%f" "%%g" "%%h") do (
+    if not %%i=="" (
+      set INCLUDE=!INCLUDE! -I %%i
+    )
+  )
+)
+
+if "%LIBPATH%"=="" goto check_dir_exist_LIBPATH
+
+set LIBPATH_SC=%LIBPATH%
+set LIBPATH=
+for /f "tokens=1-8 delims=;" %%a in ("%LIBPATH_SC%") do (
+  for %%i in ("%%a" "%%b" "%%c" "%%d" "%%e" "%%f" "%%g" "%%h") do (
+    if not %%i=="" (
+      set LIBPATH=!LIBPATH! -libpath:%%i
+    )
+  )
+)
+
+rem ***************************************************************************
+rem *                            COMPILATION OPTIONS                          *
+rem ***************************************************************************
+
+set OS=windowsce
+set OS_VERSION=8.0
+set OS_VERSION_NUMBER=0x800
+set LIBARCH=arm
+set MACH=ARM
+
+for /f "delims=" %%i in ('cd') do set THIS_DIR=%%i
+
+set SOURCES_ROOT=%THIS_DIR%\..
+set TARGET_DIR=%THIS_DIR%\bin\%OS%_%OS_VERSION%_%LIBARCH%
+
+for /f "tokens=3" %%i in ('findstr /c:"#define CS_API_MAJOR" "%SOURCES_ROOT%\include\capstone\capstone.h"') do set CS_API_MAJOR=%%i
+for /f "tokens=3" %%i in ('findstr /c:"#define CS_API_MINOR" "%SOURCES_ROOT%\include\capstone\capstone.h"') do set CS_API_MINOR=%%i
+
+set TARGET_VERSION=%CS_API_MAJOR%.%CS_API_MINOR%
+set TAREGET_NAME=capstone-%TARGET_VERSION%
+
+set CPPFLAGS=-D LIBARCH_%LIBARCH% -D LIBARCH=L\"%LIBARCH%\"
+set CPPFLAGS=%CPPFLAGS% -D _CRT_SECURE_NO_DEPRECATE -D _WINDOWS -D WINVER=%OS_VERSION_NUMBER% -D UNDER_CE=%OS_VERSION_NUMBER% -D _WIN32_WCE=%OS_VERSION_NUMBER% -D WINCE -D _UNICODE -D UNICODE -D STANDARDSHELL_UI_MODEL -D _USE_MATH_DEFINES -D ARM -D _ARM -D _ARM_ -D __ARM_ARCH_7__ -D __ARM_ARCH_7A__ -D __VFP_FP__=1
+
+for %%a in (%DISASM_ARCH_LIST%) do set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_HAS_%%a
+
+if %SHARED%==0 (
+  set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_STATIC -D LIB_EXT=L\".lib\"
+) else (
+  set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_SHARED -D LIB_EXT=L\".dll\"
+)
+
+if not %USE_SYS_DYN_MEM%==0 ( set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_USE_SYS_DYN_MEM )
+if not %DIET_MODE%==0 ( set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_DIET )
+if not %X86_REDUCE%==0 ( set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_X86_REDUCE )
+if not %X86_ATT_DISABLE%==0 ( set CPPFLAGS=!CPPFLAGS! -D CAPSTONE_X86_ATT_DISABLE )
+
+set INCLUDE=-I %SOURCES_ROOT%\include -I %SOURCES_ROOT% %INCLUDE%
+
+set CFLAGS=%CPPFLAGS% %INCLUDE% -nologo -MP -Zi -MT -Oi -GS -fp:fast -Oy- -W3 -WX
+
+set LDFLAGS=-nologo -debug -incremental:no -manifest:no -version:%TARGET_VERSION% -machine:%MACH% -subsystem:WINDOWSCE,%OS_VERSION% %LIBPATH% %LIBS%
+
+set ARFLAGS=-nologo -machine:%MACH% -subsystem:WINDOWSCE,%OS_VERSION% %LIBPATH% %LIBS%
+
+set SOURCES=
+for %%f in (%SOURCES_ROOT%\*.c) do set SOURCES=!SOURCES! %%f
+for %%a in (%DISASM_ARCH_DIRS%) do for %%f in (%SOURCES_ROOT%\arch\%%a\*.c) do set SOURCES=!SOURCES! %%f
+
+rem ***************************************************************************
+rem *                           COMPILATION COMMANDS                          *
+rem ***************************************************************************
+
+rd /q /s "%TARGET_DIR%"
+md "%TARGET_DIR%"
+
+set PATH=%TOOLCHAIN%;%PATH%
+
+rem %CC% -c %CFLAGS% -D DEBUG -D _DEBUG -Od -Fo"%TARGET_DIR%\\" -Fd"%TARGET_DIR%\%TAREGET_NAME%.pdb" %SOURCES%
+%CC% -c %CFLAGS% -D NDEBUG -Ox -Fo"%TARGET_DIR%\\" -Fd"%TARGET_DIR%\%TAREGET_NAME%.pdb" %SOURCES%
+if errorlevel 1 goto compilation_failed
+
+if %SHARED%==0 (
+  %AR% -out:%TARGET_DIR%\%TAREGET_NAME%.lib %ARFLAGS% %TARGET_DIR%\*.obj
+) else (
+  %LD% -dll -out:%TARGET_DIR%\%TAREGET_NAME%.dll -map:"%TARGET_DIR%\%TAREGET_NAME%.map" -pdb:"%TARGET_DIR%\%TAREGET_NAME%.pdb" %LDFLAGS% -opt:REF -opt:ICF %TARGET_DIR%\*.obj
+)
+
+endlocal
+goto done
+
+rem ***************************************************************************
+rem *                             ERROR REPORTING                             *
+rem ***************************************************************************
+
+:check_dir_exist_WINCE_TOOLCHAIN_ROOT
+echo ERROR: WINCE_TOOLCHAIN_ROOT does not specify an existing directory.
+goto done
+
+:check_dir_exist_TOOLCHAIN
+echo ERROR: TOOLCHAIN does not specify an existing directory.
+goto done
+
+:check_dir_exist_CC_LD_AR
+echo ERROR: TOOLCHAIN does not specify a valid toolchain directory.
+goto done
+
+:check_dir_exist_INCLUDE
+echo ERROR: INCLUDE does not specify an existing directory.
+goto done
+
+:check_dir_exist_LIBPATH
+echo ERROR: LIBPATH does not specify an existing directory.
+goto done
+
+:compilation_failed
+echo ERROR: Compilation failed.
+goto done
+
+:done
+pause

--- a/windowsce/make_windowsce8-armv7.bat
+++ b/windowsce/make_windowsce8-armv7.bat
@@ -16,13 +16,10 @@ rem ***************************************************************************
 
 set SHARED=1
 set DIET_MODE=0
+set USE_SYS_DYN_MEM=1
 set X86_REDUCE=0
 set X86_ATT_DISABLE=0
-set USE_SYS_DYN_MEM=0
 set DISASM_ARCH_LIST=ARM ARM64 M68K MIPS POWERPC SPARC SYSZ X86 XCORE
-set DISASM_ARCH_DIRS=ARM AARCH64 M68K MIPS POWERPC SPARC SystemZ X86 XCORE
-rem set DISASM_ARCH_LIST=ARM
-rem set DISASM_ARCH_DIRS=ARM
 
 rem ***************************************************************************
 rem *                              SANITY CHECKS                              *
@@ -126,7 +123,7 @@ set ARFLAGS=-nologo -machine:%MACH% -subsystem:WINDOWSCE,%OS_VERSION% %LIBPATH% 
 
 set SOURCES=
 for %%f in (%SOURCES_ROOT%\*.c) do set SOURCES=!SOURCES! %%f
-for %%a in (%DISASM_ARCH_DIRS%) do for %%f in (%SOURCES_ROOT%\arch\%%a\*.c) do set SOURCES=!SOURCES! %%f
+for /d %%a in (%SOURCES_ROOT%\arch\*) do for %%f in (%%a\*.c) do set SOURCES=!SOURCES! %%f
 
 rem ***************************************************************************
 rem *                           COMPILATION COMMANDS                          *


### PR DESCRIPTION
Added support for building binaries for:
- Windows CE 7 (a.k.a., [Windows Embedded Compact 7](https://www.microsoft.com/windowsembedded/en-us/windows-embedded-compact-7.aspx)) on [ARMv7](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0406c/index.html), and
- Windows CE 8 (a.k.a., [Windows Embedded Compact 2013](https://www.microsoft.com/windowsembedded/en-us/windows-embedded-compact-2013.aspx)) on [ARMv7](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0406c/index.html).