### PR TITLE
Reorder M68KOp elements to match order on C side

### DIFF
--- a/bindings/python/capstone/m68k.py
+++ b/bindings/python/capstone/m68k.py
@@ -38,9 +38,9 @@ class M68KOpValue(ctypes.Union):
 class M68KOp(ctypes.Structure):
     _fields_ = (
         ('value', M68KOpValue),
-        ('type', ctypes.c_uint),
         ('mem', M68KOpMem),
         ('register_bits', ctypes.c_uint),
+        ('type', ctypes.c_uint),
         ('address_mode', ctypes.c_uint),
     )
 


### PR DESCRIPTION
I noticed that the element order was incorrect for M68KOp when I tried using it from a Python program. With this change I can successfully inspect parts of disassembled 68k operands.