### PR TITLE
ppc: fix endian check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
   include:
     - if: branch = master
       os: osx
-      script: brew install --HEAD capstone && brew test capstone
+      script: brew update && brew install --HEAD capstone && brew test capstone
       compiler: gcc
     - if: branch = master
       os: osx
-      script: brew install --HEAD capstone && brew test capstone
+      script: brew update && brew install --HEAD capstone && brew test capstone
       compiler: clang

--- a/arch/AArch64/AArch64Disassembler.c
+++ b/arch/AArch64/AArch64Disassembler.c
@@ -238,7 +238,7 @@ static DecodeStatus _getInstruction(cs_struct *ud, MCInst *MI,
 			MI->flat_insn->detail->arm64.operands[i].vector_index = -1;
 	}
 
-	if (ud->big_endian)
+	if (MODE_IS_BIG_ENDIAN(ud->mode))
 		insn = (code[3] << 0) | (code[2] << 8) |
 			(code[1] <<  16) | (code[0] <<  24);
 	else

--- a/arch/AArch64/AArch64Module.c
+++ b/arch/AArch64/AArch64Module.c
@@ -12,11 +12,6 @@
 static cs_err init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
-
-	// verify if requested mode is valid
-	if (ud->mode & ~(CS_MODE_LITTLE_ENDIAN | CS_MODE_ARM | CS_MODE_BIG_ENDIAN))
-		return CS_ERR_MODE;
-
 	mri = cs_mem_malloc(sizeof(*mri));
 
 	AArch64_init(mri);
@@ -36,7 +31,7 @@ static cs_err init(cs_struct *ud)
 static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 {
 	if (type == CS_OPT_MODE) {
-		handle->big_endian = (((cs_mode)value & CS_MODE_BIG_ENDIAN) != 0);
+		handle->mode = (cs_mode)value;
 	}
 
 	return CS_ERR_OK;
@@ -51,6 +46,7 @@ void AArch64_enable(void)
 	arch_init[CS_ARCH_ARM64] = init;
 	arch_option[CS_ARCH_ARM64] = option;
 	arch_destroy[CS_ARCH_ARM64] = destroy;
+	arch_disallowed_mode_mask[CS_ARCH_ARM64] = ~(CS_MODE_LITTLE_ENDIAN | CS_MODE_ARM | CS_MODE_BIG_ENDIAN);
 
 	// support this arch
 	all_arch |= (1 << CS_ARCH_ARM64);

--- a/arch/ARM/ARMDisassembler.c
+++ b/arch/ARM/ARMDisassembler.c
@@ -462,7 +462,7 @@ static DecodeStatus _ARM_getInstruction(cs_struct *ud, MCInst *MI, const uint8_t
 
 	memcpy(bytes, code, 4);
 
-	if (ud->big_endian)
+	if (MODE_IS_BIG_ENDIAN(ud->mode))
 		insn = (bytes[3] << 0) |
 			(bytes[2] << 8) |
 			(bytes[1] <<  16) |
@@ -704,7 +704,7 @@ static DecodeStatus _Thumb_getInstruction(cs_struct *ud, MCInst *MI, const uint8
 
 	memcpy(bytes, code, 2);
 
-	if (ud->big_endian)
+	if (MODE_IS_BIG_ENDIAN(ud->mode))
 		insn16 = (bytes[0] << 8) | bytes[1];
 	else
 		insn16 = (bytes[1] << 8) | bytes[0];
@@ -757,7 +757,7 @@ static DecodeStatus _Thumb_getInstruction(cs_struct *ud, MCInst *MI, const uint8
 
 	memcpy(bytes, code, 4);
 
-	if (ud->big_endian)
+	if (MODE_IS_BIG_ENDIAN(ud->mode))
 		insn32 = (bytes[3] <<  0) |
 			(bytes[2] <<  8) |
 			(bytes[1] << 16) |

--- a/arch/ARM/ARMModule.c
+++ b/arch/ARM/ARMModule.c
@@ -12,12 +12,6 @@
 static cs_err init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
-
-	// verify if requested mode is valid
-	if (ud->mode & ~(CS_MODE_LITTLE_ENDIAN | CS_MODE_ARM | CS_MODE_V8 |
-				CS_MODE_MCLASS | CS_MODE_THUMB | CS_MODE_BIG_ENDIAN))
-		return CS_ERR_MODE;
-
 	mri = cs_mem_malloc(sizeof(*mri));
 
 	ARM_init(mri);
@@ -49,7 +43,6 @@ static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 				handle->disasm = ARM_getInstruction;
 
 			handle->mode = (cs_mode)value;
-			handle->big_endian = ((handle->mode & CS_MODE_BIG_ENDIAN) != 0);
 
 			break;
 		case CS_OPT_SYNTAX:
@@ -72,6 +65,9 @@ void ARM_enable(void)
 	arch_init[CS_ARCH_ARM] = init;
 	arch_option[CS_ARCH_ARM] = option;
 	arch_destroy[CS_ARCH_ARM] = destroy;
+	arch_disallowed_mode_mask[CS_ARCH_ARM] = ~(CS_MODE_LITTLE_ENDIAN |
+		CS_MODE_ARM | CS_MODE_V8 | CS_MODE_MCLASS | CS_MODE_THUMB |
+		CS_MODE_BIG_ENDIAN);
 
 	// support this arch
 	all_arch |= (1 << CS_ARCH_ARM);

--- a/arch/Mips/MipsDisassembler.c
+++ b/arch/Mips/MipsDisassembler.c
@@ -398,7 +398,7 @@ bool Mips_getInstruction(csh ud, const uint8_t *code, size_t code_len, MCInst *i
 	DecodeStatus status = MipsDisassembler_getInstruction(handle->mode, instr,
 			code, code_len,
 			size,
-			address, handle->big_endian, (MCRegisterInfo *)info);
+			address, MODE_IS_BIG_ENDIAN(handle->mode), (MCRegisterInfo *)info);
 
 	return status == MCDisassembler_Success;
 }
@@ -450,9 +450,8 @@ bool Mips64_getInstruction(csh ud, const uint8_t *code, size_t code_len, MCInst 
 	cs_struct *handle = (cs_struct *)(uintptr_t)ud;
 
 	DecodeStatus status = Mips64Disassembler_getInstruction(handle->mode, instr,
-			code, code_len,
-			size,
-			address, handle->big_endian, (MCRegisterInfo *)info);
+			code, code_len, size, address,
+			MODE_IS_BIG_ENDIAN(handle->mode), (MCRegisterInfo *)info);
 
 	return status == MCDisassembler_Success;
 }

--- a/arch/Mips/MipsModule.c
+++ b/arch/Mips/MipsModule.c
@@ -22,13 +22,6 @@ static inline cs_mode updated_mode(cs_mode mode)
 static cs_err init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
-
-	// verify if requested mode is valid
-	if (ud->mode & ~(CS_MODE_LITTLE_ENDIAN | CS_MODE_32 | CS_MODE_64 |
-				CS_MODE_MICRO | CS_MODE_MIPS32R6 |
-				CS_MODE_MIPSGP64 | CS_MODE_BIG_ENDIAN))
-		return CS_ERR_MODE;
-
 	mri = cs_mem_malloc(sizeof(*mri));
 
 	Mips_init(mri);
@@ -59,7 +52,6 @@ static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 			handle->disasm = Mips64_getInstruction;
 
 		handle->mode = (cs_mode)value;
-		handle->big_endian = ((handle->mode & CS_MODE_BIG_ENDIAN) != 0);
 	}
 	return CS_ERR_OK;
 }
@@ -73,6 +65,9 @@ void Mips_enable(void)
 	arch_init[CS_ARCH_MIPS] = init;
 	arch_option[CS_ARCH_MIPS] = option;
 	arch_destroy[CS_ARCH_MIPS] = destroy;
+	arch_disallowed_mode_mask[CS_ARCH_MIPS] = ~(CS_MODE_LITTLE_ENDIAN |
+		CS_MODE_32 | CS_MODE_64 | CS_MODE_MICRO | CS_MODE_MIPS32R6 |
+		CS_MODE_MIPSGP64 | CS_MODE_BIG_ENDIAN);
 
 	// support this arch
 	all_arch |= (1 << CS_ARCH_MIPS);

--- a/arch/PowerPC/PPCDisassembler.c
+++ b/arch/PowerPC/PPCDisassembler.c
@@ -342,7 +342,7 @@ static DecodeStatus getInstruction(MCInst *MI,
 	}
 
 	// The instruction is big-endian encoded.
-	if (MI->csh->mode & CS_MODE_BIG_ENDIAN)
+	if (MODE_IS_BIG_ENDIAN(MI->csh->mode))
 		insn = (code[0] << 24) | (code[1] << 16) |
 			(code[2] <<  8) | (code[3] <<  0);
 	else

--- a/arch/PowerPC/PPCModule.c
+++ b/arch/PowerPC/PPCModule.c
@@ -12,12 +12,6 @@
 static cs_err init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
-
-	// verify if requested mode is valid
-	if (ud->mode & ~(CS_MODE_LITTLE_ENDIAN | CS_MODE_32 | CS_MODE_64 |
-				CS_MODE_BIG_ENDIAN))
-		return CS_ERR_MODE;
-
 	mri = (MCRegisterInfo *) cs_mem_malloc(sizeof(*mri));
 
 	PPC_init(mri);
@@ -41,7 +35,7 @@ static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 		handle->syntax = (int) value;
 
 	if (type == CS_OPT_MODE) {
-		handle->big_endian = (((cs_mode)value & CS_MODE_BIG_ENDIAN) != 0);
+		handle->mode = (cs_mode)value;
 	}
 
 	return CS_ERR_OK;
@@ -56,6 +50,8 @@ void PPC_enable(void)
 	arch_init[CS_ARCH_PPC] = init;
 	arch_option[CS_ARCH_PPC] = option;
 	arch_destroy[CS_ARCH_PPC] = destroy;
+	arch_disallowed_mode_mask[CS_ARCH_PPC] = ~(CS_MODE_LITTLE_ENDIAN |
+		CS_MODE_32 | CS_MODE_64 | CS_MODE_BIG_ENDIAN);
 
 	// support this arch
 	all_arch |= (1 << CS_ARCH_PPC);

--- a/arch/Sparc/SparcModule.c
+++ b/arch/Sparc/SparcModule.c
@@ -12,11 +12,6 @@
 static cs_err init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
-
-	// verify if requested mode is valid
-	if (ud->mode & ~(CS_MODE_BIG_ENDIAN | CS_MODE_V9))
-		return CS_ERR_MODE;
-
 	mri = cs_mem_malloc(sizeof(*mri));
 
 	Sparc_init(mri);
@@ -40,7 +35,7 @@ static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 		handle->syntax = (int) value;
 
 	if (type == CS_OPT_MODE) {
-		handle->big_endian = (((cs_mode)value & CS_MODE_BIG_ENDIAN) != 0);
+		handle->mode = (cs_mode)value;
 	}
 
 	return CS_ERR_OK;
@@ -55,6 +50,8 @@ void Sparc_enable(void)
 	arch_init[CS_ARCH_SPARC] = init;
 	arch_option[CS_ARCH_SPARC] = option;
 	arch_destroy[CS_ARCH_SPARC] = destroy;
+	arch_disallowed_mode_mask[CS_ARCH_SPARC] =
+		~(CS_MODE_BIG_ENDIAN | CS_MODE_V9);
 
 	// support this arch
 	all_arch |= (1 << CS_ARCH_SPARC);

--- a/arch/SystemZ/SystemZModule.c
+++ b/arch/SystemZ/SystemZModule.c
@@ -12,7 +12,6 @@
 static cs_err init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
-
 	mri = cs_mem_malloc(sizeof(*mri));
 
 	SystemZ_init(mri);
@@ -35,6 +34,9 @@ static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 	if (type == CS_OPT_SYNTAX)
 		handle->syntax = (int) value;
 
+	// Do not set mode because only CS_MODE_BIG_ENDIAN is valid; we cannot
+	// test for CS_MODE_LITTLE_ENDIAN because it is 0
+
 	return CS_ERR_OK;
 }
 
@@ -47,6 +49,7 @@ void SystemZ_enable(void)
 	arch_init[CS_ARCH_SYSZ] = init;
 	arch_option[CS_ARCH_SYSZ] = option;
 	arch_destroy[CS_ARCH_SYSZ] = destroy;
+	arch_disallowed_mode_mask[CS_ARCH_SYSZ] = ~CS_MODE_BIG_ENDIAN;
 
 	// support this arch
 	all_arch |= (1 << CS_ARCH_SYSZ);

--- a/arch/X86/X86Module.c
+++ b/arch/X86/X86Module.c
@@ -12,11 +12,6 @@
 static cs_err init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
-
-	// verify if requested mode is valid
-	if (ud->mode & ~(CS_MODE_LITTLE_ENDIAN | CS_MODE_32 | CS_MODE_64 | CS_MODE_16))
-		return CS_ERR_MODE;
-
 	mri = cs_mem_malloc(sizeof(*mri));
 
 	X86_init(mri);
@@ -96,6 +91,8 @@ void X86_enable(void)
 	arch_init[CS_ARCH_X86] = init;
 	arch_option[CS_ARCH_X86] = option;
 	arch_destroy[CS_ARCH_X86] = destroy;
+	arch_disallowed_mode_mask[CS_ARCH_X86] = ~(CS_MODE_LITTLE_ENDIAN |
+		CS_MODE_32 | CS_MODE_64 | CS_MODE_16);
 
 	// support this arch
 	all_arch |= (1 << CS_ARCH_X86);

--- a/arch/XCore/XCoreModule.c
+++ b/arch/XCore/XCoreModule.c
@@ -12,7 +12,6 @@
 static cs_err init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
-
 	mri = cs_mem_malloc(sizeof(*mri));
 
 	XCore_init(mri);
@@ -32,6 +31,9 @@ static cs_err init(cs_struct *ud)
 
 static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 {
+	// Do not set mode because only CS_MODE_BIG_ENDIAN is valid; we cannot
+	// test for CS_MODE_LITTLE_ENDIAN because it is 0
+
 	return CS_ERR_OK;
 }
 
@@ -44,6 +46,7 @@ void XCore_enable(void)
 	arch_init[CS_ARCH_XCORE] = init;
 	arch_option[CS_ARCH_XCORE] = option;
 	arch_destroy[CS_ARCH_XCORE] = destroy;
+	arch_disallowed_mode_mask[CS_ARCH_XCORE] = ~CS_MODE_BIG_ENDIAN;
 
 	// support this arch
 	all_arch |= (1 << CS_ARCH_XCORE);

--- a/cs_priv.h
+++ b/cs_priv.h
@@ -37,7 +37,6 @@ struct cs_struct {
 	void *printer_info; // aux info for printer
 	Disasm_t disasm;	// disassembler
 	void *getinsn_info; // auxiliary info for printer
-	bool big_endian;
 	GetName_t reg_name;
 	GetName_t insn_name;
 	GetName_t group_name;
@@ -58,6 +57,9 @@ struct cs_struct {
 
 #define MAX_ARCH 8
 
+// Returns a bool (0 or 1) whether big endian is enabled for a mode
+#define MODE_IS_BIG_ENDIAN(mode) (((mode) & CS_MODE_BIG_ENDIAN) != 0)
+
 // constructor initialization for all archs
 extern cs_err (*arch_init[MAX_ARCH]) (cs_struct *);
 
@@ -66,6 +68,10 @@ extern cs_err (*arch_option[MAX_ARCH]) (cs_struct*, cs_opt_type, size_t value);
 
 // deinitialized functions: to be called when cs_close() is called
 extern void (*arch_destroy[MAX_ARCH]) (cs_struct*);
+
+// bitmask for finding disallowed modes for an arch:
+// to be called in cs_open()/cs_option()
+extern cs_mode arch_disallowed_mode_mask[MAX_ARCH];
 
 extern unsigned int all_arch;
 


### PR DESCRIPTION
Using `cs_option()` to set the endianness fails for PowerPC.

The following code (based on `test_ppc.c`) will fail to disassemble without this fix:
~~~c
/* Capstone Disassembler Engine */
/* By Nguyen Anh Quynh <aquynh@gmail.com>, 2013> */

#include <stdio.h>

#include <platform.h>
#include <capstone.h>

struct platform {
	cs_arch arch;
	cs_mode mode;
	unsigned char *code;
	size_t size;
	char *comment;
};

static csh handle;

static void print_string_hex(char *comment, unsigned char *str, size_t len)
{
	unsigned char *c;

	printf("%s", comment);
	for (c = str; c < str + len; c++) {
		printf("0x%02x ", *c & 0xff);
	}

	printf("\n");
}

static void test()
{
#define PPC_CODE "\x43\x20\x0c\x07\x41\x56\xff\x17\x80\x20\x00\x00\x80\x3f\x00\x00\x10\x43\x23\x0e\xd0\x44\x00\x80\x4c\x43\x22\x02\x2d\x03\x00\x80\x7c\x43\x20\x14\x7c\x43\x20\x93\x4f\x20\x00\x21\x4c\xc8\x00\x21\x40\x82\x00\x14"

	struct platform platforms[] = {
		{
			CS_ARCH_PPC,
			CS_MODE_BIG_ENDIAN,
			(unsigned char*)PPC_CODE,
			sizeof(PPC_CODE) - 1,
			"PPC-64",
		}
	};

	uint64_t address = 0x1000;
	cs_insn *insn;
	int i;
	size_t count;

	for (i = 0; i < sizeof(platforms)/sizeof(platforms[0]); i++) {
		cs_err err = cs_open(platforms[i].arch, 0, &handle);
		if (err) {
			printf("Failed on cs_open() with error returned: %u\n", err);
			continue;
		}
		cs_option(handle, CS_OPT_MODE, platforms[i].mode);

		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);

		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
		if (count) {
			size_t j;

			printf("****************\n");
			printf("Platform: %s\n", platforms[i].comment);
			print_string_hex("Code:", platforms[i].code, platforms[i].size);
			printf("Disasm:\n");

			for (j = 0; j < count; j++) {
				printf("0x%" PRIx64 ":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
			}
			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);

			// free memory allocated by cs_disasm()
			cs_free(insn, count);
		} else {
			printf("****************\n");
			printf("Platform: %s\n", platforms[i].comment);
			print_string_hex("Code:", platforms[i].code, platforms[i].size);
			printf("ERROR: Failed to disasm given code!\n");
		}

		printf("\n");

		cs_close(&handle);
	}
}

int main()
{
	test();

	return 0;
}
~~~