### PR TITLE
python-bindings: fix setup.py for wheel installation

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -33,6 +33,15 @@ if "--user" in sys.argv:
     except ImportError:
         pass
 
+# If building a wheel, the path listed in data_files is interpreted relative to
+# python's site-packages directory, even if it starts with a slash. So we need
+# to use only `/capstone` as path in this case.
+#
+# Note: using `capstone` does not work, since that for some reason is interpreted
+# relative to the the python installation prefix, not to the site-packages directory.
+if "bdist_wheel" in sys.argv:
+    SITE_PACKAGES = "/capstone"
+
 
 # adapted from commit e504b81 of Nguyen Tan Cong
 # Reference: https://docs.python.org/2/library/platform.html#cross-platform


### PR DESCRIPTION
When the python bindings are installed using the new wheels
infrastructure, data_files are relative to the site-packages directory
even if using absolute paths.

The following example demonstrates the bug fixed by this commit: (ran on archlinux)

```bash
$ pip install wheel       # if this package is installed, wheel installation is made the default
Collecting wheel
  Downloading wheel-0.29.0-py2.py3-none-any.whl (66kB)
    100% |################################| 71kB 124kB/s
Installing collected packages: wheel
Successfully installed wheel-0.29.0

$ pip install capstone    # this will use the wheel installation method now
Collecting capstone
  Using cached capstone-3.0.4.tar.gz
Building wheels for collected packages: capstone
  Running setup.py bdist_wheel for capstone ... done
  Stored in directory: /root/.cache/pip/wheels/7c/d1/d0/db6e2c5ef1063aabb9de2dd8b92b4c27ee6f9fd213240099b8
Successfully built capstone
Installing collected packages: capstone
Successfully installed capstone-3.0.4

$ find /usr/lib/ -name "libcapstone.so"
/usr/lib/python3.5/site-packages/usr/lib/python3.5/site-packages/capstone/libcapstone.so
```

So the path `SITE_PACKAGES` in the `data_files` specification of the
setup.py file was interpreted relative to the python site-packages
directory. The fix for this is simple: use `/capstone` instead of an
absolute path for `SITE_PACKAGES`.