### PR TITLE
Cleanup build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 env:
   global:
     - LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/tests/:$TRAVIS_BUILD_DIR:$LD_LIBRARY_PATH
-    - DYLD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/tests/:$TRAVIS_BUILD_DIR:$DYLD_LIBRARY_PATH
 script:
   - ./make.sh
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./make.sh install; fi
   - make check
   - cd bindings/python && make check
 compiler:

--- a/Makefile
+++ b/Makefile
@@ -443,11 +443,9 @@ TESTS += test_basic.static test_detail.static test_arm.static test_arm64.static
 TESTS += test_mips.static test_ppc.static test_sparc.static
 TESTS += test_systemz.static test_x86.static test_xcore.static
 TESTS += test_skipdata test_skipdata.static test_iter.static
-check:
-	@for t in $(TESTS); do \
-		echo Check $$t ... ; \
-		LD_LIBRARY_PATH=./tests ./tests/$$t > /dev/null && echo OK || echo FAILED; \
-	done
+check: $(TESTS)
+test_%:
+	./tests/$@ > /dev/null && echo OK || echo FAILED
 
 $(OBJDIR)/%.o: %.c
 	@mkdir -p $(@D)


### PR DESCRIPTION
avoiding bash subshells (which happen in for loops) because they
like to selectively inherit environment variables

https://github.com/aquynh/capstone/pull/1023#issuecomment-389701608