### PR TITLE
__getattr__ should raise AttributeError, not return None, on failure

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -567,12 +567,12 @@ class CsInsn(object):
 
         attr = object.__getattribute__
         if not attr(self, '_cs')._detail:
-            return None
+            raise AttributeError(name)
         _dict = attr(self, '__dict__')
         if 'operands' not in _dict:
             self.__gen_detail()
         if name not in _dict:
-            return None
+            raise AttributeError(name)
         return _dict[name]
 
     # get the last error code


### PR DESCRIPTION
Fix for issue #634