### PR TITLE
Add X86_REG_EFLAGS for X86_STC and X86_STD for full x86 instructions …

### DIFF
--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -4040,13 +4040,13 @@ static insn_map insns[] = {	// full x86 instructions
 	{
 		X86_CLC, X86_INS_CLC,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { 0 }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS }, { 0 }, 0, 0
 #endif
 	},
 	{
 		X86_CLD, X86_INS_CLD,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { 0 }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS }, { 0 }, 0, 0
 #endif
 	},
 	{
@@ -4076,7 +4076,7 @@ static insn_map insns[] = {	// full x86 instructions
 	{
 		X86_CMC, X86_INS_CMC,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { 0 }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS }, { 0 }, 0, 0
 #endif
 	},
 	{
@@ -17036,13 +17036,13 @@ static insn_map insns[] = {	// full x86 instructions
 	{
 		X86_STC, X86_INS_STC,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { 0 }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS, 0 }, { 0 }, 0, 0
 #endif
 	},
 	{
 		X86_STD, X86_INS_STD,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { 0 }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS, 0 }, { 0 }, 0, 0
 #endif
 	},
 	{
@@ -39283,13 +39283,13 @@ static insn_map insns[] = {	// reduce x86 instructions
 	{
 		X86_CLC, X86_INS_CLC,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { 0 }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS }, { 0 }, 0, 0
 #endif
 	},
 	{
 		X86_CLD, X86_INS_CLD,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { 0 }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS }, { 0 }, 0, 0
 #endif
 	},
 	{
@@ -39313,7 +39313,7 @@ static insn_map insns[] = {	// reduce x86 instructions
 	{
 		X86_CMC, X86_INS_CMC,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { 0 }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS }, { 0 }, 0, 0
 #endif
 	},
 	{

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -4040,13 +4040,13 @@ static insn_map insns[] = {	// full x86 instructions
 	{
 		X86_CLC, X86_INS_CLC,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { X86_REG_EFLAGS }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS, 0 }, { 0 }, 0, 0
 #endif
 	},
 	{
 		X86_CLD, X86_INS_CLD,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { X86_REG_EFLAGS }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS, 0 }, { 0 }, 0, 0
 #endif
 	},
 	{
@@ -4076,7 +4076,7 @@ static insn_map insns[] = {	// full x86 instructions
 	{
 		X86_CMC, X86_INS_CMC,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { X86_REG_EFLAGS }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS, 0 }, { 0 }, 0, 0
 #endif
 	},
 	{
@@ -39283,13 +39283,13 @@ static insn_map insns[] = {	// reduce x86 instructions
 	{
 		X86_CLC, X86_INS_CLC,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { X86_REG_EFLAGS }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS, 0 }, { 0 }, 0, 0
 #endif
 	},
 	{
 		X86_CLD, X86_INS_CLD,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { X86_REG_EFLAGS }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS, 0 }, { 0 }, 0, 0
 #endif
 	},
 	{
@@ -39313,7 +39313,7 @@ static insn_map insns[] = {	// reduce x86 instructions
 	{
 		X86_CMC, X86_INS_CMC,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { X86_REG_EFLAGS }, { 0 }, 0, 0
+		{ 0 }, { X86_REG_EFLAGS, 0 }, { 0 }, 0, 0
 #endif
 	},
 	{


### PR DESCRIPTION
…; Add X86_REG_EFLAGS for X86_CLD, X86_CMC for reduce and full x86 instructions

1) Fix correctly https://github.com/aquynh/capstone/pull/798

2) Add EFLAGS for CLD, CMC and CLC instructions.

Test case:

```
from capstone import *
from capstone.x86 import *

md = Cs(CS_ARCH_X86, CS_MODE_64)
md.detail = True

for t in ["\xFC", "\xF5", "\xF8"]:
    insn = next(md.disasm(t, 0x00))
    print "0x%016X    %s %s" % (insn.address, insn.mnemonic, insn.op_str)
    print "reg_read     => ", insn.regs_read
    print "reg_write    => ", insn.regs_write
    print X86_REG_EFLAGS in insn.regs_write
    print hex(insn.eflags)
    print "-" * 10
```

Result:

```
0x0000000000000000    cld
reg_read     =>  []
reg_write    =>  []
False
0x800000L
----------
0x0000000000000000    cmc
reg_read     =>  []
reg_write    =>  []
False
0x2L
----------
0x0000000000000000    clc
reg_read     =>  []
reg_write    =>  []
False
0x400000L
```

Expected result:

```
0x0000000000000000    cld
reg_read     =>  []
reg_write    =>  [25]
False
0x800000L
----------
0x0000000000000000    cmc
reg_read     =>  []
reg_write    =>  [25]
False
0x2L
----------
0x0000000000000000    clc
reg_read     =>  []
reg_write    =>  [25]
False
0x400000L
```