### PR TITLE
Fix kernel addresses shown as negative numbers

### DIFF
--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -421,11 +421,8 @@ static void printImm(int syntax, SStream *O, int64_t imm, bool positive)
 			if (imm < 0) {
 				if (imm == 0x8000000000000000LL)  // imm == -imm
 					SStream_concat0(O, "0x8000000000000000");
-				else if (imm < -HEX_THRESHOLD)
-					SStream_concat(O, "-0x%"PRIx64, -imm);
-				else
-					SStream_concat(O, "-%"PRIu64, -imm);
-
+                                else
+					SStream_concat(O, "0x%"PRIx64, imm);
 			} else {
 				if (imm > HEX_THRESHOLD)
 					SStream_concat(O, "0x%"PRIx64, imm);


### PR DESCRIPTION
Some instructions like movq when setting kernel addresses (major bit set to 1) shows a negative hex number which is wrong. This patch disabled the negative hexadecimal number for those cases, the patch have passed the entire r2 testsuite without any broken test, and @jpenalbae confirms that its working.

The GNU disassembler and udis86 already did that right, so i think capstone should keep the same behaviour.

If changing this behaviour can hurt someone we can have an option flag for this, but it's only affecting x86 and on some instructions, not all, negative immediates still work.