### PR TITLE
Add MIPS_GRP_INT and MIPS_GRP_CALL

### DIFF
--- a/arch/Mips/MipsMapping.c
+++ b/arch/Mips/MipsMapping.c
@@ -902,6 +902,9 @@ static name_map group_name_maps[] = {
 	// generic groups
 	{ MIPS_GRP_INVALID, NULL },
 	{ MIPS_GRP_JUMP, "jump" },
+	{ MIPS_GRP_CALL, "call" },
+	{ MIPS_GRP_RET, "ret" },
+	{ MIPS_GRP_INT, "int" },
 
 	// architecture-specific groups
 	{ MIPS_GRP_BITCOUNT, "bitcount" },

--- a/arch/Mips/MipsMapping.c
+++ b/arch/Mips/MipsMapping.c
@@ -905,6 +905,8 @@ static name_map group_name_maps[] = {
 	{ MIPS_GRP_CALL, "call" },
 	{ MIPS_GRP_RET, "ret" },
 	{ MIPS_GRP_INT, "int" },
+	{ MIPS_GRP_IRET, "iret" },
+	{ MIPS_GRP_PRIVILEGE, "privileged" },
 
 	// architecture-specific groups
 	{ MIPS_GRP_BITCOUNT, "bitcount" },

--- a/arch/Mips/MipsMappingInsn.inc
+++ b/arch/Mips/MipsMappingInsn.inc
@@ -4720,43 +4720,43 @@
 {
 	Mips_JALR, MIPS_INS_JALR,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_STDENC, MIPS_GRP_NOTINMICROMIPS, 0 }, 0, 0
+	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_STDENC, MIPS_GRP_NOTINMICROMIPS, MIPS_GRP_CALL, 0 }, 0, 0
 #endif
 },
 {
 	Mips_JALR16_MM, MIPS_INS_JALR,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_MICROMIPS, 0 }, 0, 0
+	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_MICROMIPS, MIPS_GRP_CALL, 0 }, 0, 0
 #endif
 },
 {
 	Mips_JALR64, MIPS_INS_JALR,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_STDENC, 0 }, 0, 0
+	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_STDENC, MIPS_GRP_CALL, 0 }, 0, 0
 #endif
 },
 {
 	Mips_JALRS16_MM, MIPS_INS_JALRS16,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_MICROMIPS, 0 }, 0, 0
+	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_MICROMIPS, MIPS_GRP_CALL, 0 }, 0, 0
 #endif
 },
 {
 	Mips_JALRS_MM, MIPS_INS_JALRS,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_MICROMIPS, 0 }, 0, 0
+	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_MICROMIPS, MIPS_GRP_CALL, 0 }, 0, 0
 #endif
 },
 {
 	Mips_JALR_HB, MIPS_INS_JALR_HB,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { MIPS_GRP_STDENC, MIPS_GRP_MIPS32, 0 }, 0, 1
+	{ 0 }, { 0 }, { MIPS_GRP_STDENC, MIPS_GRP_MIPS32, MIPS_GRP_CALL, 0 }, 0, 1
 #endif
 },
 {
 	Mips_JALR_MM, MIPS_INS_JALR,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_MICROMIPS, 0 }, 0, 0
+	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_MICROMIPS, MIPS_GRP_CALL, 0 }, 0, 0
 #endif
 },
 {
@@ -4876,7 +4876,7 @@
 {
 	Mips_JumpLinkReg16, MIPS_INS_JALRC,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_MIPS16MODE, 0 }, 0, 0
+	{ 0 }, { MIPS_REG_RA, 0 }, { MIPS_GRP_MIPS16MODE, MIPS_GRP_CALL, 0 }, 0, 0
 #endif
 },
 {
@@ -8812,13 +8812,13 @@
 {
 	Mips_SYSCALL, MIPS_INS_SYSCALL,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { MIPS_GRP_STDENC, 0 }, 0, 0
+	{ 0 }, { 0 }, { MIPS_GRP_STDENC, MIPS_GRP_INT, 0 }, 0, 0
 #endif
 },
 {
 	Mips_SYSCALL_MM, MIPS_INS_SYSCALL,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { MIPS_GRP_MICROMIPS, 0 }, 0, 0
+	{ 0 }, { 0 }, { MIPS_GRP_MICROMIPS, MIPS_GRP_INT, 0 }, 0, 0
 #endif
 },
 {

--- a/bindings/java/capstone/Mips_const.java
+++ b/bindings/java/capstone/Mips_const.java
@@ -844,6 +844,11 @@ public class Mips_const {
 
 	// Generic groups
 	public static final int MIPS_GRP_JUMP = 1;
+	public static final int MIPS_GRP_CALL = 2;
+	public static final int MIPS_GRP_RET = 3;
+	public static final int MIPS_GRP_INT = 4;
+	public static final int MIPS_GRP_IRET = 5;
+	public static final int MIPS_GRP_PRIVILEGE = 6;
 
 	// Architecture-specific groups
 	public static final int MIPS_GRP_BITCOUNT = 128;

--- a/bindings/ocaml/mips_const.ml
+++ b/bindings/ocaml/mips_const.ml
@@ -841,6 +841,11 @@ let _MIPS_GRP_INVALID = 0;;
 
 (* Generic groups *)
 let _MIPS_GRP_JUMP = 1;;
+let _MIPS_GRP_CALL = 2;;
+let _MIPS_GRP_RET = 3;;
+let _MIPS_GRP_INT = 4;;
+let _MIPS_GRP_IRET = 5;;
+let _MIPS_GRP_PRIVILEGE = 6;;
 
 (* Architecture-specific groups *)
 let _MIPS_GRP_BITCOUNT = 128;;

--- a/bindings/python/capstone/mips_const.py
+++ b/bindings/python/capstone/mips_const.py
@@ -841,6 +841,11 @@ MIPS_GRP_INVALID = 0
 
 # Generic groups
 MIPS_GRP_JUMP = 1
+MIPS_GRP_CALL = 2
+MIPS_GRP_RET = 3
+MIPS_GRP_INT = 4
+MIPS_GRP_IRET = 5
+MIPS_GRP_PRIVILEGE = 6
 
 # Architecture-specific groups
 MIPS_GRP_BITCOUNT = 128

--- a/include/capstone/mips.h
+++ b/include/capstone/mips.h
@@ -898,6 +898,16 @@ typedef enum mips_insn_group {
 	//> Generic groups
 	// all jump instructions (conditional+direct+indirect jumps)
 	MIPS_GRP_JUMP,	// = CS_GRP_JUMP
+	// all call instructions
+	MIPS_GRP_CALL,	// = CS_GRP_CALL
+	// all return instructions
+	MIPS_GRP_RET,	// = CS_GRP_RET
+	// all interrupt instructions (int+syscall)
+	MIPS_GRP_INT,	// = CS_GRP_INT
+	// all interrupt return instructions
+	MIPS_GRP_IRET,	// = CS_GRP_IRET
+	// all privileged instructions
+	MIPS_GRP_PRIVILEGE,	// = CS_GRP_PRIVILEGE
 
 	//> Architecture-specific groups
 	MIPS_GRP_BITCOUNT = 128,

--- a/suite/test_group_name.py
+++ b/suite/test_group_name.py
@@ -83,6 +83,11 @@ arm64_dict = {
 
 mips_dict = {
     MIPS_GRP_JUMP: "jump",
+    MIPS_GRP_CALL: "call",
+    MIPS_GRP_RET: "ret",
+    MIPS_GRP_INT: "int",
+    MIPS_GRP_IRET: "iret",
+    MIPS_GRP_PRIVILEGE: "privilege",
     MIPS_GRP_BITCOUNT: "bitcount",
     MIPS_GRP_DSP: "dsp",
     MIPS_GRP_DSPR2: "dspr2",


### PR DESCRIPTION
Also annotates the `jalr` and `syscall` instructions to have these groups.

Since I was adding these two generic groups, I added all of the generic groups.