### PR TITLE
Fixed bug in memory operand decoding.

### DIFF
--- a/arch/TMS320C64x/TMS320C64xDisassembler.c
+++ b/arch/TMS320C64x/TMS320C64xDisassembler.c
@@ -289,7 +289,7 @@ static DecodeStatus DecodeMemOperandSc(MCInst *Inst, unsigned Val,
 			if((offset >= TMS320C64X_REG_A0) && (offset <= TMS320C64X_REG_A31))
 				offset = (offset - TMS320C64X_REG_A0 + TMS320C64X_REG_B0);
 			else if((offset >= TMS320C64X_REG_B0) && (offset <= TMS320C64X_REG_B31))
-				offset = (base - TMS320C64X_REG_B0 + TMS320C64X_REG_A0);
+				offset = (offset - TMS320C64X_REG_B0 + TMS320C64X_REG_A0);
 			offsetreg = getReg(GPRegsDecoderTable, offset);
 			MCOperand_CreateImm0(Inst, (scaled << 19) | (basereg << 12) | (offsetreg << 5) | (mode << 1) | unit);
 			break;


### PR DESCRIPTION
Fixed bug #979. Decoding a memory operand with a register offset from
the B file would return an incorrect register.