### PR TITLE
Fix use of uninitialized value for some instructions

### DIFF
--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -921,6 +921,7 @@ static int readOpcode(struct InternalInstruction *insn)
 	// printf(">>> readOpcode() = %x\n", insn->readerCursor);
 
 	insn->opcodeType = ONEBYTE;
+	insn->firstByte = 0x00;
 
 	if (insn->vectorExtensionType == TYPE_EVEX) {
 		switch (mmFromEVEX2of4(insn->vectorExtensionPrefix[1])) {


### PR DESCRIPTION
Caught by Valgrind:

    Conditional jump or move depends on uninitialised value(s)
       at 0xD5BB6F: readModRM (X86DisassemblerDecoder.c:1528)
       by 0xD5BF02: getIDWithAttrMask (X86DisassemblerDecoder.c:1101)
       by 0xD5CC5E: getID (X86DisassemblerDecoder.c:1249)
       by 0xD5CC5E: decodeInstruction (X86DisassemblerDecoder.c:2335)
       by 0xD52009: X86_getInstruction (X86Disassembler.c:822)
       by 0xD51781: cs_disasm (cs.c:503)