### PR TITLE
Fix language statistics by considering *.inc files to be C files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/arch/**/*.inc linguist-language=C


### PR DESCRIPTION
Otherwise, they are considered to be PHP or C++ files, which causes GitHub's language statistics to show that Capstone is written mostly in PHP (42.2%) and C++ (33.1%), which is nonsense.

**Before:**
![before](https://user-images.githubusercontent.com/5675953/34909483-5ad15860-f8a2-11e7-8bd7-efab025e50d3.png)

**After:**
![after](https://user-images.githubusercontent.com/5675953/34909482-5aaca45c-f8a2-11e7-96dc-2e7d010cee2d.png)

Fore more information on how language statistics are computed, see [GitHub's linguist](https://github.com/github/linguist).
