### PR TITLE
use of uninitialzed value for operands type fix

### DIFF
--- a/MCInst.c
+++ b/MCInst.c
@@ -16,6 +16,11 @@
 
 void MCInst_Init(MCInst *inst)
 {
+	int i;
+
+	for (i = 0; i < 48; i++){
+		inst->Operands[i].Kind = kInvalid;
+	}
 	inst->Opcode = 0;
 	inst->OpcodePub = 0;
 	inst->size = 0;


### PR DESCRIPTION
Found using oss-fuzz (see #1145)

I am unsure if this is the right level for the fix.
Another fix could be to memset to zero the `Operands`array in function `MCInst_Init` in MCInst.c 