### PR TITLE
Properly exit on python test failure

### DIFF
--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -132,6 +132,6 @@ TESTS += test_ppc.py test_sparc.py test_systemz.py test_x86.py test_xcore.py tes
 check:
 	@for t in $(TESTS); do \
 		echo Check $$t ... ; \
-		./$$t > /dev/null && echo OK || echo FAILED; \
+		./$$t > /dev/null && echo OK || (echo FAILED; exit 1;) \
 	done
 


### PR DESCRIPTION
Currently, if python tests fails, we still report that build succeeded. For example, see: https://travis-ci.org/aquynh/capstone/jobs/126903560#L328

This failure should not be reported  as success. Fix this by returning non-zero value from Makefile. It will now fail as expected. For example, see: https://travis-ci.org/pranith/capstone/jobs/126907904#L413