### PR TITLE
Update capstone.h

### DIFF
--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -141,7 +141,7 @@ typedef struct cs_opt_mnem {
 	// ID of instruction to be customized.
 	unsigned int id;
 	// Customized instruction mnemonic.
-	char *mnemonic;
+	const char *mnemonic;
 } cs_opt_mnem;
 
 // Runtime option for the disassembled engine


### PR DESCRIPTION
VS2015: error: C2440: 'initializing': cannot convert from 'const char [4]' to 'char *'