### PR TITLE
Fix UB when accessing un-initialized array

### DIFF
--- a/arch/X86/X86ATTInstPrinter.c
+++ b/arch/X86/X86ATTInstPrinter.c
@@ -917,7 +917,7 @@ void X86_ATT_printInst(MCInst *MI, SStream *OS, void *info)
 	}
 
 	if (MI->csh->detail) {
-		uint8_t access[6];
+		uint8_t access[6] = {0};
 
 		// some instructions need to supply immediate 1 in the first op
 		switch(MCInst_getOpcode(MI)) {


### PR DESCRIPTION
Bug found in r2 and patch tested for a week or so

Ref: https://github.com/radare/radare2/blob/master/shlr/capstone-patches/fix-undef.patch