### PR TITLE
Fix selection of mips disasm handler

### DIFF
--- a/arch/Mips/MipsModule.c
+++ b/arch/Mips/MipsModule.c
@@ -10,7 +10,8 @@
 #include "MipsMapping.h"
 
 // Returns mode value with implied bits set
-static inline cs_mode updated_mode(cs_mode mode) {
+static inline cs_mode updated_mode(cs_mode mode)
+{
 	if (mode & CS_MODE_MIPS32R6) {
 		mode |= CS_MODE_32;
 	}

--- a/arch/Mips/MipsModule.c
+++ b/arch/Mips/MipsModule.c
@@ -9,6 +9,15 @@
 #include "MipsInstPrinter.h"
 #include "MipsMapping.h"
 
+// Returns mode value with implied bits set
+static inline cs_mode updated_mode(cs_mode mode) {
+	if (mode & CS_MODE_MIPS32R6) {
+		mode |= CS_MODE_32;
+	}
+
+	return mode;
+}
+
 static cs_err init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
@@ -30,7 +39,8 @@ static cs_err init(cs_struct *ud)
 	ud->insn_name = Mips_insn_name;
 	ud->group_name = Mips_group_name;
 
-	if (ud->mode & CS_MODE_32 || ud->mode & CS_MODE_MIPS32R6)
+	ud->mode = updated_mode(ud->mode);
+	if (ud->mode & CS_MODE_32)
 		ud->disasm = Mips_getInstruction;
 	else
 		ud->disasm = Mips64_getInstruction;
@@ -41,6 +51,7 @@ static cs_err init(cs_struct *ud)
 static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 {
 	if (type == CS_OPT_MODE) {
+		value = updated_mode(value);
 		if (value & CS_MODE_32)
 			handle->disasm = Mips_getInstruction;
 		else


### PR DESCRIPTION
handle->disasm was incorrectly set to `Mips64_getInstruction` if `CS_MODE_MIPS32R6`
was set but `CS_MODE_32` was not set.


If you change the mode at runtime with `cs_option` (instead of the initial `cs_open`), then the wrong disassembler handle is picked. You can observe the bug by applying the following patch to `test_mips.c`:

~~~diff
--- ../tests/test_mips.c        2017-10-04 01:02:46.392004908 -0700
+++ ../tests/test_mips_set_option.c     2017-10-04 01:17:35.682116291 -0700
@@ -120,12 +120,13 @@
        size_t count;
 
        for (i = 0; i < sizeof(platforms)/sizeof(platforms[0]); i++) {
-               cs_err err = cs_open(platforms[i].arch, platforms[i].mode, &handle);
+               cs_err err = cs_open(platforms[i].arch, 0, &handle);
                if (err) {
                        printf("Failed on cs_open() with error returned: %u\n", err);
                        continue;
                }
 
+               cs_option(handle, CS_OPT_MODE, platforms[i].mode);
                cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
                count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
~~~

The output should be the same, but you get a difference:

~~~diff
--- test_mips.A	2017-10-06 03:55:00.084300117 -0700
+++ test_mips.B	2017-10-06 03:55:10.280333123 -0700
@@ -50,42 +50,22 @@
 Platform: MIPS-32R6 | Micro (Big-endian)
 Code:0x00 0x07 0x00 0x07 0x00 0x11 0x93 0x7c 0x01 0x8c 0x8b 0x7c 0x00 0xc7 0x48 0xd0 
 Disasm:
-0x1000:	break	7, 0
-	op_count: 2
-		operands[0].type: IMM = 0x7
-		operands[1].type: IMM = 0x0
-
-0x1004:	wait	0x11
-	op_count: 1
-		operands[0].type: IMM = 0x11
-
-0x1008:	syscall	0x18c
-	op_count: 1
-		operands[0].type: IMM = 0x18c
+0x1000:	srav	$zero, $a3, $zero
+	op_count: 3
+		operands[0].type: REG = zero
+		operands[1].type: REG = a3
+		operands[2].type: REG = zero
 
-0x100c:	rotrv	$t1, $a2, $a3
+0x1004:	dsll32	$s2, $s1, 0xd
 	op_count: 3
-		operands[0].type: REG = t1
-		operands[1].type: REG = a2
-		operands[2].type: REG = a3
+		operands[0].type: REG = s2
+		operands[1].type: REG = s1
+		operands[2].type: IMM = 0xd
 
-0x1010:
+0x1008:
 
 ****************
 Platform: MIPS-32R6 (Big-endian)
 Code:0xec 0x80 0x00 0x19 0x7c 0x43 0x22 0xa0 
-Disasm:
-0x1000:	addiupc	$a0, 0x64
-	op_count: 2
-		operands[0].type: REG = a0
-		operands[1].type: IMM = 0x64
-
-0x1004:	align	$a0, $v0, $v1, 2
-	op_count: 4
-		operands[0].type: REG = a0
-		operands[1].type: REG = v0
-		operands[2].type: REG = v1
-		operands[3].type: IMM = 0x2
-
-0x1008:
+ERROR: Failed to disasm given code!
~~~