### PR TITLE
fixed hardcoded paths with variables.

### DIFF
--- a/capstone.pc.in
+++ b/capstone.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/lib
+libdir=${prefix}/lib@LIBSUFFIX@
 includedir=${prefix}/include
 
 Name: capstone

--- a/capstone.pc.in
+++ b/capstone.pc.in
@@ -1,7 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
 Name: capstone
 Description: Capstone disassembly engine
 Version: @VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@
 URL: http://www.capstone-engine.org
-archive=@CMAKE_INSTALL_PREFIX@/lib/libcapstone.a
-Libs: -L@CMAKE_INSTALL_PREFIX@/lib -lcapstone
-Cflags: -I@CMAKE_INSTALL_PREFIX@/include/capstone
+archive=${libdir}/libcapstone.a
+Libs: -L${libdir} -lcapstone
+Cflags: -I${includedir}


### PR DESCRIPTION
cmake pkg-config file fixed hardcoded paths with variables. CMakeLists.txt line 394 needs to be modified
> configure_file("capstone.pc.in" "capstone.pc" @ONLY)