### PR TITLE
Fix pkg-config output when using cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,7 +391,7 @@ mark_as_advanced(INSTALL_LIB_DIR)
 
 ## installation
 install(FILES ${HEADERS_COMMON} DESTINATION include/capstone)
-configure_file(capstone.pc.in capstone.pc)
+configure_file(capstone.pc.in capstone.pc @ONLY)
 
 if (CAPSTONE_BUILD_STATIC)
     install(TARGETS capstone-static


### PR DESCRIPTION
Currently, when you compile capstone on Linux using cmake, the generated capstone.pc file is broken:

```
prefix=/root/capstone-git/prefix
exec_prefix=
libdir=/lib
includedir=/include

Name: capstone
Description: Capstone disassembly engine
Version: 3.0.5
URL: http://www.capstone-engine.org
archive=/libcapstone.a
Libs: -L -lcapstone
Cflags: -I
```

You need to pass `@ONLY` to cmake's `configure_file()` to tell cmake to preserve pkg-config's `${}` expressions. This fixes the generated capstone.pc file:

```
prefix=/root/capstone-git/prefix
exec_prefix=${prefix}
libdir=${prefix}/lib
includedir=${prefix}/include

Name: capstone
Description: Capstone disassembly engine
Version: 3.0.5
URL: http://www.capstone-engine.org
archive=${libdir}/libcapstone.a
Libs: -L${libdir} -lcapstone
Cflags: -I${includedir}
```