### PR TITLE
mingw build: cstool fails to build with mingw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ PKGCFGF = $(BLDIR)/$(LIBNAME).pc
 
 all: $(LIBRARY) $(ARCHIVE) $(PKGCFGF)
 ifeq (,$(findstring yes,$(CAPSTONE_BUILD_CORE_ONLY)))
-	@V=$(V) $(MAKE) -C cstool
+	@V=$(V) CC=$(CC) $(MAKE) -C cstool
 ifndef BUILDDIR
 	cd tests && $(MAKE)
 else

--- a/cstool/Makefile
+++ b/cstool/Makefile
@@ -13,21 +13,21 @@ TARGET = cstool
 SOURCES := $(wildcard *.c)
 OBJECTS := $(SOURCES:.c=.o)
 
-AR_EXT = a
+LIBCAPSTONE = libcapstone.a
 
 IS_CYGWIN := $(shell $(CC) -dumpmachine 2>/dev/null | grep -i cygwin | wc -l)
 ifeq ($(IS_CYGWIN),1)
-AR_EXT = lib
+LIBCAPSTONE = capstone.lib
 else
 IS_MINGW := $(shell $(CC) --version 2>/dev/null | grep -i mingw | wc -l)
 ifeq ($(IS_MINGW),1)
-AR_EXT = lib
+LIBCAPSTONE = capstone.lib
 endif
 endif
 
 all: $(TARGET)
 
-$(TARGET): ../libcapstone.$(AR_EXT) $(OBJECTS)
+$(TARGET): ../$(LIBCAPSTONE) $(OBJECTS)
 ifeq ($(V),0)
 	$(call log,LINK,$@)
 	@${CC} $(OBJECTS) $(LDFLAGS) -o $@


### PR DESCRIPTION
The correct compiler was not being passed to `cstool/Makefile`. The expected name for the capstone lib was also incorrect - there is no "lib" prefix when compiling with mingw.