### PR TITLE
fix undefined behavior due to uninitialized memory

### DIFF
--- a/MCInst.c
+++ b/MCInst.c
@@ -16,6 +16,7 @@
 
 void MCInst_Init(MCInst *inst)
 {
+	inst->Opcode = 0;
 	inst->OpcodePub = 0;
 	inst->size = 0;
 	inst->has_imm = false;

--- a/utils.c
+++ b/utils.c
@@ -17,7 +17,7 @@ static unsigned short *make_id2insn(insn_map *insns, unsigned int size)
 	unsigned short max_id = insns[size - 1].id;
 	unsigned short i;
 
-	unsigned short *cache = (unsigned short *)cs_mem_malloc(sizeof(*cache) * (max_id + 1));
+	unsigned short *cache = (unsigned short *)cs_mem_calloc(sizeof(*cache) * (max_id + 1));
 
 	for (i = 1; i < size; i++)
 		cache[insns[i].id] = i;


### PR DESCRIPTION
The MCInst structure was not being initialized properly, leading to undefined behavior, e.g. access violations when disassembling ud0 x86 instructions.
The change in utils.c isn't strictly necessary, but might prevent similar bugs in the future.
Maybe the special ud0 handling in X86Disassembler (marked FIXME) should also be adjusted, i.e. explicitly set instr->Opcode = 0 there.