### PR TITLE
Merge #929 with some changes to get things compile

### DIFF
--- a/arch/X86/X86GenAsmWriter1.inc
+++ b/arch/X86/X86GenAsmWriter1.inc
@@ -20484,6 +20484,8 @@ static char *getRegisterName(unsigned RegNo)
 #ifdef PRINT_ALIAS_INSTR
 #undef PRINT_ALIAS_INSTR
 
+#ifndef CAPSTONE_DIET
+
 static void printCustomAliasOperand(MCInst *MI, unsigned OpIdx,
   unsigned PrintMethodIdx, SStream *OS)
 {
@@ -20572,5 +20574,7 @@ static char *printAliasInstr(MCInst *MI, SStream *OS, void *info)
   }
   return tmp;
 }
+
+#endif
 
 #endif // PRINT_ALIAS_INSTR

--- a/arch/X86/X86GenAsmWriter1_reduce.inc
+++ b/arch/X86/X86GenAsmWriter1_reduce.inc
@@ -4575,6 +4575,8 @@ static char *getRegisterName(unsigned RegNo)
 #ifdef PRINT_ALIAS_INSTR
 #undef PRINT_ALIAS_INSTR
 
+#ifndef CAPSTONE_DIET
+
 static void printCustomAliasOperand(MCInst *MI, unsigned OpIdx,
   unsigned PrintMethodIdx, SStream *OS)
 {
@@ -4645,5 +4647,7 @@ static char *printAliasInstr(MCInst *MI, SStream *OS, void *info)
   }
   return tmp;
 }
+
+#endif
 
 #endif // PRINT_ALIAS_INSTR

--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -720,11 +720,16 @@ static void printMemOffs64(MCInst *MI, unsigned OpNo, SStream *O)
 	printMemOffset(MI, OpNo, O);
 }
 
+#ifndef CAPSTONE_DIET
 static char *printAliasInstr(MCInst *MI, SStream *OS, void *info);
+#endif
 static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI);
+
 void X86_Intel_printInst(MCInst *MI, SStream *O, void *Info)
 {
+#ifndef CAPSTONE_DIET
 	char *mnem;
+#endif
 	x86_reg reg, reg2;
 	enum cs_ac_type access1, access2;
 
@@ -734,11 +739,13 @@ void X86_Intel_printInst(MCInst *MI, SStream *O, void *Info)
 		return;
 	}
 
+#ifndef CAPSTONE_DIET
 	// Try to print any aliases first.
 	mnem = printAliasInstr(MI, O, Info);
 	if (mnem)
 		cs_mem_free(mnem);
 	else
+#endif
 		printInstruction(MI, O, Info);
 
 	reg = X86_insn_reg_intel(MCInst_getOpcode(MI), &access1);

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -4,7 +4,9 @@
 #ifdef CAPSTONE_HAS_X86
 
 #include <string.h>
+#ifndef CAPSTONE_HAS_OSXKERNEL
 #include <stdlib.h>
+#endif
 
 #include "X86Mapping.h"
 #include "X86DisassemblerDecoder.h"
@@ -3128,6 +3130,7 @@ static bool valid_repne(cs_struct *h, unsigned int opcode)
 
 // given MCInst's id, find out if this insn is valid for BND prefix
 // BND prefix is valid for CALL/JMP/RET
+#ifndef CAPSTONE_DIET
 static bool valid_bnd(cs_struct *h, unsigned int opcode)
 {
 	unsigned int id;
@@ -3171,6 +3174,7 @@ static bool valid_bnd(cs_struct *h, unsigned int opcode)
 	// not found
 	return false;
 }
+#endif
 
 // given MCInst's id, find out if this insn is valid for REP prefix
 static bool valid_rep(cs_struct *h, unsigned int opcode)

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -30,9 +30,9 @@ extern "C" {
 #endif
 #else
 #define CAPSTONE_API
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(CAPSTONE_STATIC)
 #define CAPSTONE_EXPORT __attribute__((visibility("default")))
-#else
+#else    // defined(CAPSTONE_STATIC)
 #define CAPSTONE_EXPORT
 #endif
 #endif

--- a/include/capstone/platform.h
+++ b/include/capstone/platform.h
@@ -62,6 +62,11 @@ typedef unsigned long long uint64_t;
 #define UINT64_MAX       0xffffffffffffffffui64
 #endif  // defined(_MSC_VER) && (_MSC_VER <= 1700 || defined(_KERNEL_MODE))
 
+#ifdef CAPSTONE_HAS_OSXKERNEL
+// this system has stdint.h
+#include <stdint.h>
+#endif
+
 #define __PRI_8_LENGTH_MODIFIER__ "hh"
 #define __PRI_64_LENGTH_MODIFIER__ "ll"
 


### PR DESCRIPTION
This implements the changes made in #929 along with two small header fixes to get things compile for OS X kernel.

While these two changes are exactly necessary, there are (at least) two more changes for next branch to be used in the kernel:
1. qsort — there is no public KPI for it
2. Vulnerability fix https://github.com/aquynh/capstone/pull/725#issuecomment-301737249, this remains present in next branch.

Could you fix both of these on your own? They clearly are not part of this PR.
There are multiple qsort implementations with permissive licenses: [example 1](https://opensource.apple.com/source/xnu/xnu-3248.60.10/bsd/kern/qsort.c.html), [example 2](https://opensource.apple.com/source/Libc/Libc-1158.50.2/stdlib/FreeBSD/qsort.c.auto.html), [example 3](http://www.d-rift.nl/combuster/mos3/?p=viewsource&file=/libc/stdlib/qsort.c).
And the vulnerability issue is properly explained in the comment.

Thanks