### PR TITLE
Patch for issue #842

### DIFF
--- a/arch/ARM/ARMMapping.c
+++ b/arch/ARM/ARMMapping.c
@@ -13418,7 +13418,7 @@ static insn_map insns[] = {
 	{
 		ARM_tSETEND, ARM_INS_SETEND,
 #ifndef CAPSTONE_DIET
-		{ 0 }, { 0 }, { ARM_GRP_NOTMCLASS, 0 }, 0, 0
+		{ 0 }, { 0 }, { ARM_GRP_THUMB, ARM_GRP_V6, ARM_GRP_NOTMCLASS, 0}, 0, 0
 #endif
 	},
 	{


### PR DESCRIPTION
The SETEND instruction is a 16 bit Thumb instruction which is included
in T variants of ARMv6 and above, but is not available in M-Class cores
(see ARM Compiler toolchain Assembler Reference Ver 5.0).

To be consistent with other similar instructions its group flags have
been updated to be:

{ARM_GRP_THUMB, ARM_GRP_V6, ARM_GRP_NOTMCLASS,0}