### PR TITLE
Fix error in setup.py when not building static library

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -141,7 +141,9 @@ def build_libraries():
         os.system("CAPSTONE_BUILD_CORE_ONLY=yes bash ./make.sh")
 
     shutil.copy(LIBRARY_FILE, LIBS_DIR)
-    if STATIC_LIBRARY_FILE: shutil.copy(STATIC_LIBRARY_FILE, LIBS_DIR)
+    # only copy static library if it exists (it's a build option)
+    if STATIC_LIBRARY_FILE and os.path.exists(STATIC_LIBRARY_FILE):
+        shutil.copy(STATIC_LIBRARY_FILE, LIBS_DIR)
     os.chdir(cwd)
 
 


### PR DESCRIPTION
Check to make sure static library file exists before trying to copy it. Current build options include option to not build a static lib.