### PR TITLE
Java: Fix a bug where Arm.Operand is wrongly calculated for the second and following operands

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 This file details the changelog of Capstone.
 
+[ Arm ]
+
+- Fix a bug where Arm.Operand is wrongly calculated for the second and
+  following operands
+
 ---------------------------------
 Version 3.0.2: March 11th, 2015
 

--- a/bindings/java/capstone/Arm.java
+++ b/bindings/java/capstone/Arm.java
@@ -55,8 +55,8 @@ public class Arm {
     public int type;
     public OpValue value;
     public boolean subtracted;
-    public int access;
-    public int neon_lane;
+    public byte access;
+    public byte neon_lane;
 
     public void read() {
       readField("vector_index");


### PR DESCRIPTION
Fix an incorrect type in the Java binding which causes incorrect field values.