### PR TITLE
cstool: Separate instruction bytes by spaces

### DIFF
--- a/cstool/cstool.c
+++ b/cstool/cstool.c
@@ -324,6 +324,8 @@ int main(int argc, char **argv)
 
 			printf("%"PRIx64"  ", insn[i].address);
 			for (j = 0; j < insn[i].size; j++) {
+				if (j > 0)
+					putchar(' ');
 				printf("%02x", insn[i].bytes[j]);
 			}
 			// X86 instruction size is variable.


### PR DESCRIPTION
Fixes #1005.