### PR TITLE
speed up X86_insn_reg_intel by using balanced bst

### DIFF
--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -83,7 +83,7 @@ static void set_mem_access(MCInst *MI, bool status)
 	}
 }
 
-void AArch64_printInst(MCInst *MI, SStream *O, void *Info)
+void AArch64_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *Info)
 {
 	// Check for special encodings and print the canonical alias instead.
 	unsigned Opcode = MCInst_getOpcode(MI);

--- a/arch/AArch64/AArch64InstPrinter.h
+++ b/arch/AArch64/AArch64InstPrinter.h
@@ -21,7 +21,7 @@
 #include "../../MCRegisterInfo.h"
 #include "../../SStream.h"
 
-void AArch64_printInst(MCInst *MI, SStream *O, void *);
+void AArch64_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *);
 
 void AArch64_post_printer(csh handle, cs_insn *pub_insn, char *insn_asm, MCInst *mci);
 

--- a/arch/ARM/ARMInstPrinter.c
+++ b/arch/ARM/ARMInstPrinter.c
@@ -424,7 +424,7 @@ void ARM_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci)
 	}
 }
 
-void ARM_printInst(MCInst *MI, SStream *O, void *Info)
+void ARM_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *Info)
 {
 	MCRegisterInfo *MRI = (MCRegisterInfo *)Info;
 	unsigned Opcode = MCInst_getOpcode(MI), tmp, i, pubOpcode;

--- a/arch/ARM/ARMInstPrinter.h
+++ b/arch/ARM/ARMInstPrinter.h
@@ -21,7 +21,7 @@
 #include "../../MCRegisterInfo.h"
 #include "../../SStream.h"
 
-void ARM_printInst(MCInst *MI, SStream *O, void *Info);
+void ARM_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *Info);
 void ARM_post_printer(csh handle, cs_insn *pub_insn, char *mnem, MCInst *mci);
 
 // setup handle->get_regname

--- a/arch/M68K/M68KInstPrinter.c
+++ b/arch/M68K/M68KInstPrinter.c
@@ -233,7 +233,7 @@ void printAddressingMode(SStream* O, const cs_m68k* inst, const cs_m68k_op* op)
 }
 #endif
 
-void M68K_printInst(MCInst* MI, SStream* O, void* PrinterInfo)
+void M68K_printInst(struct cs_struct* cs, MCInst* MI, SStream* O, void* PrinterInfo)
 {
 #ifndef CAPSTONE_DIET
 	m68k_info *info = (m68k_info *)PrinterInfo;

--- a/arch/M68K/M68KInstPrinter.h
+++ b/arch/M68K/M68KInstPrinter.h
@@ -12,7 +12,7 @@ struct SStream;
 
 void M68K_init(MCRegisterInfo *MRI);
 
-void M68K_printInst(MCInst* MI, struct SStream* O, void* Info);
+void M68K_printInst(struct cs_struct* cs, MCInst* MI, struct SStream* O, void* Info);
 const char* M68K_reg_name(csh handle, unsigned int reg);
 void M68K_get_insn_id(cs_struct* h, cs_insn* insn, unsigned int id);
 const char *M68K_insn_name(csh handle, unsigned int id);

--- a/arch/Mips/MipsInstPrinter.c
+++ b/arch/Mips/MipsInstPrinter.c
@@ -152,7 +152,7 @@ static void printRegName(SStream *OS, unsigned RegNo)
 	SStream_concat(OS, "$%s", getRegisterName(RegNo));
 }
 
-void Mips_printInst(MCInst *MI, SStream *O, void *info)
+void Mips_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *info)
 {
 	char *mnem;
 

--- a/arch/Mips/MipsInstPrinter.h
+++ b/arch/Mips/MipsInstPrinter.h
@@ -20,6 +20,6 @@
 #include "../../MCInst.h"
 #include "../../SStream.h"
 
-void Mips_printInst(MCInst *MI, SStream *O, void *info);
+void Mips_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *info);
 
 #endif

--- a/arch/PowerPC/PPCInstPrinter.c
+++ b/arch/PowerPC/PPCInstPrinter.c
@@ -95,7 +95,7 @@ static int isBOCTRBranch(unsigned int op)
 	return ((op >= PPC_BDNZ) && (op <= PPC_BDZp));
 }
 
-void PPC_printInst(MCInst *MI, SStream *O, void *Info)
+void PPC_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *Info)
 {
 	char *mnem;
 

--- a/arch/PowerPC/PPCInstPrinter.h
+++ b/arch/PowerPC/PPCInstPrinter.h
@@ -8,7 +8,7 @@
 #include "../../MCRegisterInfo.h"
 #include "../../SStream.h"
 
-void PPC_printInst(MCInst *MI, SStream *O, void *Info);
+void PPC_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *Info);
 
 void PPC_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci);
 

--- a/arch/Sparc/SparcInstPrinter.c
+++ b/arch/Sparc/SparcInstPrinter.c
@@ -355,7 +355,7 @@ static bool printGetPCX(MCInst *MI, unsigned opNum, SStream *O)
 #define PRINT_ALIAS_INSTR
 #include "SparcGenAsmWriter.inc"
 
-void Sparc_printInst(MCInst *MI, SStream *O, void *Info)
+void Sparc_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *Info)
 {
 	char *mnem, *p;
 	char instr[64];	// Sparc has no instruction this long

--- a/arch/Sparc/SparcInstPrinter.h
+++ b/arch/Sparc/SparcInstPrinter.h
@@ -8,7 +8,7 @@
 #include "../../MCRegisterInfo.h"
 #include "../../SStream.h"
 
-void Sparc_printInst(MCInst *MI, SStream *O, void *Info);
+void Sparc_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *Info);
 
 void Sparc_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci);
 

--- a/arch/SystemZ/SystemZInstPrinter.c
+++ b/arch/SystemZ/SystemZInstPrinter.c
@@ -386,7 +386,7 @@ static void printCond4Operand(MCInst *MI, int OpNum, SStream *O)
 #define PRINT_ALIAS_INSTR
 #include "SystemZGenAsmWriter.inc"
 
-void SystemZ_printInst(MCInst *MI, SStream *O, void *Info)
+void SystemZ_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *Info)
 {
 	printInstruction(MI, O, Info);
 }

--- a/arch/SystemZ/SystemZInstPrinter.h
+++ b/arch/SystemZ/SystemZInstPrinter.h
@@ -8,7 +8,7 @@
 #include "../../MCRegisterInfo.h"
 #include "../../SStream.h"
 
-void SystemZ_printInst(MCInst *MI, SStream *O, void *Info);
+void SystemZ_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *Info);
 
 void SystemZ_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci);
 

--- a/arch/X86/X86ATTInstPrinter.c
+++ b/arch/X86/X86ATTInstPrinter.c
@@ -862,7 +862,7 @@ static void printRegName(SStream *OS, unsigned RegNo)
 	SStream_concat(OS, "%%%s", getRegisterName(RegNo));
 }
 
-void X86_ATT_printInst(MCInst *MI, SStream *OS, void *info)
+void X86_ATT_printInst(struct cs_struct* cs, MCInst *MI, SStream *OS, void *info)
 {
 	char *mnem;
 	x86_reg reg, reg2;

--- a/arch/X86/X86InstPrinter.h
+++ b/arch/X86/X86InstPrinter.h
@@ -20,7 +20,7 @@
 #include "../../MCInst.h"
 #include "../../SStream.h"
 
-void X86_Intel_printInst(MCInst *MI, SStream *OS, void *Info);
-void X86_ATT_printInst(MCInst *MI, SStream *OS, void *Info);
+void X86_Intel_printInst(struct cs_struct* cs, MCInst *MI, SStream *OS, void *Info);
+void X86_ATT_printInst(struct cs_struct* cs, MCInst *MI, SStream *OS, void *Info);
 
 #endif

--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -713,7 +713,7 @@ static void printMemOffs64(MCInst *MI, unsigned OpNo, SStream *O)
 
 static char *printAliasInstr(MCInst *MI, SStream *OS, void *info);
 static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI);
-void X86_Intel_printInst(MCInst *MI, SStream *O, void *Info)
+void X86_Intel_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *Info)
 {
 	char *mnem;
 	x86_reg reg, reg2;
@@ -726,7 +726,7 @@ void X86_Intel_printInst(MCInst *MI, SStream *O, void *Info)
 	else
 		printInstruction(MI, O, Info);
 
-	reg = X86_insn_reg_intel(MCInst_getOpcode(MI), &access1);
+	reg = X86_insn_reg_intel(cs, MCInst_getOpcode(MI), &access1);
 	if (MI->csh->detail) {
 #ifndef CAPSTONE_DIET
 		uint8_t access[6];

--- a/arch/X86/X86Mapping.h
+++ b/arch/X86/X86Mapping.h
@@ -31,7 +31,7 @@ const char *X86_group_name(csh handle, unsigned int id);
 // return register of given instruction id
 // return 0 if not found
 // this is to handle instructions embedding accumulate registers into AsmStrs[]
-x86_reg X86_insn_reg_intel(unsigned int id, enum cs_ac_type *access);
+x86_reg X86_insn_reg_intel(struct cs_struct* cs, unsigned int id, enum cs_ac_type *access);
 x86_reg X86_insn_reg_att(unsigned int id, enum cs_ac_type *access);
 bool X86_insn_reg_intel2(unsigned int id, x86_reg *reg1, enum cs_ac_type *access1, x86_reg *reg2, enum cs_ac_type *access2);
 bool X86_insn_reg_att2(unsigned int id, x86_reg *reg1, enum cs_ac_type *access1, x86_reg *reg2, enum cs_ac_type *access2);
@@ -70,5 +70,17 @@ void X86_reg_access(const cs_insn *insn,
 
 // given the instruction id, return the size of its immediate operand (or 0)
 int X86_immediate_size(unsigned int id);
+
+struct insn_reg_node_t {
+       uint16_t insn;
+       struct insn_reg* value;
+       struct insn_reg_node_t* left;
+       struct insn_reg_node_t* right;
+};
+
+struct insn_reg_node_t* new_insn_reg_node(struct insn_reg* data);
+struct insn_reg_node_t* regs_to_bst(struct insn_reg* arr, int start, int end);
+struct insn_reg* insn_id_to_reg(struct insn_reg_node_t* bst, unsigned int id);
+//void free_bst (struct insn_reg_node_t* node);
 
 #endif

--- a/arch/XCore/XCoreInstPrinter.c
+++ b/arch/XCore/XCoreInstPrinter.c
@@ -254,7 +254,7 @@ static void printInlineJT32(MCInst *MI, int OpNum, SStream *O)
 #define PRINT_ALIAS_INSTR
 #include "XCoreGenAsmWriter.inc"
 
-void XCore_printInst(MCInst *MI, SStream *O, void *Info)
+void XCore_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *Info)
 {
 	printInstruction(MI, O, Info);
 	set_mem_access(MI, false, 0);

--- a/arch/XCore/XCoreInstPrinter.h
+++ b/arch/XCore/XCoreInstPrinter.h
@@ -8,7 +8,7 @@
 #include "../../MCRegisterInfo.h"
 #include "../../SStream.h"
 
-void XCore_printInst(MCInst *MI, SStream *O, void *Info);
+void XCore_printInst(struct cs_struct* cs, MCInst *MI, SStream *O, void *Info);
 
 void XCore_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci);
 

--- a/cs.c
+++ b/cs.c
@@ -273,6 +273,7 @@ cs_err CAPSTONE_API cs_open(cs_arch arch, cs_mode mode, csh *handle)
 		ud->big_endian = (mode & CS_MODE_BIG_ENDIAN) != 0;
 		// by default, do not break instruction into details
 		ud->detail = CS_OPT_OFF;
+		ud->intel_reg_bst = NULL;
 
 		// default skipdata setup
 		ud->skipdata_setup.mnemonic = SKIPDATA_MNEM;
@@ -304,6 +305,7 @@ cs_err CAPSTONE_API cs_close(csh *handle)
 		return CS_ERR_CSH;
 
 	ud = (struct cs_struct *)(*handle);
+	free_bst (ud->intel_reg_bst);
 
 	if (ud->printer_info)
 		cs_mem_free(ud->printer_info);
@@ -661,7 +663,7 @@ size_t CAPSTONE_API cs_disasm(csh ud, const uint8_t *buffer, size_t size, uint64
 			// map internal instruction opcode to public insn ID
 			handle->insn_id(handle, insn_cache, mci.Opcode);
 
-			handle->printer(&mci, &ss, handle->printer_info);
+			handle->printer(handle, &mci, &ss, handle->printer_info);
 
 			fill_insn(handle, insn_cache, ss.buffer, &mci, handle->post_printer, buffer);
 
@@ -865,7 +867,7 @@ bool CAPSTONE_API cs_disasm_iter(csh ud, const uint8_t **code, size_t *size,
 		// map internal instruction opcode to public insn ID
 		handle->insn_id(handle, insn, mci.Opcode);
 
-		handle->printer(&mci, &ss, handle->printer_info);
+		handle->printer(handle, &mci, &ss, handle->printer_info);
 
 		fill_insn(handle, insn, ss.buffer, &mci, handle->post_printer, *code);
 

--- a/cs_priv.h
+++ b/cs_priv.h
@@ -9,7 +9,7 @@
 #include "MCInst.h"
 #include "SStream.h"
 
-typedef void (*Printer_t)(MCInst *MI, SStream *OS, void *info);
+typedef void (*Printer_t)(struct cs_struct* cs, MCInst *MI, SStream *OS, void *info);
 
 // function to be called after Printer_t
 // this is the best time to gather insn's characteristics
@@ -74,6 +74,7 @@ struct cs_struct {
 	uint8_t *regsize_map;	// map to register size (x86-only for now)
 	GetRegisterAccess_t reg_access;
 	struct insn_mnem *mnem_list;	// linked list of customized instruction mnemonic
+	struct insn_reg_node_t* intel_reg_bst;
 };
 
 #define MAX_ARCH 9

--- a/utils.h
+++ b/utils.h
@@ -62,6 +62,6 @@ int cs_snprintf(char *buffer, size_t size, const char *fmt, ...);
 bool arr_exist8(unsigned char *arr, unsigned char max, unsigned int id);
 
 bool arr_exist(uint16_t *arr, unsigned char max, unsigned int id);
-
+void free_bst (struct insn_reg_node_t* node);
 #endif
 


### PR DESCRIPTION
should be much faster, with a maximum of 7 comparisons vs 155.

fixes #719