### PR TITLE
Fixes shift for ARM memory operand

### DIFF
--- a/arch/ARM/ARMInstPrinter.c
+++ b/arch/ARM/ARMInstPrinter.c
@@ -2111,8 +2111,8 @@ static void printT2AddrModeSoRegOperand(MCInst *MI,
 		SStream_concat0(O, ", lsl ");
 		SStream_concat(O, "#%d", ShAmt);
 		if (MI->csh->detail) {
-			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count - 1].shift.type = ARM_SFT_LSL;
-			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count - 1].shift.value = ShAmt;
+			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].shift.type = ARM_SFT_LSL;
+			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].shift.value = ShAmt;
 		}
 	}
 


### PR DESCRIPTION
Shift is for same operand as index register

Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=8727
With instruction`12 f8 20 f0`
```
pld		[r2, r0, lsl #2] // insn-ID: 95, insn-mnem: pld
	This instruction belongs to groups: thumb2 0x1004:
```