### PR TITLE
Java: Support cs_strerror() and cs_regs_access()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ This file details the changelog of Capstone.
 - Fix a bug where Arm.OpInfo.memBarrier and Arm.OpInfo.op is wrongly
   calculated
 
+[ Bindings ]
+
+- Java; add Capstone.strerror() and CsInsn.regsAccess().
+
 ---------------------------------
 Version 3.0.2: March 11th, 2015
 


### PR DESCRIPTION
Add two more functions to the Java binding: cs_strerror() as Capstone.strerror() and cs_regs_access() as CsInsn.regsAccess().