### PR TITLE
Fix compilation from within a macOS kernel extension

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -4,7 +4,11 @@
 #ifndef CS_UTILS_H
 #define CS_UTILS_H
 
+#if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <libkern/libkern.h>
+#else
 #include <stddef.h>
+#endif
 #include "include/capstone.h"
 #include "cs_priv.h"
 


### PR DESCRIPTION
Now that capstone is getting close to the release of a new version, would you be so kind to fix the compilation error arising when you try to compile it into the macOS kernel? There is no stddef.h file in Kernel.framework and thus an include is invalid.

Also, might you want to delete [this line](https://github.com/aquynh/capstone/blob/f177f92a7c9bea2dd7259577175cfa13579ec425/cs.c#L326)? I remember receiving a compiler warning for it.