### PR TITLE
Make sure bindir exists before installing to it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,6 +416,7 @@ endif
 	$(INSTALL_DATA) include/capstone/*.h $(DESTDIR)$(INCDIR)/$(LIBNAME)
 	mkdir -p $(DESTDIR)$(PKGCFGDIR)
 	$(INSTALL_DATA) $(PKGCFGF) $(DESTDIR)$(PKGCFGDIR)
+	mkdir -p $(DESTDIR)$(BINDIR)
 	$(INSTALL_LIB) cstool/cstool $(DESTDIR)$(BINDIR)
 
 uninstall:


### PR DESCRIPTION
Without this, installing to a temporary directory tree (as done by
some package managers) installs cstool as the file /usr/bin.

This brings next in line with the behavior of master.