### PR TITLE
Change pointer-deref-then-assignment to memmove to make PyPy happy.

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -503,7 +503,7 @@ class CsInsn(object):
         if self._cs._detail and self._raw.id != 0:
             # save detail
             self._raw.detail = ctypes.pointer(all_info.detail._type_())
-            ctypes.pointer(self._raw.detail[0])[0] = all_info.detail[0]
+            ctypes.memmove(ctypes.byref(self._raw.detail[0]), ctypes.byref(all_info.detail[0]), ctypes.sizeof(type(all_info.detail[0])))
 
     # return instruction's ID.
     @property


### PR DESCRIPTION
The `pointer(...)[0] = ...` idiom doesn't play nicely with pypy's implementation of ctypes. This patch should also be ported to the master branch.

Patch credit @ltfish