### PR TITLE
Fix MSVC build in next branch

### DIFF
--- a/arch/X86/X86ATTInstPrinter.c
+++ b/arch/X86/X86ATTInstPrinter.c
@@ -18,6 +18,11 @@
 // this code is only relevant when DIET mode is disable
 #if defined(CAPSTONE_HAS_X86) && !defined(CAPSTONE_DIET) && !defined(CAPSTONE_X86_ATT_DISABLE)
 
+#if defined (WIN32) || defined (WIN64) || defined (_WIN32) || defined (_WIN64)
+#pragma warning(disable:4996)			// disable MSVC's warning on strncpy()
+#pragma warning(disable:28719)		// disable MSVC's warning on strncpy()
+#endif
+
 #if !defined(CAPSTONE_HAS_OSXKERNEL)
 #include <ctype.h>
 #endif

--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -19,6 +19,11 @@
 
 #ifdef CAPSTONE_HAS_X86
 
+#if defined (WIN32) || defined (WIN64) || defined (_WIN32) || defined (_WIN64)
+#pragma warning(disable:4996)			// disable MSVC's warning on strncpy()
+#pragma warning(disable:28719)		// disable MSVC's warning on strncpy()
+#endif
+
 #include <capstone/platform.h>
 #include <string.h>
 

--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -17,6 +17,11 @@
 
 #ifdef CAPSTONE_HAS_X86
 
+#if defined (WIN32) || defined (WIN64) || defined (_WIN32) || defined (_WIN64)
+#pragma warning(disable:4996)			// disable MSVC's warning on strncpy()
+#pragma warning(disable:28719)		// disable MSVC's warning on strncpy()
+#endif
+
 #if !defined(CAPSTONE_HAS_OSXKERNEL)
 #include <ctype.h>
 #endif

--- a/msvc/cstool/cstool.vcxproj
+++ b/msvc/cstool/cstool.vcxproj
@@ -157,11 +157,13 @@
     <ClCompile Include="..\..\cstool\cstool.c" />
     <ClCompile Include="..\..\cstool\cstool_arm.c" />
     <ClCompile Include="..\..\cstool\cstool_arm64.c" />
+    <ClCompile Include="..\..\cstool\cstool_m680x.c" />
     <ClCompile Include="..\..\cstool\cstool_m68k.c" />
     <ClCompile Include="..\..\cstool\cstool_mips.c" />
     <ClCompile Include="..\..\cstool\cstool_ppc.c" />
     <ClCompile Include="..\..\cstool\cstool_sparc.c" />
     <ClCompile Include="..\..\cstool\cstool_systemz.c" />
+    <ClCompile Include="..\..\cstool\cstool_tms320c64x.c" />
     <ClCompile Include="..\..\cstool\cstool_x86.c" />
     <ClCompile Include="..\..\cstool\cstool_xcore.c" />
   </ItemGroup>


### PR DESCRIPTION
I disabled a few warnings from new calls to `strncpy`.

There were also couple missing references in the vcxproj for cstool.