### PR TITLE
Fix EFLAGS for the stosb/stosd/stosq/stosw instructions

### DIFF
--- a/arch/X86/X86MappingInsnOp.inc
+++ b/arch/X86/X86MappingInsnOp.inc
@@ -10050,19 +10050,19 @@
 	{ CS_AC_READ, 0 }
 },
 {	/* X86_STOSB, X86_INS_STOSB: stosb	$dst, al */
-	0,
+	X86_EFLAGS_TEST_DF,
 	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_STOSL, X86_INS_STOSD: stos{l|d}	{%eax, $dst|$dst, eax} */
-	0,
+	X86_EFLAGS_TEST_DF,
 	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_STOSQ, X86_INS_STOSQ: stosq	$dst, rax */
-	0,
+	X86_EFLAGS_TEST_DF,
 	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_STOSW, X86_INS_STOSW: stosw	$dst, ax */
-	0,
+	X86_EFLAGS_TEST_DF,
 	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_STR16r, X86_INS_STR: str{w}	$dst */

--- a/arch/X86/X86MappingInsnOp_reduce.inc
+++ b/arch/X86/X86MappingInsnOp_reduce.inc
@@ -5402,19 +5402,19 @@
 	{ 0 }
 },
 {	/* X86_STOSB, X86_INS_STOSB: stosb	$dst, al */
-	0,
+	X86_EFLAGS_TEST_DF,
 	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_STOSL, X86_INS_STOSD: stos{l|d}	{%eax, $dst|$dst, eax} */
-	0,
+	X86_EFLAGS_TEST_DF,
 	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_STOSQ, X86_INS_STOSQ: stosq	$dst, rax */
-	0,
+	X86_EFLAGS_TEST_DF,
 	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_STOSW, X86_INS_STOSW: stosw	$dst, ax */
-	0,
+	X86_EFLAGS_TEST_DF,
 	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_STR16r, X86_INS_STR: str{w}	$dst */


### PR DESCRIPTION
the (E)DI register is incremented or decremented according to the setting of the DF flag in the EFLAGS register. If the DF flag is 0, the register is incremented; if the DF flag is 1, the register is decremented .
 - intel manual