### PR TITLE
Fix generated library name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
 script:
         - ./make.sh
         - make check
-        - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cp libcapstone.so bindings/python/; fi
-        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp libcapstone.dylib bindings/python/; fi
+        - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cp libcapstone.so.* bindings/python/libcapstone.so; fi
+        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp libcapstone.*.dylib bindings/python/libcapstone.dylib; fi
         - cd bindings/python && make check
 compiler:
         - clang

--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ ifeq ($(CAPSTONE_SHARED),yes)
 	$(INSTALL_LIB) $(LIBRARY) $(DESTDIR)/$(LIBDIR)
 ifneq ($(VERSION_EXT),)
 	cd $(DESTDIR)/$(LIBDIR) && \
-	mv lib$(LIBNAME).$(EXT) lib$(LIBNAME).$(VERSION_EXT) && \
+	rm -f lib$(LIBNAME).$(EXT) && \
 	ln -s lib$(LIBNAME).$(VERSION_EXT) lib$(LIBNAME).$(EXT)
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -330,11 +330,11 @@ endif
 
 ifeq ($(CAPSTONE_SHARED),yes)
 ifeq ($(IS_MINGW),1)
-LIBRARY = $(BLDIR)/$(LIBNAME).$(EXT)
+LIBRARY = $(BLDIR)/$(LIBNAME).$(VERSION_EXT)
 else ifeq ($(IS_CYGWIN),1)
-LIBRARY = $(BLDIR)/$(LIBNAME).$(EXT)
+LIBRARY = $(BLDIR)/$(LIBNAME).$(VERSION_EXT)
 else	# *nix
-LIBRARY = $(BLDIR)/lib$(LIBNAME).$(EXT)
+LIBRARY = $(BLDIR)/lib$(LIBNAME).$(VERSION_EXT)
 CFLAGS += -fvisibility=hidden
 endif
 endif


### PR DESCRIPTION
The build script currently generates library as libcapstone.so. But the name given to the library is libcapstone.so.4. I think it is better to generate a library with the same file name as the given library name to avoid any confusion.

This also helps when you do not install the library system-wide but set LD_LIBRARY_PATH to the capstone directory. In such cases, we look for libcapstone.so.<version> and will not find it.