### PR TITLE
replace stdint.h in API headers 

### DIFF
--- a/include/arm.h
+++ b/include/arm.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include "../myinttypes.h"
+#include <stdint.h>
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/arm64.h
+++ b/include/arm64.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include "../myinttypes.h"
+#include <stdint.h>
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/capstone.h
+++ b/include/capstone.h
@@ -8,8 +8,9 @@
 extern "C" {
 #endif
 
-#include "../myinttypes.h"
+#include <stdint.h>
 #include <stdarg.h>
+
 #if defined(CAPSTONE_HAS_OSXKERNEL)
 #include <libkern/libkern.h>
 #else

--- a/include/mips.h
+++ b/include/mips.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include "../myinttypes.h"
+#include <stdint.h>
 #include "platform.h"
 
 // GCC MIPS toolchain has a default macro called "mips" which breaks

--- a/include/ppc.h
+++ b/include/ppc.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include "../myinttypes.h"
+#include <stdint.h>
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/sparc.h
+++ b/include/sparc.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include "../myinttypes.h"
+#include <stdint.h>
 #include "platform.h"
 
 // GCC SPARC toolchain has a default macro called "sparc" which breaks

--- a/include/systemz.h
+++ b/include/systemz.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include "../myinttypes.h"
+#include <stdint.h>
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/x86.h
+++ b/include/x86.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include "../myinttypes.h"
+#include <stdint.h>
 
 // Calculate relative address for X86-64, given cs_insn structure
 #define X86_REL_ADDR(insn) (insn.address + insn.size + insn.detail->x86.disp)

--- a/include/xcore.h
+++ b/include/xcore.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include "../myinttypes.h"
+#include <stdint.h>
 #include "platform.h"
 
 #ifdef _MSC_VER


### PR DESCRIPTION
To fix an issue (I made), revert API headers to use stdint.h.
https://github.com/aquynh/capstone/commit/760940fdceb50a09f1a8ebee5dc807b6039f144e

This change breaks support of drivers obviously, but its impact will be nearly zero at this time. Sorry for this errors, I will work on a right fix after we have discussed a solution.