### PR TITLE
x86: initialize eaDisplacement in 16-bit mode.  Fixes #656

### DIFF
--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -1646,6 +1646,7 @@ static int readModRM(struct InternalInstruction *insn)
 					break;
 				case 0x3:
 					insn->eaBase = (EABase)(insn->eaRegBase + rm);
+					insn->eaDisplacement = EA_DISP_NONE;
 					if (readDisplacement(insn))
 						return -1;
 					break;


### PR DESCRIPTION
Per discussion on #656. Please check carefully - I'm not by any means an expert on x86 instruction encoding, or capstone. 