### PR TITLE
[M68K] Fixed invalid base reg

### DIFF
--- a/arch/M68K/M68KInstPrinter.c
+++ b/arch/M68K/M68KInstPrinter.c
@@ -145,7 +145,7 @@ void printAddressingMode(SStream* O, const cs_m68k* inst, const cs_m68k_op* op)
 		case M68K_AM_REGI_ADDR: SStream_concat(O, "(a%d)", (op->reg - M68K_REG_A0)); break;
 		case M68K_AM_REGI_ADDR_POST_INC: SStream_concat(O, "(a%d)+", (op->reg - M68K_REG_A0)); break;
 		case M68K_AM_REGI_ADDR_PRE_DEC: SStream_concat(O, "-(a%d)", (op->reg - M68K_REG_A0)); break;
-		case M68K_AM_REGI_ADDR_DISP: SStream_concat(O, "%s$%x(a%d)", op->mem.disp < 0 ? "-" : "", abs(op->mem.disp), (op->reg - M68K_REG_A0)); break;
+		case M68K_AM_REGI_ADDR_DISP: SStream_concat(O, "%s$%x(a%d)", op->mem.disp < 0 ? "-" : "", abs(op->mem.disp), (op->mem.base_reg - M68K_REG_A0)); break;
 		case M68K_AM_PCI_DISP: SStream_concat(O, "%s$%x(pc)", op->mem.disp < 0 ? "-" : "", abs(op->mem.disp)); break;
 		case M68K_AM_ABSOLUTE_DATA_SHORT: SStream_concat(O, "$%x.w", op->imm); break;
 		case M68K_AM_ABSOLUTE_DATA_LONG: SStream_concat(O, "$%x.l", op->imm); break;

--- a/bindings/python/capstone/m68k.py
+++ b/bindings/python/capstone/m68k.py
@@ -33,14 +33,14 @@ class M68KOpValue(ctypes.Union):
         ('simm', ctypes.c_float),
         ('reg', ctypes.c_uint),
         ('reg_pair', M68KOpRegPair),
-        ('mem', M68KOpMem),
-        ('register_bits', ctypes.c_uint),
     )
 
 class M68KOp(ctypes.Structure):
     _fields_ = (
         ('value', M68KOpValue),
         ('type', ctypes.c_uint),
+        ('mem', M68KOpMem),
+        ('register_bits', ctypes.c_uint),
         ('address_mode', ctypes.c_uint),
     )
 
@@ -62,11 +62,11 @@ class M68KOp(ctypes.Structure):
 
     @property
     def mem(self):
-        return self.value.mem
+        return self.mem
 
     @property
     def register_bits(self):
-        return self.value.register_bits
+        return self.register_bits
 
 class M68KOpSize(ctypes.Structure):
     _fields_ = (

--- a/include/capstone/m68k.h
+++ b/include/capstone/m68k.h
@@ -77,7 +77,7 @@ typedef enum m68k_reg {
 
 //> M68K Addressing Modes
 typedef enum m68k_address_mode {
-	M68K_AM_NONE = 0,			// No address mode. 
+	M68K_AM_NONE = 0,			// No address mode.
 
 	M68K_AM_REG_DIRECT_DATA,		// Register Direct - Data
 	M68K_AM_REG_DIRECT_ADDR,		// Register Direct - Address
@@ -115,7 +115,7 @@ typedef enum m68k_op_type {
 	M68K_OP_FP_SINGLE,   // single precision Floating-Point operand
 	M68K_OP_FP_DOUBLE,   // double precision Floating-Point operand
 	M68K_OP_REG_BITS,    // Register bits move
-	M68K_OP_REG_PAIR,    // Register pair in the same op (upper 4 bits for first reg, lower for second) 
+	M68K_OP_REG_PAIR,    // Register pair in the same op (upper 4 bits for first reg, lower for second)
 } m68k_op_type;
 
 // Instruction's operand referring to memory
@@ -124,8 +124,8 @@ typedef struct m68k_op_mem {
 	m68k_reg base_reg;      // base register (or M68K_REG_INVALID if irrelevant)
 	m68k_reg index_reg;     // index register (or M68K_REG_INVALID if irrelevant)
 	m68k_reg in_base_reg;   // indirect base register (or M68K_REG_INVALID if irrelevant)
-	uint32_t in_disp; 	    // indirect displacement 
-	uint32_t out_disp;      // other displacement 
+	uint32_t in_disp; 	    // indirect displacement
+	uint32_t out_disp;      // other displacement
 	int16_t disp;	        // displacement value
 	uint8_t scale;	        // scale for index register
 	uint8_t bitfield;       // set to true if the two values below should be used
@@ -145,9 +145,10 @@ typedef struct cs_m68k_op {
 			m68k_reg reg_0;
 			m68k_reg reg_1;
 		} reg_pair;
-		m68k_op_mem mem; 	    // data when operand is targeting memory
-		uint32_t register_bits; // register bits for movem etc. (always in d0-d7, a0-a7, fp0 - fp7 order)
 	};
+
+	m68k_op_mem mem; 	    // data when operand is targeting memory
+	uint32_t register_bits; // register bits for movem etc. (always in d0-d7, a0-a7, fp0 - fp7 order)
 	m68k_op_type type;
 	m68k_address_mode address_mode;	// M68K addressing mode for this op
 } cs_m68k_op;


### PR DESCRIPTION
This is one of those “how did this ever work?” changes. Problem was that as m68k_op was aliased with the imm value so when changing that to something big it would trash the values in the mem struct which would make things go really bad.

Now m68k_op_mem has been moved out of the union so this will not happen again. Also fixed instruction printing bug related to this (just happened to “work” due to the old union layout)

Fixes the problem outlined in #1025 

