### PR TITLE
Add CS_MODE_MIPS2 to opt-in for COP3 instructions

### DIFF
--- a/arch/Mips/MipsDisassembler.c
+++ b/arch/Mips/MipsDisassembler.c
@@ -451,7 +451,7 @@ static DecodeStatus MipsDisassembler_getInstruction(int mode, MCInst *instr,
 
 	readInstruction32((unsigned char*)code, &Insn, isBigEndian, false);
 
-	if (((mode & CS_MODE_MIPS32) == 0) && ((mode & CS_MODE_MIPS3) == 0)) {
+	if ((mode & CS_MODE_MIPS2) && ((mode & CS_MODE_MIPS3) == 0)) {
 		// DEBUG(dbgs() << "Trying COP3_ table (32-bit opcodes):\n");
 		Result = decodeInstruction(DecoderTableCOP3_32, instr, Insn, Address, MRI, mode);
 		if (Result != MCDisassembler_Fail) {

--- a/arch/Mips/MipsModule.c
+++ b/arch/Mips/MipsModule.c
@@ -16,7 +16,7 @@ static cs_err init(cs_struct *ud)
 	// verify if requested mode is valid
 	if (ud->mode & ~(CS_MODE_LITTLE_ENDIAN | CS_MODE_32 | CS_MODE_64 |
 				CS_MODE_MICRO | CS_MODE_MIPS32R6 | CS_MODE_BIG_ENDIAN |
-                CS_MODE_MIPS2 | CS_MODE_MIPS3))
+				CS_MODE_MIPS2 | CS_MODE_MIPS3))
 		return CS_ERR_MODE;
 
 	mri = cs_mem_malloc(sizeof(*mri));

--- a/arch/Mips/MipsModule.c
+++ b/arch/Mips/MipsModule.c
@@ -15,7 +15,8 @@ static cs_err init(cs_struct *ud)
 
 	// verify if requested mode is valid
 	if (ud->mode & ~(CS_MODE_LITTLE_ENDIAN | CS_MODE_32 | CS_MODE_64 |
-				CS_MODE_MICRO | CS_MODE_MIPS32R6 | CS_MODE_BIG_ENDIAN))
+				CS_MODE_MICRO | CS_MODE_MIPS32R6 | CS_MODE_BIG_ENDIAN |
+                CS_MODE_MIPS2 | CS_MODE_MIPS3))
 		return CS_ERR_MODE;
 
 	mri = cs_mem_malloc(sizeof(*mri));

--- a/bindings/java/capstone/Capstone.java
+++ b/bindings/java/capstone/Capstone.java
@@ -336,6 +336,7 @@ public class Capstone {
   public static final int CS_MODE_MICRO = 1 << 4;	  // MicroMips mode (Mips arch)
   public static final int CS_MODE_MIPS3 = 1 << 5;     // Mips III ISA
   public static final int CS_MODE_MIPS32R6 = 1 << 6;  // Mips32r6 ISA
+  public static final int CS_MODE_MIPS2 = 1 << 7;  // Mips II ISA
   public static final int CS_MODE_BIG_ENDIAN = 1 << 31; // big-endian mode
   public static final int CS_MODE_V9 = 1 << 4;	      // SparcV9 mode (Sparc arch)
   public static final int CS_MODE_MIPS32 = CS_MODE_32; // Mips32 ISA

--- a/bindings/ocaml/capstone.ml
+++ b/bindings/ocaml/capstone.ml
@@ -35,6 +35,7 @@ type mode =
   |	CS_MODE_MICRO		(* MicroMips mode (MIPS architecture) *)
   |	CS_MODE_MIPS3		(* Mips3 mode (MIPS architecture) *)
   |	CS_MODE_MIPS32R6	(* Mips32-R6 mode (MIPS architecture) *)
+  |	CS_MODE_MIPS2	    (* Mips2 mode (MIPS architecture) *)
   |	CS_MODE_V9			(* SparcV9 mode (Sparc architecture) *)
   |	CS_MODE_BIG_ENDIAN	(* big-endian mode *)
   |	CS_MODE_MIPS32		(* Mips32 mode (for Mips) *)

--- a/bindings/ocaml/ocaml.c
+++ b/bindings/ocaml/ocaml.c
@@ -700,18 +700,21 @@ CAMLprim value ocaml_cs_disasm(value _arch, value _mode, value _code, value _add
 				mode |= CS_MODE_MIPS32R6;
 				break;
 			case 11:
-				mode |= CS_MODE_V9;
+				mode |= CS_MODE_MIPS2;
 				break;
 			case 12:
-				mode |= CS_MODE_BIG_ENDIAN;
+				mode |= CS_MODE_V9;
 				break;
 			case 13:
-				mode |= CS_MODE_MIPS32;
+				mode |= CS_MODE_BIG_ENDIAN;
 				break;
 			case 14:
-				mode |= CS_MODE_MIPS64;
+				mode |= CS_MODE_MIPS32;
 				break;
 			case 15:
+				mode |= CS_MODE_MIPS64;
+				break;
+			case 16:
 				mode |= CS_MODE_QPX;
 				break;
 			default:
@@ -831,18 +834,21 @@ CAMLprim value ocaml_open(value _arch, value _mode)
 				mode |= CS_MODE_MIPS32R6;
 				break;
 			case 11:
-				mode |= CS_MODE_V9;
+				mode |= CS_MODE_MIPS2;
 				break;
 			case 12:
-				mode |= CS_MODE_BIG_ENDIAN;
+				mode |= CS_MODE_V9;
 				break;
 			case 13:
-				mode |= CS_MODE_MIPS32;
+				mode |= CS_MODE_BIG_ENDIAN;
 				break;
 			case 14:
-				mode |= CS_MODE_MIPS64;
+				mode |= CS_MODE_MIPS32;
 				break;
 			case 15:
+				mode |= CS_MODE_MIPS64;
+				break;
+			case 16:
 				mode |= CS_MODE_QPX;
 				break;
 			default:

--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -46,6 +46,7 @@ __all__ = [
     'CS_MODE_MICRO',
     'CS_MODE_MIPS3',
     'CS_MODE_MIPS32R6',
+    'CS_MODE_MIPS2',
     'CS_MODE_V8',
     'CS_MODE_V9',
     'CS_MODE_QPX',
@@ -151,6 +152,7 @@ CS_MODE_V8 = (1 << 6)          # ARMv8 A32 encodings for ARM
 CS_MODE_MICRO = (1 << 4)       # MicroMips mode (MIPS architecture)
 CS_MODE_MIPS3 = (1 << 5)       # Mips III ISA
 CS_MODE_MIPS32R6 = (1 << 6)    # Mips32r6 ISA
+CS_MODE_MIPS2 = (1 << 7)       # Mips II ISA
 CS_MODE_V9 = (1 << 4)          # Sparc V9 mode (for Sparc)
 CS_MODE_QPX = (1 << 4)         # Quad Processing eXtensions mode (PPC)
 CS_MODE_M68K_000 = (1 << 1)    # M68K 68000 mode

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -109,6 +109,7 @@ typedef enum cs_mode {
 	CS_MODE_MICRO = 1 << 4, // MicroMips mode (MIPS)
 	CS_MODE_MIPS3 = 1 << 5, // Mips III ISA
 	CS_MODE_MIPS32R6 = 1 << 6, // Mips32r6 ISA
+	CS_MODE_MIPS2 = 1 << 7, // Mips II ISA
 	CS_MODE_V9 = 1 << 4, // SparcV9 mode (Sparc)
 	CS_MODE_QPX = 1 << 4, // Quad Processing eXtensions mode (PPC)
 	CS_MODE_M68K_000 = 1 << 1, // M68K 68000 mode

--- a/tests/test_mips.c
+++ b/tests/test_mips.c
@@ -82,35 +82,50 @@ static void test()
 #define MIPS_CODE2 "\x56\x34\x21\x34\xc2\x17\x01\x00"
 #define MIPS_32R6M "\x00\x07\x00\x07\x00\x11\x93\x7c\x01\x8c\x8b\x7c\x00\xc7\x48\xd0"
 #define MIPS_32R6 "\xec\x80\x00\x19\x7c\x43\x22\xa0"
+#define MIPS_64SD "\x70\x00\xb2\xff"
 
 	struct platform platforms[] = {
 		{
 			CS_ARCH_MIPS,
-			(cs_mode)(CS_MODE_MIPS32 + CS_MODE_BIG_ENDIAN),
+			(cs_mode)(CS_MODE_MIPS32 | CS_MODE_BIG_ENDIAN),
 			(unsigned char *)MIPS_CODE,
 			sizeof(MIPS_CODE) - 1,
 			"MIPS-32 (Big-endian)"
 		},
 		{
 			CS_ARCH_MIPS,
-			(cs_mode)(CS_MODE_MIPS64 + CS_MODE_LITTLE_ENDIAN),
+			(cs_mode)(CS_MODE_MIPS64 | CS_MODE_LITTLE_ENDIAN),
 			(unsigned char *)MIPS_CODE2,
 			sizeof(MIPS_CODE2) - 1,
 			"MIPS-64-EL (Little-endian)"
 		},
 		{
 			CS_ARCH_MIPS,
-			(cs_mode)(CS_MODE_MIPS32R6 + CS_MODE_MICRO + CS_MODE_BIG_ENDIAN),
+			(cs_mode)(CS_MODE_MIPS32R6 | CS_MODE_MICRO + CS_MODE_BIG_ENDIAN),
 			(unsigned char*)MIPS_32R6M,
 			sizeof(MIPS_32R6M) - 1,
 			"MIPS-32R6 | Micro (Big-endian)"
 		},
 		{
 			CS_ARCH_MIPS,
-			(cs_mode)(CS_MODE_MIPS32R6 + CS_MODE_BIG_ENDIAN),
+			(cs_mode)(CS_MODE_MIPS32R6 | CS_MODE_BIG_ENDIAN),
 			(unsigned char*)MIPS_32R6,
 			sizeof(MIPS_32R6) - 1,
 			"MIPS-32R6 (Big-endian)"
+		},
+		{
+			CS_ARCH_MIPS,
+			(cs_mode)(CS_MODE_MIPS64 | CS_MODE_MIPS2 | CS_MODE_LITTLE_ENDIAN),
+			(unsigned char *)MIPS_64SD,
+			sizeof(MIPS_64SD) - 1,
+			"MIPS-64-EL + Mips II (Little-endian)"
+		},
+		{
+			CS_ARCH_MIPS,
+			(cs_mode)(CS_MODE_MIPS64 | CS_MODE_LITTLE_ENDIAN),
+			(unsigned char *)MIPS_64SD,
+			sizeof(MIPS_64SD) - 1,
+			"MIPS-64-EL (Little-endian)"
 		},
 	};
 

--- a/tests/test_mips.c
+++ b/tests/test_mips.c
@@ -101,7 +101,7 @@ static void test()
 		},
 		{
 			CS_ARCH_MIPS,
-			(cs_mode)(CS_MODE_MIPS32R6 | CS_MODE_MICRO + CS_MODE_BIG_ENDIAN),
+			(cs_mode)(CS_MODE_MIPS32R6 | CS_MODE_MICRO | CS_MODE_BIG_ENDIAN),
 			(unsigned char*)MIPS_32R6M,
 			sizeof(MIPS_32R6M) - 1,
 			"MIPS-32R6 | Micro (Big-endian)"


### PR DESCRIPTION
If both CS_MODE_MIPS2 and CS_MODE_MIPS3 are set, MIPS3 wins.

It's possible to set CS_MODE_MIPS2 also in combination with CS_MODE_{MIPS32|MIPS64} because the first versions of those specs were based on Mips II. In this case the opcodes for the new doubleword instructions won't be available since they overlap with COP3 (coprocessor 3) instructions.

Intended to fix https://github.com/aquynh/capstone/issues/938