### PR TITLE
add X86_REG_EFLAGS for X86_STC

### DIFF
--- a/arch/X86/X86MappingInsn.inc
+++ b/arch/X86/X86MappingInsn.inc
@@ -15046,7 +15046,7 @@
 {
 	X86_STC, X86_INS_STC,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 0, 0
+	{ 0 }, { X86_REG_EFLAGS, 0 }, { X86_GRP_PRIVILEGE, 0 }, 0, 0
 #endif
 },
 {

--- a/arch/X86/X86MappingInsn.inc
+++ b/arch/X86/X86MappingInsn.inc
@@ -15046,13 +15046,13 @@
 {
 	X86_STC, X86_INS_STC,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { X86_REG_EFLAGS, 0 }, { X86_GRP_PRIVILEGE, 0 }, 0, 0
+	{ 0 }, { X86_REG_EFLAGS, 0 }, { 0 }, 0, 0
 #endif
 },
 {
 	X86_STD, X86_INS_STD,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 0, 0
+	{ 0 }, { X86_REG_EFLAGS, 0 }, { 0 }, 0, 0
 #endif
 },
 {


### PR DESCRIPTION
```
from capstone import *
from capstone.x86 import *

# F9 stc
# Sets the CF flag in the EFLAGS register.
# CF = 1;

md = Cs(CS_ARCH_X86, CS_MODE_64)
md.detail = True
insn = next(md.disasm("\xF9", 0x00))
print "0x%016X    %s %s" % (insn.address, insn.mnemonic, insn.op_str)
print "reg_read     => ", insn.regs_read
print "reg_write    => ", insn.regs_write
print X86_REG_EFLAGS in insn.regs_write
```

Result:

```
0x0000000000000000    stc
reg_read     =>  []
reg_write    =>  []
False
```

The STC instruction doesn't show that EFLAGS will been written.

Expected result:

```
0x0000000000000000    stc
reg_read     =>  []
reg_write    =>  [25]
True
```