### PR TITLE
Fixes truncated immediate value in operand details

### DIFF
--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -958,7 +958,7 @@ static void printLogicalImm64(MCInst *MI, unsigned OpNum, SStream *O)
 		MI->ac_idx++;
 #endif
 		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].type = ARM64_OP_IMM;
-		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].imm = (int)Val;
+		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].imm = (int64_t)Val;
 		MI->flat_insn->detail->arm64.op_count++;
 	}
 }


### PR DESCRIPTION
The instruction encoded « 00 00 19 B2 » was correctly disassembled « orr x0, x0, #0x8000000080 », but the reported immediate value, in the detail structure, was truncated to 0x80 due to the cast.