### PR TITLE
[M68K] Implemented regs read/write lists

### DIFF
--- a/arch/M68K/M68KDisassembler.h
+++ b/arch/M68K/M68KDisassembler.h
@@ -17,6 +17,10 @@ typedef struct m68k_info {
 	unsigned int type;
 	unsigned int address_mask; /* Address mask to simulate address lines */
 	cs_m68k extension;
+	uint16_t regs_read[12]; // list of implicit registers read by this insn
+	uint8_t regs_read_count; // number of implicit registers read by this insn
+	uint16_t regs_write[20]; // list of implicit registers modified by this insn
+	uint8_t regs_write_count; // number of implicit registers modified by this insn
 	uint8_t groups[8];
 	uint8_t groups_count;
 } m68k_info;

--- a/arch/M68K/M68KInstPrinter.c
+++ b/arch/M68K/M68KInstPrinter.c
@@ -233,6 +233,9 @@ void printAddressingMode(SStream* O, const cs_m68k* inst, const cs_m68k_op* op)
 }
 #endif
 
+#define m68k_sizeof_array(array) (int)(sizeof(array)/sizeof(array[0]))
+#define m68k_min(a, b) (a < b) ? a : b
+
 void M68K_printInst(MCInst* MI, SStream* O, void* PrinterInfo)
 {
 #ifndef CAPSTONE_DIET
@@ -243,11 +246,20 @@ void M68K_printInst(MCInst* MI, SStream* O, void* PrinterInfo)
 
 	detail = MI->flat_insn->detail;
 	if (detail) {
+		int regs_read_count = m68k_min(m68k_sizeof_array(detail->regs_read), info->regs_read_count);
+		int regs_write_count = m68k_min(m68k_sizeof_array(detail->regs_write), info->regs_write_count);
+		int groups_count = m68k_min(m68k_sizeof_array(detail->groups), info->groups_count);
+
 		memcpy(&detail->m68k, ext, sizeof(cs_m68k));
-		memcpy(&detail->groups, &info->groups, info->groups_count);
-		detail->groups_count = info->groups_count;
-		detail->regs_read_count = 0;
-		detail->regs_write_count = 0;
+
+		memcpy(&detail->regs_read, &info->regs_read, regs_read_count * sizeof(uint16_t));
+		detail->regs_read_count = regs_read_count;
+
+		memcpy(&detail->regs_write, &info->regs_write, regs_write_count * sizeof(uint16_t));
+		detail->regs_write_count = regs_write_count;
+
+		memcpy(&detail->groups, &info->groups, groups_count);
+		detail->groups_count = groups_count;
 	}
 
 	if (MI->Opcode == M68K_INS_INVALID) {

--- a/bindings/python/test_m68k.py
+++ b/bindings/python/test_m68k.py
@@ -6,7 +6,7 @@ from capstone import *
 from capstone.m68k import *
 from xprint import to_hex, to_x
 
-M68K_CODE = b"\xd4\x40\x87\x5a\x4e\x71\x02\xb4\xc0\xde\xc0\xde\x5c\x00\x1d\x80\x71\x12\x01\x23\xf2\x3c\x44\x22\x40\x49\x0e\x56\x54\xc5\xf2\x3c\x44\x00\x44\x7a\x00\x00\xf2\x00\x0a\x28\x4E\xB9\x00\x00\x00\x12\x4E\x75"
+M68K_CODE = b"\x4c\x00\x54\x04\x48\xe7\xe0\x30\x4c\xdf\x0c\x07\xd4\x40\x87\x5a\x4e\x71\x02\xb4\xc0\xde\xc0\xde\x5c\x00\x1d\x80\x71\x12\x01\x23\xf2\x3c\x44\x22\x40\x49\x0e\x56\x54\xc5\xf2\x3c\x44\x00\x44\x7a\x00\x00\xf2\x00\x0a\x28\x4e\xb9\x00\x00\x00\x12\x4e\x75"
 
 all_tests = (
         (CS_ARCH_M68K, CS_MODE_BIG_ENDIAN | CS_MODE_M68K_040, M68K_CODE, "M68K"),
@@ -42,10 +42,19 @@ s_addressing_modes = {
 	18: "Immidate value",
 }
 
+def print_read_write_regs(insn):
+    for m in insn.regs_read:
+        print("\treading from reg: %s" % insn.reg_name(m))
+
+    for m in insn.regs_write:
+        print("\twriting to reg:   %s" % insn.reg_name(m))
+
 def print_insn_detail(insn):
     if len(insn.operands) > 0:
         print("\top_count: %u" % (len(insn.operands)))
         print("\tgroups_count: %u" % len(insn.groups))
+
+    print_read_write_regs(insn)
 
     for i, op in enumerate(insn.operands):
         if op.type == M68K_OP_REG:

--- a/tests/test_m68k.c
+++ b/tests/test_m68k.c
@@ -58,6 +58,25 @@ const char* s_addressing_modes[] = {
 	"Immidate value",
 };
 
+static void print_read_write_regs(cs_detail* detail)
+{
+	int i;
+
+	for (i = 0; i < detail->regs_read_count; ++i)
+	{
+		uint16_t reg_id = detail->regs_read[i];
+		const char* reg_name = cs_reg_name(handle, reg_id);
+		printf("\treading from reg: %s\n", reg_name);
+	}
+
+	for (i = 0; i < detail->regs_write_count; ++i)
+	{
+		uint16_t reg_id = detail->regs_write[i];
+		const char* reg_name = cs_reg_name(handle, reg_id);
+		printf("\twriting to reg:   %s\n", reg_name);
+	}
+}
+
 static void print_insn_detail(cs_insn *ins)
 {
 	cs_m68k* m68k;
@@ -72,6 +91,8 @@ static void print_insn_detail(cs_insn *ins)
 	m68k = &detail->m68k;
 	if (m68k->op_count)
 		printf("\top_count: %u\n", m68k->op_count);
+
+	print_read_write_regs(detail);
 
 	printf("\tgroups_count: %u\n", detail->groups_count);
 
@@ -119,12 +140,9 @@ static void print_insn_detail(cs_insn *ins)
 	printf("\n");
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 static void test()
 {
-#define M68K_CODE "\xd4\x40\x87\x5a\x4e\x71\x02\xb4\xc0\xde\xc0\xde\x5c\x00\x1d\x80\x71\x12\x01\x23\xf2\x3c\x44\x22\x40\x49\x0e\x56\x54\xc5\xf2\x3c\x44\x00\x44\x7a\x00\x00\xf2\x00\x0a\x28\x4E\xB9\x00\x00\x00\x12\x4E\x75"
-
+#define M68K_CODE "\x4C\x00\x54\x04\x48\xe7\xe0\x30\x4C\xDF\x0C\x07\xd4\x40\x87\x5a\x4e\x71\x02\xb4\xc0\xde\xc0\xde\x5c\x00\x1d\x80\x71\x12\x01\x23\xf2\x3c\x44\x22\x40\x49\x0e\x56\x54\xc5\xf2\x3c\x44\x00\x44\x7a\x00\x00\xf2\x00\x0a\x28\x4E\xB9\x00\x00\x00\x12\x4E\x75"
 	struct platform platforms[] = {
 		{
 			CS_ARCH_M68K,


### PR DESCRIPTION
Implemented so the ``regs_read`` and ``regs_write`` arrays gets filled with the correct data for the M68K backend.

Also added some more data in the ``m68k.c`` to show this of and also printing of the read/written registers. These changes were mirrored in the ``test_m68k.py`` python version also.

cc @nplanel for visibility and review 