### PR TITLE
Reduced confusion caused by the m68k test being out of date

### DIFF
--- a/bindings/python/test_m68k.py
+++ b/bindings/python/test_m68k.py
@@ -50,19 +50,9 @@ def print_insn_detail(insn):
     for i, op in enumerate(insn.operands):
         if op.type == M68K_OP_REG:
             print("\t\toperands[%u].type: REG = %s" % (i, insn.reg_name(op.reg)))
-
-        if op.type == M68K_OP_IMM:
-            if insn.op_size.type == M68K_SIZE_TYPE_FPU:
-                if insn.op_size.size == M68K_FPU_SIZE_SINGLE:
-                    print("\t\toperands[%u].type: IMM = %f" % (i, op.simm))
-                elif insn.op_size.size == M68K_FPU_SIZE_DOUBLE:
-                    print("\t\toperands[%u].type: IMM = %lf" % (i, op.dimm))
-                else:
-                    print("\t\toperands[%u].type: IMM = <unsupported>" % (i))
-                continue
+        elif op.type == M68K_OP_IMM:
             print("\t\toperands[%u].type: IMM = 0x%x" % (i, op.imm & 0xffffffff))
-
-        if op.type == M68K_OP_MEM:
+        elif op.type == M68K_OP_MEM:
             print("\t\toperands[%u].type: MEM" % (i))
             if op.mem.base_reg != M68K_REG_INVALID:
                 print("\t\t\toperands[%u].mem.base: REG = %s" % (i, insn.reg_name(op.mem.base_reg)))
@@ -77,6 +67,12 @@ def print_insn_detail(insn):
             if op.mem.scale != 0:
                 print("\t\t\toperands[%u].mem.scale: %d" % (i, op.mem.scale))
             print("\t\taddress mode: %s" % (s_addressing_modes[op.address_mode]))
+        elif op.type == M68K_OP_FP_SINGLE:
+            print("\t\toperands[%u].type: FP_SINGLE" % i)
+            print("\t\ŧ\toperands[%u].simm: %f", i, op.simm)
+        elif op.type == M68K_OP_FP_DOUBLE:
+            print("\t\toperands[%u].type: FP_DOUBLE" % i)
+            print("\t\ŧ\toperands[%u].dimm: %lf", i, op.dimm)
     print()
 
 # ## Test class Cs

--- a/tests/test_m68k.c
+++ b/tests/test_m68k.c
@@ -115,6 +115,10 @@ static void print_insn_detail(cs_insn *ins)
 
 				printf("\t\taddress mode: %s\n", s_addressing_modes[op->address_mode]);
 				break;
+			case M68K_OP_FP_SINGLE:
+				printf("\t\toperands[%u].type: FP_SINGLE\n", i);
+				printf("\t\t\toperands[%u].simm: %f\n", i, op->simm);
+				break;
 		}
 	}
 

--- a/tests/test_m68k.c
+++ b/tests/test_m68k.c
@@ -85,16 +85,6 @@ static void print_insn_detail(cs_insn *ins)
 				printf("\t\toperands[%u].type: REG = %s\n", i, cs_reg_name(handle, op->reg));
 				break;
 			case M68K_OP_IMM:
-				if (m68k->op_size.type == M68K_SIZE_TYPE_FPU) {
-					if (m68k->op_size.fpu_size == M68K_FPU_SIZE_SINGLE)
-						printf("\t\toperands[%u].type: IMM = %f\n", i, op->simm);
-					else if (m68k->op_size.fpu_size == M68K_FPU_SIZE_DOUBLE)
-						printf("\t\toperands[%u].type: IMM = %lf\n", i, op->dimm);
-					else
-						printf("\t\toperands[%u].type: IMM = <unsupported>\n", i);
-					break;
-				}
-
 				printf("\t\toperands[%u].type: IMM = 0x%x\n", i, (int)op->imm);
 				break;
 			case M68K_OP_MEM:
@@ -118,6 +108,10 @@ static void print_insn_detail(cs_insn *ins)
 			case M68K_OP_FP_SINGLE:
 				printf("\t\toperands[%u].type: FP_SINGLE\n", i);
 				printf("\t\t\toperands[%u].simm: %f\n", i, op->simm);
+				break;
+			case M68K_OP_FP_DOUBLE:
+				printf("\t\toperands[%u].type: FP_DOUBLE\n", i);
+				printf("\t\t\toperands[%u].dimm: %lf\n", i, op->dimm);
 				break;
 		}
 	}


### PR DESCRIPTION
* added a new case branch to account for floating point operands.

As mentioned in #677, the `m68k` tests broke (although it isn't clear what exactly caused that).
This pull request fixes this in a trivial manner, which appears right to me. 