### PR TITLE
Bugfix : setting all fields to insns cache

### DIFF
--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -230,9 +230,9 @@ static void translateImmediate(MCInst *mcInst, uint64_t immediate,
 				case X86_CMPSSrr:  NewOpc = X86_CMPSSrr_alt;  break;
 			}
 			// Switch opcode to the one that doesn't get special printing.
-            if (NewOpc != 0) {
-                MCInst_setOpcode(mcInst, NewOpc);
-            }
+			if (NewOpc != 0) {
+				MCInst_setOpcode(mcInst, NewOpc);
+			}
 		}
 #endif
 	} else if (type == TYPE_IMM5) {
@@ -265,9 +265,9 @@ static void translateImmediate(MCInst *mcInst, uint64_t immediate,
 				case X86_VCMPSSZrr:  NewOpc = X86_VCMPSSZrri_alt; break;
 			}
 			// Switch opcode to the one that doesn't get special printing.
-            if (NewOpc != 0) {
-                MCInst_setOpcode(mcInst, NewOpc);
-            }
+			if (NewOpc != 0) {
+				MCInst_setOpcode(mcInst, NewOpc);
+			}
 		}
 #endif
 	}

--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -230,7 +230,9 @@ static void translateImmediate(MCInst *mcInst, uint64_t immediate,
 				case X86_CMPSSrr:  NewOpc = X86_CMPSSrr_alt;  break;
 			}
 			// Switch opcode to the one that doesn't get special printing.
-			MCInst_setOpcode(mcInst, NewOpc);
+            if (NewOpc != 0) {
+                MCInst_setOpcode(mcInst, NewOpc);
+            }
 		}
 #endif
 	} else if (type == TYPE_IMM5) {

--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -263,7 +263,9 @@ static void translateImmediate(MCInst *mcInst, uint64_t immediate,
 				case X86_VCMPSSZrr:  NewOpc = X86_VCMPSSZrri_alt; break;
 			}
 			// Switch opcode to the one that doesn't get special printing.
-			MCInst_setOpcode(mcInst, NewOpc);
+            if (NewOpc != 0) {
+                MCInst_setOpcode(mcInst, NewOpc);
+            }
 		}
 #endif
 	}

--- a/utils.c
+++ b/utils.c
@@ -19,7 +19,7 @@ static unsigned short *make_id2insn(insn_map *insns, unsigned int size)
 
 	unsigned short *cache = (unsigned short *)cs_mem_malloc(sizeof(*cache) * (max_id + 1));
 
-	for (i = 1; i < size; i++)
+	for (i = 0; i < size; i++)
 		cache[insns[i].id] = i;
 
 	return cache;

--- a/utils.c
+++ b/utils.c
@@ -19,7 +19,7 @@ static unsigned short *make_id2insn(insn_map *insns, unsigned int size)
 
 	unsigned short *cache = (unsigned short *)cs_mem_malloc(sizeof(*cache) * (max_id + 1));
 
-	for (i = 0; i < size; i++)
+	for (i = 1; i < size; i++)
 		cache[insns[i].id] = i;
 
 	return cache;


### PR DESCRIPTION
The insn_cache array was not set for index 0.
But it happens that insn_find can look for id 0.
And so, insn_find may return something bigger than max and we get a set fault.

This happened on a compilation on Linux with gcc -O3