### PR TITLE
arm: Add uint32_t addr to the union in cs_arm_op

### DIFF
--- a/arch/ARM/ARMInstPrinter.c
+++ b/arch/ARM/ARMInstPrinter.c
@@ -742,6 +742,12 @@ static void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 				SStream_concat(O, "#0x%x", address);
 			else
 				SStream_concat(O, "#%u", address);
+
+			if (MI->csh->detail) {
+				MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].type = ARM_OP_IMM;
+				MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].addr = address;
+				MI->flat_insn->detail->arm.op_count++;
+			}
 		} else {
 			switch(MI->flat_insn->id) {
 				default:
@@ -769,15 +775,15 @@ static void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 						SStream_concat(O, "#0x%x", imm);
 					break;
 			}
-		}
 
-		if (MI->csh->detail) {
-			if (MI->csh->doing_mem)
-				MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].mem.disp = imm;
-			else {
-				MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].type = ARM_OP_IMM;
-				MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].imm = imm;
-				MI->flat_insn->detail->arm.op_count++;
+			if (MI->csh->detail) {
+				if (MI->csh->doing_mem)
+					MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].mem.disp = imm;
+				else {
+					MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].type = ARM_OP_IMM;
+					MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].imm = imm;
+					MI->flat_insn->detail->arm.op_count++;
+				}
 			}
 		}
 	}

--- a/include/arm.h
+++ b/include/arm.h
@@ -236,6 +236,7 @@ typedef struct cs_arm_op {
 		double fp;			// floating point value for FP operand
 		arm_op_mem mem;		// base/index/scale/disp value for MEM operand
 		arm_setend_type setend; // SETEND instruction's operand type
+		uint32_t addr;	// address constructed with PC-relative expression
 	};
 	// in some instructions, an operand can be subtracted or added to
 	// the base register,


### PR DESCRIPTION
__ATTENTION: THIS CHANGE BREAKS COMPATIBILITY__

I found the assumption that address is stored as `ARM_OP_IMM` is actually already broken with #762. However, it is no longer possible to put it to `imm` since `address` can be greater than `INT32_MAX`. Doing so can result in anything, especially faults in arithmetic operations.

Moreover, the old binding in Ocaml ignores bit 31 since the length of `int` in the language is 31 bits. It means accidentally I also found that addresses should be treated differently in the binding.

Though the series of changes is a bug fix, breaking compatibility is inevitable.