### PR TITLE
Fix buffer overflow in M68K

### DIFF
--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -188,7 +188,7 @@ static uint64_t m68k_read_disassembler_64(const m68k_info *info, const uint64_t 
 static unsigned int m68k_read_safe_16(const m68k_info *info, const uint64_t address)
 {
 	const uint64_t addr = (address - info->baseAddress) & info->address_mask;
-	if (info->code_len < 2) {
+	if (info->code_len < addr + 2) {
 		return 0xaaaa;
 	}
 	return m68k_read_disassembler_16(info, addr);
@@ -197,7 +197,7 @@ static unsigned int m68k_read_safe_16(const m68k_info *info, const uint64_t addr
 static unsigned int m68k_read_safe_32(const m68k_info *info, const uint64_t address)
 {
 	const uint64_t addr = (address - info->baseAddress) & info->address_mask;
-	if (info->code_len < 4) {
+	if (info->code_len < addr + 4) {
 		return 0xaaaaaaaa;
 	}
 	return m68k_read_disassembler_32(info, addr);
@@ -206,7 +206,7 @@ static unsigned int m68k_read_safe_32(const m68k_info *info, const uint64_t addr
 static uint64_t m68k_read_safe_64(const m68k_info *info, const uint64_t address)
 {
 	const uint64_t addr = (address - info->baseAddress) & info->address_mask;
-	if (info->code_len < 8) {
+	if (info->code_len < addr + 8) {
 		return 0xaaaaaaaaaaaaaaaaLL;
 	}
 	return m68k_read_disassembler_64(info, addr);


### PR DESCRIPTION
Found using oss-fuzz
Fixes an overflow in M68K disassembling, see also #1145

@emoon this is a clean pull request for the commit we discussed