### PR TITLE
Fix undefined behaviour produced by disassembling 6662dcbc615a

### DIFF
--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -901,7 +901,7 @@ bool X86_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 		MCInst *instr, uint16_t *size, uint64_t address, void *_info)
 {
 	cs_struct *handle = (cs_struct *)(uintptr_t)ud;
-	InternalInstruction insn;
+	InternalInstruction insn = {0};
 	struct reader_info info;
 	int ret;
 	bool result;
@@ -909,8 +909,6 @@ bool X86_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 	info.code = code;
 	info.size = code_len;
 	info.offset = address;
-
-	memset(&insn, 0, offsetof(InternalInstruction, reader));
 
 	if (instr->flat_insn->detail) {
 		instr->flat_insn->detail->x86.op_count = 0;


### PR DESCRIPTION
Bug found by @h4ng3r and fixed by @trufae in radare2 https://github.com/radare/radare2/commit/d692bfb37a28965b7824b8486baeaeaab630dbb8

cstool reproducer and proof:

<img width="575" alt="screen shot 2017-04-20 at 16 52 21" src="https://cloud.githubusercontent.com/assets/917142/25237218/531dbdc4-25ea-11e7-8777-23655dd175ce.png">
