### PR TITLE
Workaround unicorn handing back bytearrays

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -843,6 +843,10 @@ class Cs(object):
             print(code)
             code = code.encode()
             print(code)'''
+        # Hack, unicorn's memory accessors give you back bytearrays, but they
+        # cause TypeErrors when you hand them into Capstone.
+        if isinstance(code, bytearray):
+            code = bytes(code)
         res = _cs.cs_disasm(self.csh, code, len(code), offset, count, ctypes.byref(all_insn))
         if res > 0:
             try:


### PR DESCRIPTION
There's probably some more elegant fix for this, but currently everything breaks if you hand memory from unicorn directly into capstone.

There's also not any obvious tests, so I didn't add a regression test, but let me know if I should have somewhere.