### PR TITLE
Replace copy.deepcopy by  copy_ctypes_list for get_arch_info

### DIFF
--- a/bindings/python/capstone/m68k.py
+++ b/bindings/python/capstone/m68k.py
@@ -86,5 +86,4 @@ class CsM68K(ctypes.Structure):
     )
 
 def get_arch_info(a):
-    return (copy.deepcopy(a.operands[:a.op_count]), a.op_size)
-
+    return (copy_ctypes_list(a.operands[:a.op_count]), a.op_size)


### PR DESCRIPTION
This replacement was done for commit
16477206564745782854e0ec5c68defa02429dd8, allowing the python binding to
be used in PyPy. It seems the m68k arch has been forgotten.