### PR TITLE
Added an explicit cast to silence `-Wshorten-64-to-32` warning with clang.

### DIFF
--- a/arch/Mips/MipsModule.c
+++ b/arch/Mips/MipsModule.c
@@ -45,7 +45,7 @@ static cs_err init(cs_struct *ud)
 static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
 {
 	if (type == CS_OPT_MODE) {
-		value = updated_mode(value);
+		value = updated_mode((cs_mode)value);
 		if (value & CS_MODE_32)
 			handle->disasm = Mips_getInstruction;
 		else


### PR DESCRIPTION
Currently using Xcode 9.1 to build the provided Xcode project.  
Build issues the following warning:

    capstone/arch/Mips/MipsModule.c:48:24: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'cs_mode' (aka 'enum cs_mode') [-Wshorten-64-to-32]
        value = updated_mode(value);

Issue is in the `option` function in `MipsModule.c`:

    static cs_err option(cs_struct *handle, cs_opt_type type, size_t value)
    {
        if (type == CS_OPT_MODE) {
            value = updated_mode(value);

The `updated_mode` function takes an enum type (`cs_mode`) as parameter.  
On systems where `size_t` is 64-bits, this might trigger a warning, as it will implicitly convert a 64-bits value to a 32-bits value (enum is most likely an `int`).

An explicit cast will silence the error, and based on the `updated_mode` definition, this won't have any side-effect:

    static inline cs_mode updated_mode(cs_mode mode)
    {
        if (mode & CS_MODE_MIPS32R6) {
            mode |= CS_MODE_32;
        }
    
        return mode;
    }
