### PR TITLE
change structure copying so python bindings work in pypy

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -4,7 +4,6 @@ from platform import system
 _python2 = sys.version_info[0] < 3
 if _python2:
     range = xrange
-from . import arm, arm64, mips, ppc, sparc, systemz, x86, xcore
 
 __all__ = [
     'Cs',
@@ -251,6 +250,19 @@ if _found == False:
 
 
 # low-level structure for C code
+
+def copy_ctypes(src):
+    """Returns a new ctypes object which is a bitwise copy of an existing one"""
+    dst = type(src)()
+    ctypes.memmove(ctypes.byref(dst), ctypes.byref(src), ctypes.sizeof(type(src)))
+    return dst
+
+def copy_ctypes_list(src):
+    return [copy_ctypes(n) for n in src]
+
+# Weird import placement because these modules are needed by the below code but need the above functions
+from . import arm, arm64, mips, ppc, sparc, systemz, x86, xcore
+
 class _cs_arch(ctypes.Union):
     _fields_ = (
         ('arm64', arm64.CsArm64),
@@ -433,14 +445,6 @@ def cs_disasm_lite(arch, mode, code, offset, count=0):
     status = _cs.cs_close(ctypes.byref(csh))
     if status != CS_ERR_OK:
         raise CsError(status)
-
-
-# alternately
-def copy_ctypes(src):
-    """Returns a new ctypes object which is a bitwise copy of an existing one"""
-    dst = type(src)()
-    ctypes.pointer(dst)[0] = src
-    return dst
 
 
 # Python-style class to disasm code

--- a/bindings/python/capstone/arm.py
+++ b/bindings/python/capstone/arm.py
@@ -1,6 +1,7 @@
 # Capstone Python bindings, by Nguyen Anh Quynnh <aquynh@gmail.com>
 
-import ctypes, copy
+import ctypes
+from . import copy_ctypes_list
 from .arm_const import *
 
 # define the API
@@ -74,5 +75,5 @@ class CsArm(ctypes.Structure):
 
 def get_arch_info(a):
     return (a.usermode, a.vector_size, a.vector_data, a.cps_mode, a.cps_flag, a.cc, a.update_flags, \
-        a.writeback, a.mem_barrier, copy.deepcopy(a.operands[:a.op_count]))
+        a.writeback, a.mem_barrier, copy_ctypes_list(a.operands[:a.op_count]))
 

--- a/bindings/python/capstone/arm64.py
+++ b/bindings/python/capstone/arm64.py
@@ -1,6 +1,7 @@
 # Capstone Python bindings, by Nguyen Anh Quynnh <aquynh@gmail.com>
 
-import ctypes, copy
+import ctypes
+from . import copy_ctypes_list
 from .arm64_const import *
 
 # define the API
@@ -84,5 +85,5 @@ class CsArm64(ctypes.Structure):
     )
 
 def get_arch_info(a):
-    return (a.cc, a.update_flags, a.writeback, copy.deepcopy(a.operands[:a.op_count]))
+    return (a.cc, a.update_flags, a.writeback, copy_ctypes_list(a.operands[:a.op_count]))
 

--- a/bindings/python/capstone/mips.py
+++ b/bindings/python/capstone/mips.py
@@ -1,6 +1,7 @@
 # Capstone Python bindings, by Nguyen Anh Quynnh <aquynh@gmail.com>
 
-import ctypes, copy
+import ctypes
+from . import copy_ctypes_list
 from .mips_const import *
 
 # define the API
@@ -43,5 +44,5 @@ class CsMips(ctypes.Structure):
     )
 
 def get_arch_info(a):
-    return copy.deepcopy(a.operands[:a.op_count])
+    return copy_ctypes_list(a.operands[:a.op_count])
 

--- a/bindings/python/capstone/ppc.py
+++ b/bindings/python/capstone/ppc.py
@@ -1,6 +1,7 @@
 # Capstone Python bindings, by Nguyen Anh Quynnh <aquynh@gmail.com>
 
-import ctypes, copy
+import ctypes
+from . import copy_ctypes_list
 from .ppc_const import *
 
 # define the API
@@ -58,5 +59,5 @@ class CsPpc(ctypes.Structure):
     )
 
 def get_arch_info(a):
-    return (a.bc, a.bh, a.update_cr0, copy.deepcopy(a.operands[:a.op_count]))
+    return (a.bc, a.bh, a.update_cr0, copy_ctypes_list(a.operands[:a.op_count]))
 

--- a/bindings/python/capstone/sparc.py
+++ b/bindings/python/capstone/sparc.py
@@ -1,6 +1,7 @@
 # Capstone Python bindings, by Nguyen Anh Quynnh <aquynh@gmail.com>
 
-import ctypes, copy
+import ctypes
+from . import copy_ctypes_list
 from .sparc_const import *
 
 # define the API
@@ -46,5 +47,5 @@ class CsSparc(ctypes.Structure):
     )
 
 def get_arch_info(a):
-    return (a.cc, a.hint, copy.deepcopy(a.operands[:a.op_count]))
+    return (a.cc, a.hint, copy_ctypes_list(a.operands[:a.op_count]))
 

--- a/bindings/python/capstone/systemz.py
+++ b/bindings/python/capstone/systemz.py
@@ -1,6 +1,7 @@
 # Capstone Python bindings, by Nguyen Anh Quynnh <aquynh@gmail.com>
 
-import ctypes, copy
+import ctypes
+from . import copy_ctypes_list
 from .sysz_const import *
 
 # define the API
@@ -46,5 +47,5 @@ class CsSysz(ctypes.Structure):
     )
 
 def get_arch_info(a):
-    return (a.cc, copy.deepcopy(a.operands[:a.op_count]))
+    return (a.cc, copy_ctypes_list(a.operands[:a.op_count]))
 

--- a/bindings/python/capstone/x86.py
+++ b/bindings/python/capstone/x86.py
@@ -1,6 +1,7 @@
 # Capstone Python bindings, by Nguyen Anh Quynnh <aquynh@gmail.com>
 
-import ctypes, copy
+import ctypes
+from . import copy_ctypes_list
 from .x86_const import *
 
 # define the API
@@ -71,5 +72,5 @@ def get_arch_info(a):
     return (a.prefix[:], a.opcode[:], a.rex, a.addr_size, \
             a.modrm, a.sib, a.disp, a.sib_index, a.sib_scale, \
             a.sib_base, a.sse_cc, a.avx_cc, a.avx_sae, a.avx_rm, \
-            copy.deepcopy(a.operands[:a.op_count]))
+            copy_ctypes_list(a.operands[:a.op_count]))
 

--- a/bindings/python/capstone/xcore.py
+++ b/bindings/python/capstone/xcore.py
@@ -1,6 +1,7 @@
 # Capstone Python bindings, by Nguyen Anh Quynnh <aquynh@gmail.com>
 
-import ctypes, copy
+import ctypes
+from . import copy_ctypes_list
 from .xcore_const import *
 
 # define the API
@@ -45,5 +46,5 @@ class CsXcore(ctypes.Structure):
     )
 
 def get_arch_info(a):
-    return (copy.deepcopy(a.operands[:a.op_count]))
+    return (copy_ctypes_list(a.operands[:a.op_count]))
 


### PR DESCRIPTION
Previously, capstone didn't work in pypy. The basic example script failed.

The struct-copy trick that was copied from that one stack overflow post doesn't work in pypy's implementation of ctypes, so I replaced it with one of the other answers from that post.

Additionally, the use of deepcopy was erroring out on pypy, so I replaced it with a more direct method. This involved rearranging some imports so the submodules could import a method from the main `__init__.py`.

A more long-term solution would be to switch from ctypes to cffi.