### PR TITLE
Fix the include path for Android builds when building cstool

### DIFF
--- a/cstool/Makefile
+++ b/cstool/Makefile
@@ -6,8 +6,8 @@ include ../functions.mk
 
 LIBNAME = capstone
 
-CFLAGS = -I../include
-LDFLAGS = -O3 -Wall -L.. -l$(LIBNAME)
+CFLAGS += -I../include
+LDFLAGS += -O3 -Wall -L.. -l$(LIBNAME)
 
 TARGET = cstool
 SOURCES := $(wildcard *.c)


### PR DESCRIPTION
Previously, the CFLAGS= statement would strip --sysroot from CFLAGS.