### PR TITLE
Move the contents of myinttyps.h to platform.h, and skip stdint.h when not avaialable

### DIFF
--- a/include/arm.h
+++ b/include/arm.h
@@ -8,7 +8,10 @@
 extern "C" {
 #endif
 
+#if !defined(_MSC_VER) || !defined(_KERNEL_MODE)
 #include <stdint.h>
+#endif
+
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/arm64.h
+++ b/include/arm64.h
@@ -8,7 +8,10 @@
 extern "C" {
 #endif
 
+#if !defined(_MSC_VER) || !defined(_KERNEL_MODE)
 #include <stdint.h>
+#endif
+
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/capstone.h
+++ b/include/capstone.h
@@ -8,7 +8,10 @@
 extern "C" {
 #endif
 
+#if !defined(_MSC_VER) || !defined(_KERNEL_MODE)
 #include <stdint.h>
+#endif
+
 #include <stdarg.h>
 
 #if defined(CAPSTONE_HAS_OSXKERNEL)

--- a/include/mips.h
+++ b/include/mips.h
@@ -8,7 +8,10 @@
 extern "C" {
 #endif
 
+#if !defined(_MSC_VER) || !defined(_KERNEL_MODE)
 #include <stdint.h>
+#endif
+
 #include "platform.h"
 
 // GCC MIPS toolchain has a default macro called "mips" which breaks

--- a/include/platform.h
+++ b/include/platform.h
@@ -1,15 +1,16 @@
 /* Capstone Disassembly Engine */
 /* By Axel Souchet & Nguyen Anh Quynh, 2014 */
 
-// handle C99 issue (for pre-2013 VisualStudio)
 #ifndef CAPSTONE_PLATFORM_H
 #define CAPSTONE_PLATFORM_H
 
+// handle C99 issue (for pre-2013 VisualStudio)
 #if !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__) && (defined (WIN32) || defined (WIN64) || defined (_WIN32) || defined (_WIN64))
 // MSVC
 
 // stdbool.h
 #if (_MSC_VER < 1800) || defined(_KERNEL_MODE)
+// this system does not have inttypes.h
 #ifndef __cplusplus
 typedef unsigned char bool;
 #define false 0
@@ -21,8 +22,70 @@ typedef unsigned char bool;
 #include <stdbool.h>
 #endif
 
-#else // not MSVC -> C99 is supported
+#else 
+// not MSVC -> C99 is supported
 #include <stdbool.h>
+#endif
+
+
+// handle C99 issue (for pre-2013 VisualStudio)
+#if defined(CAPSTONE_HAS_OSXKERNEL) || (defined(_MSC_VER) && (_MSC_VER <= 1700 || defined(_KERNEL_MODE)))
+// this system does not have inttypes.h
+
+#if defined(_MSC_VER) && (_MSC_VER <= 1700 || defined(_KERNEL_MODE))
+typedef signed char  int8_t;
+typedef signed short int16_t;
+typedef signed int   int32_t;
+typedef unsigned char  uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int   uint32_t;
+typedef signed long long   int64_t;
+typedef unsigned long long uint64_t;
+#endif
+
+#define __PRI_8_LENGTH_MODIFIER__ "hh"
+#define __PRI_64_LENGTH_MODIFIER__ "ll"
+
+#define PRId8         __PRI_8_LENGTH_MODIFIER__ "d"
+#define PRIi8         __PRI_8_LENGTH_MODIFIER__ "i"
+#define PRIo8         __PRI_8_LENGTH_MODIFIER__ "o"
+#define PRIu8         __PRI_8_LENGTH_MODIFIER__ "u"
+#define PRIx8         __PRI_8_LENGTH_MODIFIER__ "x"
+#define PRIX8         __PRI_8_LENGTH_MODIFIER__ "X"
+
+#define PRId16        "hd"
+#define PRIi16        "hi"
+#define PRIo16        "ho"
+#define PRIu16        "hu"
+#define PRIx16        "hx"
+#define PRIX16        "hX"
+
+#if defined(_MSC_VER) && _MSC_VER <= 1700
+#define PRId32        "ld"
+#define PRIi32        "li"
+#define PRIo32        "lo"
+#define PRIu32        "lu"
+#define PRIx32        "lx"
+#define PRIX32        "lX"
+#else	// OSX
+#define PRId32        "d"
+#define PRIi32        "i"
+#define PRIo32        "o"
+#define PRIu32        "u"
+#define PRIx32        "x"
+#define PRIX32        "X"
+#endif
+
+#define PRId64        __PRI_64_LENGTH_MODIFIER__ "d"
+#define PRIi64        __PRI_64_LENGTH_MODIFIER__ "i"
+#define PRIo64        __PRI_64_LENGTH_MODIFIER__ "o"
+#define PRIu64        __PRI_64_LENGTH_MODIFIER__ "u"
+#define PRIx64        __PRI_64_LENGTH_MODIFIER__ "x"
+#define PRIX64        __PRI_64_LENGTH_MODIFIER__ "X"
+
+#else
+// this system has inttypes.h by default
+#include <inttypes.h>
 #endif
 
 #endif

--- a/include/ppc.h
+++ b/include/ppc.h
@@ -8,7 +8,10 @@
 extern "C" {
 #endif
 
+#if !defined(_MSC_VER) || !defined(_KERNEL_MODE)
 #include <stdint.h>
+#endif
+
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/sparc.h
+++ b/include/sparc.h
@@ -8,7 +8,10 @@
 extern "C" {
 #endif
 
+#if !defined(_MSC_VER) || !defined(_KERNEL_MODE)
 #include <stdint.h>
+#endif
+
 #include "platform.h"
 
 // GCC SPARC toolchain has a default macro called "sparc" which breaks

--- a/include/systemz.h
+++ b/include/systemz.h
@@ -8,7 +8,10 @@
 extern "C" {
 #endif
 
+#if !defined(_MSC_VER) || !defined(_KERNEL_MODE)
 #include <stdint.h>
+#endif
+
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/include/x86.h
+++ b/include/x86.h
@@ -8,7 +8,9 @@
 extern "C" {
 #endif
 
+#if !defined(_MSC_VER) || !defined(_KERNEL_MODE)
 #include <stdint.h>
+#endif
 
 // Calculate relative address for X86-64, given cs_insn structure
 #define X86_REL_ADDR(insn) (insn.address + insn.size + insn.detail->x86.disp)

--- a/include/xcore.h
+++ b/include/xcore.h
@@ -8,7 +8,10 @@
 extern "C" {
 #endif
 
+#if !defined(_MSC_VER) || !defined(_KERNEL_MODE)
 #include <stdint.h>
+#endif
+
 #include "platform.h"
 
 #ifdef _MSC_VER

--- a/msvc/capstone_static/capstone_static.vcxproj
+++ b/msvc/capstone_static/capstone_static.vcxproj
@@ -194,7 +194,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE;CAPSTONE_DIET;CAPSTONE_X86_REDUCE;CAPSTONE_HAS_X86;CAPSTONE_USE_SYS_DYN_MEM;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -210,7 +210,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE;CAPSTONE_DIET;CAPSTONE_X86_REDUCE;CAPSTONE_HAS_X86;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -229,7 +229,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE;CAPSTONE_DIET;CAPSTONE_X86_REDUCE;CAPSTONE_HAS_X86;CAPSTONE_USE_SYS_DYN_MEM;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -245,7 +245,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE;CAPSTONE_DIET;CAPSTONE_X86_REDUCE;CAPSTONE_HAS_X86;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -266,7 +266,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE;CAPSTONE_DIET;CAPSTONE_X86_REDUCE;CAPSTONE_HAS_X86;CAPSTONE_USE_SYS_DYN_MEM;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -286,7 +286,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE;CAPSTONE_DIET;CAPSTONE_X86_REDUCE;CAPSTONE_HAS_X86;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>
@@ -308,7 +308,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE;CAPSTONE_DIET;CAPSTONE_X86_REDUCE;CAPSTONE_HAS_X86;CAPSTONE_USE_SYS_DYN_MEM;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -328,7 +328,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE;CAPSTONE_DIET;CAPSTONE_X86_REDUCE;CAPSTONE_HAS_X86;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>

--- a/myinttypes.h
+++ b/myinttypes.h
@@ -4,62 +4,7 @@
 #ifndef CS_MYINTTYPES_H
 #define CS_MYINTTYPES_H
 
-#if defined(CAPSTONE_HAS_OSXKERNEL) || (defined(_MSC_VER) && (_MSC_VER <= 1700 || defined(_KERNEL_MODE)))
-// this system does not have inttypes.h
-
-#if defined(_MSC_VER) && (_MSC_VER <= 1700 || defined(_KERNEL_MODE))
-typedef signed char  int8_t;
-typedef signed short int16_t;
-typedef signed int   int32_t;
-typedef unsigned char  uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int   uint32_t;
-typedef signed long long   int64_t;
-typedef unsigned long long uint64_t;
-#endif
-
-#define __PRI_8_LENGTH_MODIFIER__ "hh"
-#define __PRI_64_LENGTH_MODIFIER__ "ll"
-
-#define PRId8         __PRI_8_LENGTH_MODIFIER__ "d"
-#define PRIi8         __PRI_8_LENGTH_MODIFIER__ "i"
-#define PRIo8         __PRI_8_LENGTH_MODIFIER__ "o"
-#define PRIu8         __PRI_8_LENGTH_MODIFIER__ "u"
-#define PRIx8         __PRI_8_LENGTH_MODIFIER__ "x"
-#define PRIX8         __PRI_8_LENGTH_MODIFIER__ "X"
-
-#define PRId16        "hd"
-#define PRIi16        "hi"
-#define PRIo16        "ho"
-#define PRIu16        "hu"
-#define PRIx16        "hx"
-#define PRIX16        "hX"
-
-#if defined(_MSC_VER) && _MSC_VER <= 1700
-#define PRId32        "ld"
-#define PRIi32        "li"
-#define PRIo32        "lo"
-#define PRIu32        "lu"
-#define PRIx32        "lx"
-#define PRIX32        "lX"
-#else	// OSX
-#define PRId32        "d"
-#define PRIi32        "i"
-#define PRIo32        "o"
-#define PRIu32        "u"
-#define PRIx32        "x"
-#define PRIX32        "X"
-#endif
-
-#define PRId64        __PRI_64_LENGTH_MODIFIER__ "d"
-#define PRIi64        __PRI_64_LENGTH_MODIFIER__ "i"
-#define PRIo64        __PRI_64_LENGTH_MODIFIER__ "o"
-#define PRIu64        __PRI_64_LENGTH_MODIFIER__ "u"
-#define PRIx64        __PRI_64_LENGTH_MODIFIER__ "x"
-#define PRIX64        __PRI_64_LENGTH_MODIFIER__ "X"
-
-#else	// this system has inttypes.h by default
-#include <inttypes.h>
-#endif
+// The contents of myinttype.h are moved to platform.h
+#include <platform.h>
 
 #endif


### PR DESCRIPTION
This update is for supporting windows driver configuration where `stdint.h` and `inttyps.h` are not available. This update allows MSVC with Windows Driver Kit (WDK) to skip `stdint.h` but use necessary definitions through `platform.h`. 

I did not delete the `myinttypes.h` file as its impact would be large and there would be a greater change of breaking things if I deleted it.