### PR TITLE
Fix build under VS2012 (i.e. MSC_VER = 1700)

### DIFF
--- a/cstool/cstool.c
+++ b/cstool/cstool.c
@@ -1,6 +1,4 @@
 /* Tang Yuhang <tyh000011112222@gmail.com> 2016 */
-#include <stdio.h>
-#include <inttypes.h>
 #include <string.h>
 #include <ctype.h>
 #include <errno.h>

--- a/include/platform.h
+++ b/include/platform.h
@@ -90,6 +90,11 @@ typedef unsigned long long uint64_t;
 #define PRIX32        "X"
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER <= 1700
+// redefine functions from inttypes.h used in cstool
+#define strtoull _strtoui64
+#endif
+
 #define PRId64        __PRI_64_LENGTH_MODIFIER__ "d"
 #define PRIi64        __PRI_64_LENGTH_MODIFIER__ "i"
 #define PRIo64        __PRI_64_LENGTH_MODIFIER__ "o"


### PR DESCRIPTION
cstool.c currently imports `inttypes.h`, which breaks building on older Visual Studio versions (I've been testing 2012). This commit removes the explicit include of `inttypes.h`, which is already handled in `platform.h` (which is included by `capstone.h`). A define for the function `strtoull` (used by `cstool`) has also been added to `platform.h` for the case where `MSC_VER <= 1700`.

I don't know what effect this will have on OS X builds as I'm unable to test on that platform. I've tested it successfully on Ubuntu (i.e. I've run make.sh with no complaints.)

Also, `cstool.c` doesn't need to include `stdio.h` because it's already included by `capstone.h`.