### PR TITLE
Print right hex value for MIN_INT

### DIFF
--- a/SStream.c
+++ b/SStream.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #endif
 #include <string.h>
+#include <limits.h>
 
 #include <capstone/platform.h>
 
@@ -58,8 +59,12 @@ void printInt64Bang(SStream *O, int64_t val)
 		else
 			SStream_concat(O, "#%"PRIu64, val);
 	} else {
-		if (val <- HEX_THRESHOLD)
-			SStream_concat(O, "#-0x%"PRIx64, (uint64_t)-val);
+		if (val <- HEX_THRESHOLD) {
+			if (val == LONG_MIN)
+				SStream_concat(O, "#-0x%"PRIx64, (uint64_t)val);
+			else
+				SStream_concat(O, "#-0x%"PRIx64, (uint64_t)-val);
+		}
 		else
 			SStream_concat(O, "#-%"PRIu64, -val);
 	}
@@ -82,8 +87,12 @@ void printInt64(SStream *O, int64_t val)
 		else
 			SStream_concat(O, "%"PRIu64, val);
 	} else {
-		if (val <- HEX_THRESHOLD)
-			SStream_concat(O, "-0x%"PRIx64, (uint64_t)-val);
+		if (val <- HEX_THRESHOLD) {
+			if (val == LONG_MIN)
+				SStream_concat(O, "-0x%"PRIx64, (uint64_t)val);
+			else
+				SStream_concat(O, "-0x%"PRIx64, (uint64_t)-val);
+		}
 		else
 			SStream_concat(O, "-%"PRIu64, -val);
 	}
@@ -106,8 +115,12 @@ void printInt32Bang(SStream *O, int32_t val)
 		else
 			SStream_concat(O, "#%u", val);
 	} else {
-		if (val <- HEX_THRESHOLD)
-			SStream_concat(O, "#-0x%x", (uint32_t)-val);
+		if (val <- HEX_THRESHOLD) {
+			if (val == INT_MIN)
+				SStream_concat(O, "#-0x%x", (uint32_t)val);
+			else
+				SStream_concat(O, "#-0x%x", (uint32_t)-val);
+		}
 		else
 			SStream_concat(O, "#-%u", -val);
 	}
@@ -121,8 +134,12 @@ void printInt32(SStream *O, int32_t val)
 		else
 			SStream_concat(O, "%u", val);
 	} else {
-		if (val <- HEX_THRESHOLD)
-			SStream_concat(O, "-0x%x", (uint32_t)-val);
+		if (val <- HEX_THRESHOLD) {
+			if (val == INT_MIN)
+				SStream_concat(O, "-0x%x", (uint32_t)val);
+			else
+				SStream_concat(O, "-0x%x", (uint32_t)-val);
+			}
 		else
 			SStream_concat(O, "-%u", -val);
 	}


### PR DESCRIPTION
Found using oss-fuzz

You cannot compute `- INT_MIN` as it is equal to `INT_MAX+1`