### PR TITLE
Improve init of cs_detail for x86 (#1114)

### DIFF
--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -920,17 +920,25 @@ bool X86_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 	info.offset = address;
 
 	if (instr->flat_insn->detail) {
-		instr->flat_insn->detail->x86.op_count = 0;
-		instr->flat_insn->detail->x86.sse_cc = X86_SSE_CC_INVALID;
-		instr->flat_insn->detail->x86.avx_cc = X86_AVX_CC_INVALID;
-		instr->flat_insn->detail->x86.avx_sae = false;
-		instr->flat_insn->detail->x86.avx_rm = X86_AVX_RM_INVALID;
-		instr->flat_insn->detail->x86.xop_cc = X86_XOP_CC_INVALID;
-		instr->flat_insn->detail->x86.eflags = 0;
+		// instr->flat_insn->detail initialization: 3 alternatives
 
-		memset(instr->flat_insn->detail->x86.prefix, 0, sizeof(instr->flat_insn->detail->x86.prefix));
-		memset(instr->flat_insn->detail->x86.opcode, 0, sizeof(instr->flat_insn->detail->x86.opcode));
-		memset(instr->flat_insn->detail->x86.operands, 0, sizeof(instr->flat_insn->detail->x86.operands));
+
+		// 1. The whole structure, this is how it's done in other arch disassemblers
+		// Probably overkill since cs_detail is huge because of the 36 operands of ARM
+		
+		//memset(instr->flat_insn->detail, 0, sizeof(cs_detail));
+
+
+		// 2. Only the part relevant to x86
+
+		memset(instr->flat_insn->detail, 0, offsetof(cs_detail, x86)+sizeof(cs_x86));
+
+
+		// 3. The relevant part except for x86.operands
+		// sizeof(cs_x86) is 0x1c0, sizeof(x86.operands) is 0x180
+		// marginally faster, should be okay since x86.op_count is set to 0
+
+		//memset(instr->flat_insn->detail, 0, offsetof(cs_detail, x86)+offsetof(cs_x86, operands));
 	}
 
 	if (handle->mode & CS_MODE_16)


### PR DESCRIPTION
Adding initialization for `insn->detail->regs_read_count` and `insn->detail->regs_read_count` only is not faster than a full memset and might leave other bugs (what about `insn->detail->groups_count`?).

There are three initialization alternatives described in the commit, feel free to choose the one you prefer (you have write access to my branch).

Not initializing x86.operands should be safe and is 3% faster in my (limited) benchmarks with [test_iter_benchmark.c](https://github.com/aquynh/capstone/blob/863ec0aba8fbfdc83090ba21d3afad9e1a51d96c/suite/benchmark/test_iter_benchmark.c).
I did not chose this option as x86.operands was initialized in the original code base.

Reordering the fields makes it up to 8% faster (#1115) but breaks the bindings.
I could make it work for the ones included with capstone, but there are quite a few third party bindings I might not be able to update.

Other arch disassembler currently memset sizeof(cs_detail) and might benefit from a partial initialization. The relevant part is usually much smaller.
cs_arm is much bigger than other cs_*** because of its 36 potential operands:
https://github.com/aquynh/capstone/blob/863ec0aba8fbfdc83090ba21d3afad9e1a51d96c/include/capstone/arm.h#L421-L437

I can update the initialization of other arch disassembler if you want.


