### PR TITLE
ignore VS2015 cache files and Debug|Release_WDK folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,12 +81,16 @@ packages/freebsd/ports/devel/capstone/distinfo
 
 # VisualStudio
 Debug/
+Debug_WDK/
 Release/
+Release_WDK/
 ipch/
 *.sdf
 *.opensdf
 *.suo
 *.user
+*.VC.db
+*.VC.opendb
 
 # Xcode
 xcode/Capstone.xcodeproj/xcuserdata


### PR DESCRIPTION
This changes is to ignore a couple of VS2015 cache files and output directories created when capstone_static project is compiled for a driver. 