### PR TITLE
fix #681

### DIFF
--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -1037,7 +1037,12 @@ static void printFPImmOperand(MCInst *MI, unsigned OpNum, SStream *O)
 	double FPImm = MCOperand_isFPImm(MO) ? MCOperand_getFPImm(MO) : AArch64_AM_getFPImmFloat((int)MCOperand_getImm(MO));
 
 	// 8 decimal places are enough to perfectly represent permitted floats.
+#if defined(_KERNEL_MODE)
+	// Issue #681: Windows kernel does not support formatting float point
+	SStream_concat(O, "#<float_point_unsupported>");
+#else
 	SStream_concat(O, "#%.8f", FPImm);
+#endif
 	if (MI->csh->detail) {
 		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].type = ARM64_OP_FP;
 		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].fp = FPImm;

--- a/arch/ARM/ARMInstPrinter.c
+++ b/arch/ARM/ARMInstPrinter.c
@@ -2103,7 +2103,13 @@ static void printT2AddrModeSoRegOperand(MCInst *MI,
 static void printFPImmOperand(MCInst *MI, unsigned OpNum, SStream *O)
 {
 	MCOperand *MO = MCInst_getOperand(MI, OpNum);
+
+#if defined(_KERNEL_MODE)
+	// Issue #681: Windows kernel does not support formatting float point
+	SStream_concat(O, "#<float_point_unsupported>");
+#else
 	SStream_concat(O, "#%e", getFPImmFloat((unsigned int)MCOperand_getImm(MO)));
+#endif
 	if (MI->csh->detail) {
 		MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].type = ARM_OP_FP;
 		MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].fp = getFPImmFloat((unsigned int)MCOperand_getImm(MO));

--- a/cs.c
+++ b/cs.c
@@ -21,6 +21,21 @@
 #include "windows\winkernel_mm.h"
 #endif
 
+// Issue #681: Windows kernel does not support formatting float point
+#if defined(_KERNEL_MODE) && !defined(CAPSTONE_DIET)
+#if defined(CAPSTONE_HAS_ARM) || defined(CAPSTONE_HAS_ARM64)
+#define CAPSTONE_STR_INTERNAL(x) #x
+#define CAPSTONE_STR(x) CAPSTONE_STR_INTERNAL(x)
+#define CAPSTONE_MSVC_WRANING_PREFIX __FILE__ "("CAPSTONE_STR(__LINE__)") : warning message : "
+
+#pragma message(CAPSTONE_MSVC_WRANING_PREFIX "Windows driver does not support full features for selected architecture(s). Define CAPSTONE_DIET to compile Capstone with only supported features. See issue #681 for details.")
+
+#undef CAPSTONE_MSVC_WRANING_PREFIX
+#undef CAPSTONE_STR
+#undef CAPSTONE_STR_INTERNAL
+#endif
+#endif	// defined(_KERNEL_MODE) && !defined(CAPSTONE_DIET)
+
 #if !defined(CAPSTONE_HAS_OSXKERNEL) && !defined(CAPSTONE_DIET) && !defined(_KERNEL_MODE)
 #define INSN_CACHE_SIZE 32
 #else

--- a/tests/test_arm.c
+++ b/tests/test_arm.c
@@ -56,7 +56,12 @@ static void print_insn_detail(cs_insn *ins)
 				printf("\t\toperands[%u].type: IMM = 0x%x\n", i, op->imm);
 				break;
 			case ARM_OP_FP:
+#if defined(_KERNEL_MODE)
+				// Issue #681: Windows kernel does not support formatting float point
+				printf("\t\toperands[%u].type: FP = <float_point_unsupported>\n", i);
+#else
 				printf("\t\toperands[%u].type: FP = %f\n", i, op->fp);
+#endif
 				break;
 			case ARM_OP_MEM:
 				printf("\t\toperands[%u].type: MEM\n", i);

--- a/tests/test_arm64.c
+++ b/tests/test_arm64.c
@@ -54,7 +54,12 @@ static void print_insn_detail(cs_insn *ins)
 				printf("\t\toperands[%u].type: IMM = 0x%" PRIx64 "\n", i, op->imm);
 				break;
 			case ARM64_OP_FP:
+#if defined(_KERNEL_MODE)
+				// Issue #681: Windows kernel does not support formatting float point
+				printf("\t\toperands[%u].type: FP = <float_point_unsupported>\n", i);
+#else
 				printf("\t\toperands[%u].type: FP = %f\n", i, op->fp);
+#endif
 				break;
 			case ARM64_OP_MEM:
 				printf("\t\toperands[%u].type: MEM\n", i);


### PR DESCRIPTION
Fixes #681. 

With this update, affected code starts formating flot points to a string including "<float_point_unsupported>". Also, in order to inform a developer about this issue, Visual Studio generates a warning like below when cs.c is compiled with affected configuration.

```
1>  cs.c
1>..\..\cs.c(31): warning message: Windows driver does not support full features for selected architecture(s). Define CAPSTONE_DIET to compile Capstone with only supported features. See issue #681 for details.
```
![untitled](https://cloud.githubusercontent.com/assets/1620923/15294856/d0ac6640-1b42-11e6-9631-f6070c3468d9.png)


test_arm_regression.c and test_iter_benchmark.c are unchanged because they are not affected by this issue since they are not compiled as part of Windows drivers. 

Beware that this is not essentially a fix and we will have to take care of any new code using %f, %e etc in the same manner.

I will apply the same fix to PR #680 for the next branch once this update is confirmed to be fine.
