### PR TITLE
Fix for issue #1114

### DIFF
--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -959,6 +959,7 @@ bool X86_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 			reader(&info, &b1, address);
 			reader(&info, &b2, address + 1);
 			if (b1 == 0x0f && b2 == 0xff) {
+				instr->Opcode = X86_UD0;
 				instr->OpcodePub = X86_INS_UD0;
 				strncpy(instr->assembly, "ud0", 4);
 				if (instr->flat_insn->detail) {

--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -920,17 +920,8 @@ bool X86_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 	info.offset = address;
 
 	if (instr->flat_insn->detail) {
-		instr->flat_insn->detail->x86.op_count = 0;
-		instr->flat_insn->detail->x86.sse_cc = X86_SSE_CC_INVALID;
-		instr->flat_insn->detail->x86.avx_cc = X86_AVX_CC_INVALID;
-		instr->flat_insn->detail->x86.avx_sae = false;
-		instr->flat_insn->detail->x86.avx_rm = X86_AVX_RM_INVALID;
-		instr->flat_insn->detail->x86.xop_cc = X86_XOP_CC_INVALID;
-		instr->flat_insn->detail->x86.eflags = 0;
-
-		memset(instr->flat_insn->detail->x86.prefix, 0, sizeof(instr->flat_insn->detail->x86.prefix));
-		memset(instr->flat_insn->detail->x86.opcode, 0, sizeof(instr->flat_insn->detail->x86.opcode));
-		memset(instr->flat_insn->detail->x86.operands, 0, sizeof(instr->flat_insn->detail->x86.operands));
+		// partial init of (cs_detail) instr->flat_insn->detail
+		memset(instr->flat_insn->detail, 0, offsetof(cs_detail, x86)+offsetof(cs_x86, operands));
 	}
 
 	if (handle->mode & CS_MODE_16)

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -3510,13 +3510,19 @@ void X86_reg_access(const cs_insn *insn,
 	uint8_t i;
 	uint8_t read_count, write_count;
 	cs_x86 *x86 = &(insn->detail->x86);
+	size_t regs_cpy_bytes;
 
 	read_count = insn->detail->regs_read_count;
 	write_count = insn->detail->regs_write_count;
 
 	// implicit registers
-	memcpy(regs_read, insn->detail->regs_read, read_count * sizeof(insn->detail->regs_read[0]));
-	memcpy(regs_write, insn->detail->regs_write, write_count * sizeof(insn->detail->regs_write[0]));
+	regs_cpy_bytes = read_count * sizeof(insn->detail->regs_read[0]);
+	regs_cpy_bytes = min(regs_cpy_bytes, sizeof(cs_regs));
+	memcpy(regs_read, insn->detail->regs_read, regs_cpy_bytes);
+
+	regs_cpy_bytes = write_count * sizeof(insn->detail->regs_write[0]);
+	regs_cpy_bytes = min(regs_cpy_bytes, sizeof(cs_regs));
+	memcpy(regs_write, insn->detail->regs_write, regs_cpy_bytes);
 
 	// explicit registers
 	for (i = 0; i < x86->op_count; i++) {

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -3517,11 +3517,15 @@ void X86_reg_access(const cs_insn *insn,
 
 	// implicit registers
 	regs_cpy_bytes = read_count * sizeof(insn->detail->regs_read[0]);
-	regs_cpy_bytes = min(regs_cpy_bytes, sizeof(cs_regs));
+	if (regs_cpy_bytes > sizeof(cs_regs)) {
+		regs_cpy_bytes = sizeof(cs_regs);
+	}
 	memcpy(regs_read, insn->detail->regs_read, regs_cpy_bytes);
 
 	regs_cpy_bytes = write_count * sizeof(insn->detail->regs_write[0]);
-	regs_cpy_bytes = min(regs_cpy_bytes, sizeof(cs_regs));
+	if (regs_cpy_bytes > sizeof(cs_regs)) {
+		regs_cpy_bytes = sizeof(cs_regs);
+	}
 	memcpy(regs_write, insn->detail->regs_write, regs_cpy_bytes);
 
 	// explicit registers

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -279,13 +279,13 @@ typedef struct cs_opt_skipdata {
 
 // NOTE: All information in cs_detail is only available when CS_OPT_DETAIL = CS_OPT_ON
 typedef struct cs_detail {
-	uint16_t regs_read[12]; // list of implicit registers read by this insn
+	// beware of fields order
+	// struct initialized with memset( ., 0, offsetof(cs_detail, x86)+offsetof(cs_***, last_initialized_field));
+	// only done for x86 so far
+
+	// corresponding arrays moved at the end of struct to improve partial initialization
 	uint8_t regs_read_count; // number of implicit registers read by this insn
-
-	uint16_t regs_write[20]; // list of implicit registers modified by this insn
 	uint8_t regs_write_count; // number of implicit registers modified by this insn
-
-	uint8_t groups[8]; // list of group this instruction belong to
 	uint8_t groups_count; // number of groups this insn belongs to
 
 	// Architecture-specific instruction info
@@ -303,6 +303,11 @@ typedef struct cs_detail {
 		cs_m680x m680x; // M680X architecture
 		cs_evm evm;	    // Ethereum architecture
 	};
+
+	uint16_t regs_read[12]; // list of implicit registers read by this insn
+	uint16_t regs_write[20]; // list of implicit registers modified by this insn
+	uint8_t groups[8]; // list of group this instruction belong to
+
 } cs_detail;
 
 // Detail information of disassembled instruction


### PR DESCRIPTION
The first commit fixes the issue for ud0 by properly initializing instr->Opcode in a part of the code that should eventually be removed and integrated in decodeInstruction.

The second one perform a partial initialization as requested by @aquynh. I moved a few fields in cs_detail, hopefully no code relied on their order... (I did not run the test suite)

The third one adds an extra check in X86_reg_access to prevent the buffer overflows in #1114.

Let me know if the field reordering in cs_detail was too aggressive. It is not really necessary.