### PR TITLE
cmake - fix SOVERSION property used for libcapstone.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,7 +381,6 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 ## properties
 # version info
 set_property(GLOBAL PROPERTY VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
-set_property(GLOBAL PROPERTY SOVERSION SOVERSION ${VERSION_MAJOR})
 
 ## targets
 if (CAPSTONE_BUILD_STATIC)
@@ -411,6 +410,10 @@ if (CAPSTONE_BUILD_SHARED)
 
     if (MSVC)
         set_target_properties(capstone-shared PROPERTIES IMPORT_SUFFIX _dll.lib)
+    else()
+        set_target_properties(capstone-shared PROPERTIES
+	    VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
+	    SOVERSION ${VERSION_MAJOR})
     endif ()
 
     if(NOT DEFINED default-target)      # honor `capstone-static` for tests first.


### PR DESCRIPTION
It was set as a global property before, but cmake appears to ignore that,
even after the following fix:
-set_property(GLOBAL PROPERTY SOVERSION SOVERSION ${VERSION_MAJOR})
+set_property(GLOBAL PROPERTY SOVERSION ${VERSION_MAJOR})

So this patch removes the global property, and SOVERSION is now specified as
a target specific property. The result of the cmake install target seems better:

Before:

```
$ ls -la lib
4375834 May  1 16:05 libcapstone.a
3510040 May  1 16:05 libcapstone.so
```
After:
```
$ ls -la lib
4375834 May  1 16:05 libcapstone.a
     16 May  1 16:08 libcapstone.so -> libcapstone.so.4
     20 May  1 16:08 libcapstone.so.4 -> libcapstone.so.4.0.0
3510040 May  1 16:08 libcapstone.so.4.0.0
```
The SOVERSION property triggers symlink creation in cmake, see:
https://cmake.org/cmake/help/v3.0/prop_tgt/SOVERSION.html