### PR TITLE
Java: Fix a bug where Arm.OpInfo.memBarrier and Arm.OpInfo.op is wrongly calculated

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@ This file details the changelog of Capstone.
 
 - Fix a bug where Arm.Operand is wrongly calculated for the second and
   following operands
+- Fix a bug where Arm.OpInfo.memBarrier and Arm.OpInfo.op is wrongly
+  calculated
 
 ---------------------------------
 Version 3.0.2: March 11th, 2015

--- a/bindings/java/capstone/Arm.java
+++ b/bindings/java/capstone/Arm.java
@@ -93,7 +93,7 @@ public class Arm {
     public int cc;
     public byte update_flags;
     public byte writeback;
-    public byte mem_barrier;
+    public int mem_barrier;
     public byte op_count;
 
     public Operand [] op;


### PR DESCRIPTION
Fix an incorrect type in the Java binding which causes incorrect field values.