### PR TITLE
Fix typo, style, suppress MSVC PREfast warnings, ignore residual files on project upgrade 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ _*
 packages/freebsd/ports/devel/capstone/distinfo
 
 # VisualStudio
+ProjectUpgradeLog.log
 Debug/
 Release/
 ipch/
@@ -87,6 +88,7 @@ ipch/
 *.opensdf
 *.suo
 *.user
+*.backup
 *.VC.db
 *.VC.opendb
 

--- a/COMPILE_MSVC.TXT
+++ b/COMPILE_MSVC.TXT
@@ -27,7 +27,7 @@ versions, and Windows Driver Kit 8.1 Update 1 or newer versions are required.
   steps.
 
   In VisualStudio interface, modify the preprocessor definitions via
-  "Project Properties" -> "Configuration Propertis" -> "C/C++" -> "Preprocessor"
+  "Project Properties" -> "Configuration Properties" -> "C/C++" -> "Preprocessor"
   to customize Capstone library, as followings.
 
   - CAPSTONE_HAS_ARM: support ARM. Delete this to remove ARM support.

--- a/HACK.TXT
+++ b/HACK.TXT
@@ -35,7 +35,7 @@ the code and try to recompile/reinstall again. This can be done with:
 	$ sudo ./make.sh install
 
 At the same time, for Java/Ocaml/Python bindings, be sure to always use
-the bindings coming with the core to avoid potential incompatility issue
+the bindings coming with the core to avoid potential incompatibility issue
 with older versions.
 See bindings/<language>/README for detail instructions on how to compile &
 install the bindings.

--- a/arch/AArch64/AArch64BaseInfo.c
+++ b/arch/AArch64/AArch64BaseInfo.c
@@ -17,7 +17,8 @@
 #ifdef CAPSTONE_HAS_ARM64
 
 #if defined (WIN32) || defined (WIN64) || defined (_WIN32) || defined (_WIN64)
-#pragma warning(disable:4996)
+#pragma warning(disable:4996)			// disable MSVC's warning on strcpy()
+#pragma warning(disable:28719)		// disable MSVC's warning on strcpy()
 #endif
 
 #include "../../utils.h"

--- a/arch/Sparc/SparcInstPrinter.c
+++ b/arch/Sparc/SparcInstPrinter.c
@@ -20,6 +20,10 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
+#if defined (WIN32) || defined (WIN64) || defined (_WIN32) || defined (_WIN64)
+#pragma warning(disable:28719)		// disable MSVC's warning on strncpy()
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/arch/XCore/XCoreInstPrinter.c
+++ b/arch/XCore/XCoreInstPrinter.c
@@ -16,6 +16,11 @@
 
 #ifdef CAPSTONE_HAS_XCORE
 
+#if defined (WIN32) || defined (WIN64) || defined (_WIN32) || defined (_WIN64)
+#pragma warning(disable : 4996)			// disable MSVC's warning on strcpy()
+#pragma warning(disable : 28719)		// disable MSVC's warning on strcpy()
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -46,15 +51,7 @@ void XCore_insn_extract(MCInst *MI, const char *code)
 	char *p, *p2;
 	char tmp[128];
 
-// make MSVC shut up on strcpy()
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
 	strcpy(tmp, code); // safe because code is way shorter than 128 bytes
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 	// find the first space
 	p = strchr(tmp, ' ');

--- a/contrib/cs_driver/cs_driver/cs_driver.c
+++ b/contrib/cs_driver/cs_driver/cs_driver.c
@@ -56,14 +56,14 @@ static NTSTATUS cs_driver_hello() {
   // On a 32bit driver, KeSaveFloatingPointState() is required before using any
   // Capstone function because Capstone can access to the MMX/x87 registers and
   // 32bit Windows requires drivers to use KeSaveFloatingPointState() before and
-  // KeRestoreFloatingPointState() after accesing to them. See "Using Floating
+  // KeRestoreFloatingPointState() after accessing them. See "Using Floating
   // Point or MMX in a WDM Driver" on MSDN for more details.
   status = KeSaveFloatingPointState(&float_save);
   if (!NT_SUCCESS(status)) {
     return status;
   }
 
-  // Do stuff just like user-mode. All functionalites are supported.
+  // Do stuff just like user-mode. All functionalities are supported.
   if (cs_open(CS_ARCH_X86, (sizeof(void *) == 4) ? CS_MODE_32 : CS_MODE_64,
               &handle) != CS_ERR_OK) {
     goto exit;

--- a/cs.c
+++ b/cs.c
@@ -1,7 +1,8 @@
 /* Capstone Disassembly Engine */
 /* By Nguyen Anh Quynh <aquynh@gmail.com>, 2013-2014 */
 #if defined (WIN32) || defined (WIN64) || defined (_WIN32) || defined (_WIN64)
-#pragma warning(disable:4996)
+#pragma warning(disable:4996)			// disable MSVC's warning on strcpy()
+#pragma warning(disable:28719)		// disable MSVC's warning on strcpy()
 #endif
 #if defined(CAPSTONE_HAS_OSXKERNEL)
 #include <libkern/libkern.h>

--- a/docs/README
+++ b/docs/README
@@ -1,4 +1,4 @@
-Documention of Capstone disassembly framework.
+Documentation of Capstone disassembly framework.
 
 * Switching to 2.1 engine.
 

--- a/include/x86.h
+++ b/include/x86.h
@@ -212,15 +212,15 @@ typedef struct cs_x86 {
 	// prefix[3] indicates address-size override (X86_PREFIX_ADDRSIZE)
 	uint8_t prefix[4];
 
-	// Instruction opcode, wich can be from 1 to 4 bytes in size.
+	// Instruction opcode, which can be from 1 to 4 bytes in size.
 	// This contains VEX opcode as well.
 	// An trailing opcode byte gets value 0 when irrelevant.
 	uint8_t opcode[4];
 
-	// REX prefix: only a non-zero value is relavant for x86_64
+	// REX prefix: only a non-zero value is relevant for x86_64
 	uint8_t rex;
 
-	// Address size, which can be overrided with above prefix[5].
+	// Address size, which can be overridden with above prefix[5].
 	uint8_t addr_size;
 
 	// ModR/M byte
@@ -235,7 +235,7 @@ typedef struct cs_x86 {
 	/* SIB state */
 	// SIB index register, or X86_REG_INVALID when irrelevant.
 	x86_reg sib_index;
-	// SIB scale. only applicable if sib_index is relavant.
+	// SIB scale. only applicable if sib_index is relevant.
 	int8_t sib_scale;
 	// SIB base register, or X86_REG_INVALID when irrelevant.
 	x86_reg sib_base;

--- a/tests/test_winkernel.cpp
+++ b/tests/test_winkernel.cpp
@@ -1,5 +1,6 @@
 /* Capstone Disassembly Engine */
 /* By Satoshi Tanda <tanda.sat@gmail.com>, 2016 */
+
 #include <ntddk.h>
 #include <capstone.h>
 
@@ -19,7 +20,7 @@ EXTERN_C DRIVER_INITIALIZE DriverEntry;
 #pragma warning(disable : 4005)   // 'identifier' : macro redefinition
 #pragma warning(disable : 4007)   // 'main': must be '__cdecl'
 
-// Drivers must protect floating point hardware state. See use of float simm:
+// Drivers must protect floating point hardware state. See use of float.
 // Use KeSaveFloatingPointState/KeRestoreFloatingPointState around floating
 // point operations. Display Drivers should use the corresponding Eng... routines.
 #pragma warning(disable : 28110)  // Suppress this, as it is false positive.
@@ -93,7 +94,7 @@ static void test()
 	// On a 32bit driver, KeSaveFloatingPointState() is required before using any
 	// Capstone function because Capstone can access to the MMX/x87 registers and
 	// 32bit Windows requires drivers to use KeSaveFloatingPointState() before and
-	// KeRestoreFloatingPointState() after accesing to them. See "Using Floating
+	// KeRestoreFloatingPointState() after accessing them. See "Using Floating
 	// Point or MMX in a WDM Driver" on MSDN for more details.
 	status = KeSaveFloatingPointState(&float_save);
 	if (!NT_SUCCESS(status)) {

--- a/windows/winkernel_mm.c
+++ b/windows/winkernel_mm.c
@@ -1,5 +1,6 @@
 /* Capstone Disassembly Engine */
 /* By Satoshi Tanda <tanda.sat@gmail.com>, 2016 */
+
 #include "winkernel_mm.h"
 #include <ntddk.h>
 
@@ -77,27 +78,27 @@ void * CAPSTONE_API cs_winkernel_realloc(void *ptr, size_t size)
 	return new_ptr;
 }
 
-// vsnprintf(). _vsnprintf() is avaialable for drivers, but it differs from
-// vsnprintf() in a return value and when a null-terminater is set.
+// vsnprintf(). _vsnprintf() is available for drivers, but it differs from
+// vsnprintf() in a return value and when a null-terminator is set.
 // cs_winkernel_vsnprintf() takes care of those differences.
 #pragma warning(push)
-#pragma warning(disable : 28719)  // Banned API Usage : _vsnprintf is a Banned
-// API as listed in dontuse.h for security
-// purposes.
+// Banned API Usage : _vsnprintf is a Banned API as listed in dontuse.h for
+// security purposes.
+#pragma warning(disable : 28719)
 int CAPSTONE_API cs_winkernel_vsnprintf(char *buffer, size_t count, const char *format, va_list argptr)
 {
 	int result = _vsnprintf(buffer, count, format, argptr);
 
 	// _vsnprintf() returns -1 when a string is truncated, and returns "count"
 	// when an entire string is stored but without '\0' at the end of "buffer".
-	// In both cases, null-terminater needs to be added manually.
+	// In both cases, null-terminator needs to be added manually.
 	if (result == -1 || (size_t)result == count) {
 		buffer[count - 1] = '\0';
 	}
 
 	if (result == -1) {
 		// In case when -1 is returned, the function has to get and return a number
-		// of characters that would have been written. This attempts so by re-tring
+		// of characters that would have been written. This attempts so by retrying
 		// the same conversion with temp buffer that is most likely big enough to
 		// complete formatting and get a number of characters that would have been
 		// written.

--- a/windows/winkernel_mm.c
+++ b/windows/winkernel_mm.c
@@ -31,6 +31,8 @@ void * CAPSTONE_API cs_winkernel_malloc(size_t size)
 	// in many cases, indicate a potential validation issue in the calling code.
 	NT_ASSERT(size);
 
+	// FP; a use of NonPagedPool is required for Windows 7 support
+#pragma prefast(suppress : 30030)		// Allocating executable POOL_TYPE memory
 	CS_WINKERNEL_MEMBLOCK *block = (CS_WINKERNEL_MEMBLOCK *)ExAllocatePoolWithTag(
 			NonPagedPool, size + sizeof(CS_WINKERNEL_MEMBLOCK), CS_WINKERNEL_POOL_TAG);
 	if (!block) {

--- a/windows/winkernel_mm.h
+++ b/windows/winkernel_mm.h
@@ -1,5 +1,6 @@
 /* Capstone Disassembly Engine */
 /* By Satoshi Tanda <tanda.sat@gmail.com>, 2016 */
+
 #ifndef CS_WINDOWS_WINKERNEL_MM_H
 #define CS_WINDOWS_WINKERNEL_MM_H
 


### PR DESCRIPTION
This PR:
- fixes some typo and style issues
- suppresses some warnings reported by PREfast (Static Code Analysis) that are FP (eg, 30030) or already ignored in case they are reported as non-PREfast warnings (eg, 28719 vs 4996)
- ignores files that are created when VS converts existing project files to the latest version of them