### PR TITLE
Changed X86_INS_POP flags

### DIFF
--- a/arch/X86/X86MappingInsnOp.inc
+++ b/arch/X86/X86MappingInsnOp.inc
@@ -7803,7 +7803,7 @@
 },
 {	/* X86_POP16rmm, X86_INS_POP: pop{w}	$dst */
 	0,
-	{ CS_AC_READ, 0 }
+	{ CS_AC_WRITE, 0 }
 },
 {	/* X86_POP16rmr, X86_INS_POP: pop{w}	$reg */
 	0,
@@ -7815,7 +7815,7 @@
 },
 {	/* X86_POP32rmm, X86_INS_POP: pop{l}	$dst */
 	0,
-	{ CS_AC_READ, 0 }
+	{ CS_AC_WRITE, 0 }
 },
 {	/* X86_POP32rmr, X86_INS_POP: pop{l}	$reg */
 	0,
@@ -7827,7 +7827,7 @@
 },
 {	/* X86_POP64rmm, X86_INS_POP: pop{q}	$dst */
 	0,
-	{ CS_AC_READ, 0 }
+	{ CS_AC_WRITE, 0 }
 },
 {	/* X86_POP64rmr, X86_INS_POP: pop{q}	$reg */
 	0,

--- a/arch/X86/X86MappingInsnOp_reduce.inc
+++ b/arch/X86/X86MappingInsnOp_reduce.inc
@@ -3771,7 +3771,7 @@
 },
 {	/* X86_POP16rmm, X86_INS_POP: pop{w}	$dst */
 	0,
-	{ CS_AC_READ, 0 }
+	{ CS_AC_WRITE, 0 }
 },
 {	/* X86_POP16rmr, X86_INS_POP: pop{w}	$reg */
 	0,
@@ -3783,7 +3783,7 @@
 },
 {	/* X86_POP32rmm, X86_INS_POP: pop{l}	$dst */
 	0,
-	{ CS_AC_READ, 0 }
+	{ CS_AC_WRITE, 0 }
 },
 {	/* X86_POP32rmr, X86_INS_POP: pop{l}	$reg */
 	0,
@@ -3795,7 +3795,7 @@
 },
 {	/* X86_POP64rmm, X86_INS_POP: pop{q}	$dst */
 	0,
-	{ CS_AC_READ, 0 }
+	{ CS_AC_WRITE, 0 }
 },
 {	/* X86_POP64rmr, X86_INS_POP: pop{q}	$reg */
 	0,


### PR DESCRIPTION
I think X86_INS_POP currently has wrong access flags. I tested Capstone Next with the following input:

pop dword ptr ds:[0]
pop dword ptr ss:[esp]

And received the following output:
"pop dword ptr ds:[0]": operands[0].type =MEM, operands[0].access = READ.
"pop dword ptr ss:[esp]": operands[0].type =MEM, operands[0].access = READ.

So the output is wrong because the memory locations "dword ptr ds:[0]" and "dword ptr ss:[esp]" are accessed in WRITE mode (the POP instruction extract the value on the top of the stack and saves it in the destination reg/mem).

In the pull request I changed the access flags for the instruction "POP [MEM]" to CS_AC_WRITE, now the output is right.