### PR TITLE
Use printint functions from SStream

### DIFF
--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -1267,10 +1267,7 @@ static void printAdrpLabel(MCInst *MI, unsigned OpNum, SStream *O)
 		// ADRP sign extends a 21-bit offset, shifts it left by 12
 		// and adds it to the value of the PC with its bottom 12 bits cleared
 		uint64_t imm = (MCOperand_getImm(Op) * 0x1000) + (MI->address & ~0xfff);
-		if (imm > HEX_THRESHOLD)
-			SStream_concat(O, "#0x%"PRIx64, imm);
-		else
-			SStream_concat(O, "#%"PRIu64, imm);
+		printUInt64Bang(O, imm);
 
 		if (MI->csh->detail) {
 			MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].type = ARM64_OP_IMM;

--- a/arch/ARM/ARMInstPrinter.c
+++ b/arch/ARM/ARMInstPrinter.c
@@ -511,10 +511,7 @@ void ARM_printInst(MCInst *MI, SStream *O, void *Info)
 
 							SStream_concat0(O, ", ");
 							tmp = translateShiftImm(getSORegOffset((unsigned int)MCOperand_getImm(MO2)));
-							if (tmp > HEX_THRESHOLD)
-								SStream_concat(O, "#0x%x", tmp);
-							else
-								SStream_concat(O, "#%u", tmp);
+							printUInt32Bang(O, tmp);
 							if (MI->csh->detail) {
 								MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count - 1].shift.type =
 									(arm_shifter)ARM_AM_getSORegShOp((unsigned int)MCOperand_getImm(MO2));
@@ -752,18 +749,7 @@ static void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 		} else {
 			switch(MI->flat_insn->id) {
 				default:
-					if (imm >= 0) {
-						if (imm > HEX_THRESHOLD)
-							SStream_concat(O, "#0x%x", imm);
-						else
-							SStream_concat(O, "#%u", imm);
-					} else {
-						if (imm < -HEX_THRESHOLD)
-							// cast first, then negate
-							SStream_concat(O, "#-0x%x", -(uint32_t)imm);
-						else
-							SStream_concat(O, "#-%u", -imm);
-					}
+					printInt32Bang(O, imm);
 					break;
 				case ARM_INS_AND:
 				case ARM_INS_ORR:
@@ -1631,10 +1617,7 @@ static void printSBitModifierOperand(MCInst *MI, unsigned OpNum, SStream *O)
 static void printNoHashImmediate(MCInst *MI, unsigned OpNum, SStream *O)
 {
 	unsigned tmp = (unsigned int)MCOperand_getImm(MCInst_getOperand(MI, OpNum));
-	if (tmp > HEX_THRESHOLD)
-		SStream_concat(O, "0x%x", tmp);
-	else
-		SStream_concat(O, "%u", tmp);
+	printUInt32(O, tmp);
 	if (MI->csh->detail) {
 		if (MI->csh->doing_mem) {
 			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].mem.disp = tmp;
@@ -1717,10 +1700,7 @@ static void printAdrLabelOperand(MCInst *MI, unsigned OpNum, SStream *O, unsigne
 static void printThumbS4ImmOperand(MCInst *MI, unsigned OpNum, SStream *O)
 {
 	unsigned tmp = (unsigned int)MCOperand_getImm(MCInst_getOperand(MI, OpNum)) * 4;
-	if (tmp > HEX_THRESHOLD)
-		SStream_concat(O, "#0x%x", tmp);
-	else
-		SStream_concat(O, "#%u", tmp);
+	printUInt32Bang(O, tmp);
 	if (MI->csh->detail) {
 		MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].type = ARM_OP_IMM;
 		MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].imm = tmp;
@@ -1732,10 +1712,7 @@ static void printThumbSRImm(MCInst *MI, unsigned OpNum, SStream *O)
 {
 	unsigned Imm = (unsigned int)MCOperand_getImm(MCInst_getOperand(MI, OpNum));
 	unsigned tmp = Imm == 0 ? 32 : Imm;
-	if (tmp > HEX_THRESHOLD)
-		SStream_concat(O, "#0x%x", tmp);
-	else
-		SStream_concat(O, "#%u", tmp);
+	printUInt32Bang(O, tmp);
 
 	if (MI->csh->detail) {
 		MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].type = ARM_OP_IMM;
@@ -1810,10 +1787,7 @@ static void printThumbAddrModeImm5SOperand(MCInst *MI, unsigned Op, SStream *O,
 	if (ImmOffs) {
 		tmp = ImmOffs * Scale;
 		SStream_concat0(O, ", ");
-		if (tmp > HEX_THRESHOLD)
-			SStream_concat(O, "#0x%x", tmp);
-		else
-			SStream_concat(O, "#%u", tmp);
+		printUInt32Bang(O, tmp);
 		if (MI->csh->detail)
 			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].mem.disp = tmp;
 	}
@@ -2005,10 +1979,7 @@ static void printT2AddrModeImm0_1020s4Operand(MCInst *MI, unsigned OpNum, SStrea
 	if (MCOperand_getImm(MO2)) {
 		SStream_concat0(O, ", ");
 		tmp = (unsigned int)MCOperand_getImm(MO2) * 4;
-		if (tmp > HEX_THRESHOLD)
-			SStream_concat(O, "#0x%x", tmp);
-		else
-			SStream_concat(O, "#%u", tmp);
+		printUInt32Bang(O, tmp);
 		if (MI->csh->detail)
 			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].mem.disp = tmp;
 	}
@@ -2030,17 +2001,7 @@ static void printT2AddrModeImm8OffsetOperand(MCInst *MI,
 			MI->flat_insn->detail->arm.op_count++;
 		}
 	} else {
-		if (OffImm < 0) {
-			if (OffImm < -HEX_THRESHOLD)
-				SStream_concat(O, "#-0x%x", -OffImm);
-			else
-				SStream_concat(O, "#-%u", -OffImm);
-		} else {
-			if (OffImm > HEX_THRESHOLD)
-				SStream_concat(O, "#0x%x", OffImm);
-			else
-				SStream_concat(O, "#%u", OffImm);
-		}
+		printInt32Bang(O, OffImm);
 		if (MI->csh->detail) {
 			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].type = ARM_OP_IMM;
 			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].imm = OffImm;
@@ -2066,17 +2027,7 @@ static void printT2AddrModeImm8s4OffsetOperand(MCInst *MI,
 			MI->flat_insn->detail->arm.op_count++;
 		}
 	} else {
-		if (OffImm < 0) {
-			if (OffImm < -HEX_THRESHOLD)
-				SStream_concat(O, "#-0x%x", -OffImm);
-			else
-				SStream_concat(O, "#-%u", -OffImm);
-		} else {
-			if (OffImm > HEX_THRESHOLD)
-				SStream_concat(O, "#0x%x", OffImm);
-			else
-				SStream_concat(O, "#%u", OffImm);
-		}
+		printInt32Bang(O, OffImm);
 		if (MI->csh->detail) {
 			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].type = ARM_OP_IMM;
 			MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].imm = OffImm;
@@ -2156,10 +2107,7 @@ static void printNEONModImmOperand(MCInst *MI, unsigned OpNum, SStream *O)
 static void printImmPlusOneOperand(MCInst *MI, unsigned OpNum, SStream *O)
 {
 	unsigned Imm = (unsigned int)MCOperand_getImm(MCInst_getOperand(MI, OpNum));
-	if (Imm + 1 > HEX_THRESHOLD)
-		SStream_concat(O, "#0x%x", Imm + 1);
-	else
-		SStream_concat(O, "#%u", Imm + 1);
+	printUInt32Bang(O, Imm + 1);
 	if (MI->csh->detail) {
 		MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].type = ARM_OP_IMM;
 		MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].imm = Imm + 1;

--- a/arch/Mips/MipsInstPrinter.c
+++ b/arch/Mips/MipsInstPrinter.c
@@ -206,32 +206,12 @@ static void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 		int64_t imm = MCOperand_getImm(Op);
 		if (MI->csh->doing_mem) {
 			if (imm) {	// only print Imm offset if it is not 0
-				if (imm >= 0) {
-					if (imm > HEX_THRESHOLD)
-						SStream_concat(O, "0x%"PRIx64, imm);
-					else
-						SStream_concat(O, "%"PRIu64, imm);
-				} else {
-					if (imm < -HEX_THRESHOLD)
-						SStream_concat(O, "-0x%"PRIx64, -imm);
-					else
-						SStream_concat(O, "-%"PRIu64, -imm);
-				}
+				printInt64(O, imm);
 			}
 			if (MI->csh->detail)
 				MI->flat_insn->detail->mips.operands[MI->flat_insn->detail->mips.op_count].mem.disp = imm;
 		} else {
-			if (imm >= 0) {
-				if (imm > HEX_THRESHOLD)
-					SStream_concat(O, "0x%"PRIx64, imm);
-				else
-					SStream_concat(O, "%"PRIu64, imm);
-			} else {
-				if (imm < -HEX_THRESHOLD)
-					SStream_concat(O, "-0x%"PRIx64, -imm);
-				else
-					SStream_concat(O, "-%"PRIu64, -imm);
-			}
+			printInt64(O, imm);
 
 			if (MI->csh->detail) {
 				MI->flat_insn->detail->mips.operands[MI->flat_insn->detail->mips.op_count].type = MIPS_OP_IMM;
@@ -247,17 +227,8 @@ static void printUnsignedImm(MCInst *MI, int opNum, SStream *O)
 	MCOperand *MO = MCInst_getOperand(MI, opNum);
 	if (MCOperand_isImm(MO)) {
 		int64_t imm = MCOperand_getImm(MO);
-		if (imm >= 0) {
-			if (imm > HEX_THRESHOLD)
-				SStream_concat(O, "0x%x", (unsigned short int)imm);
-			else
-				SStream_concat(O, "%u", (unsigned short int)imm);
-		} else {
-			if (imm < -HEX_THRESHOLD)
-				SStream_concat(O, "-0x%x", (short int)-imm);
-			else
-				SStream_concat(O, "-%u", (short int)-imm);
-		}
+		printInt64(O, imm);
+
 		if (MI->csh->detail) {
 			MI->flat_insn->detail->mips.operands[MI->flat_insn->detail->mips.op_count].type = MIPS_OP_IMM;
 			MI->flat_insn->detail->mips.operands[MI->flat_insn->detail->mips.op_count].imm = (unsigned short int)imm;

--- a/arch/PowerPC/PPCInstPrinter.c
+++ b/arch/PowerPC/PPCInstPrinter.c
@@ -388,17 +388,7 @@ static void printS5ImmOperand(MCInst *MI, unsigned OpNo, SStream *O)
 	int Value = (int)MCOperand_getImm(MCInst_getOperand(MI, OpNo));
 	Value = SignExtend32(Value, 5);
 
-	if (Value >= 0) {
-		if (Value > HEX_THRESHOLD)
-			SStream_concat(O, "0x%x", Value);
-		else
-			SStream_concat(O, "%u", Value);
-	} else {
-		if (Value < -HEX_THRESHOLD)
-			SStream_concat(O, "-0x%x", -Value);
-		else
-			SStream_concat(O, "-%u", -Value);
-	}
+	printInt32(O, Value);
 
 	if (MI->csh->detail) {
 		MI->flat_insn->detail->ppc.operands[MI->flat_insn->detail->ppc.op_count].type = PPC_OP_IMM;
@@ -411,10 +401,7 @@ static void printU5ImmOperand(MCInst *MI, unsigned OpNo, SStream *O)
 {
 	unsigned int Value = (unsigned int)MCOperand_getImm(MCInst_getOperand(MI, OpNo));
 	//assert(Value <= 31 && "Invalid u5imm argument!");
-	if (Value > HEX_THRESHOLD)
-		SStream_concat(O, "0x%x", Value);
-	else
-		SStream_concat(O, "%u", Value);
+	printUInt32(O, Value);
 
 	if (MI->csh->detail) {
 		MI->flat_insn->detail->ppc.operands[MI->flat_insn->detail->ppc.op_count].type = PPC_OP_IMM;
@@ -427,10 +414,7 @@ static void printU6ImmOperand(MCInst *MI, unsigned OpNo, SStream *O)
 {
 	unsigned int Value = (unsigned int)MCOperand_getImm(MCInst_getOperand(MI, OpNo));
 	//assert(Value <= 63 && "Invalid u6imm argument!");
-	if (Value > HEX_THRESHOLD)
-		SStream_concat(O, "0x%x", Value);
-	else
-		SStream_concat(O, "%u", Value);
+	printUInt32(O, Value);
 
 	if (MI->csh->detail) {
 		MI->flat_insn->detail->ppc.operands[MI->flat_insn->detail->ppc.op_count].type = PPC_OP_IMM;
@@ -675,17 +659,7 @@ static void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 
 	if (MCOperand_isImm(Op)) {
 		int32_t imm = (int32_t)MCOperand_getImm(Op);
-		if (imm >= 0) {
-			if (imm > HEX_THRESHOLD)
-				SStream_concat(O, "0x%x", imm);
-			else
-				SStream_concat(O, "%u", imm);
-		} else {
-			if (imm < -HEX_THRESHOLD)
-				SStream_concat(O, "-0x%x", -imm);
-			else
-				SStream_concat(O, "-%u", -imm);
-		}
+		printInt32(O, imm);
 
 		if (MI->csh->detail) {
 			if (MI->csh->doing_mem) {

--- a/arch/Sparc/SparcInstPrinter.c
+++ b/arch/Sparc/SparcInstPrinter.c
@@ -263,23 +263,7 @@ static void printOperand(MCInst *MI, int opNum, SStream *O)
 				break;
 		}
 		
-		if (Imm == INT_MIN) {
-			// printf("ERROR: invalid Imm value\n");
-			return;
-		}
-
-		if (Imm >= 0) {
-			if (Imm > HEX_THRESHOLD)
-				SStream_concat(O, "0x%x", Imm);
-			else
-				SStream_concat(O, "%u", Imm);
-		} else {
-			if (Imm < -HEX_THRESHOLD)
-				//cast first, then negate
-				SStream_concat(O, "-0x%x", -(uint32_t)Imm);
-			else
-				SStream_concat(O, "-%u", -Imm);
-		}
+		printInt32(O, Imm);
 
 		if (MI->csh->detail) {
 			if (MI->csh->doing_mem) {

--- a/arch/SystemZ/SystemZInstPrinter.c
+++ b/arch/SystemZ/SystemZInstPrinter.c
@@ -42,17 +42,7 @@ void SystemZ_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci)
 
 static void printAddress(MCInst *MI, unsigned Base, int64_t Disp, unsigned Index, SStream *O)
 {
-	if (Disp >= 0) {
-		if (Disp > HEX_THRESHOLD)
-			SStream_concat(O, "0x%"PRIx64, Disp);
-		else
-			SStream_concat(O, "%"PRIu64, Disp);
-	} else {
-		if (Disp < -HEX_THRESHOLD)
-			SStream_concat(O, "-0x%"PRIx64, -Disp);
-		else
-			SStream_concat(O, "-%"PRIu64, -Disp);
-	}
+	printInt64(O, Disp);
 
 	if (Base) {
 		SStream_concat0(O, "(");
@@ -93,17 +83,7 @@ static void _printOperand(MCInst *MI, MCOperand *MO, SStream *O)
 	} else if (MCOperand_isImm(MO)) {
 		int64_t Imm = MCOperand_getImm(MO);
 
-		if (Imm >= 0) {
-			if (Imm > HEX_THRESHOLD)
-				SStream_concat(O, "0x%"PRIx64, Imm);
-			else
-				SStream_concat(O, "%"PRIu64, Imm);
-		} else {
-			if (Imm < -HEX_THRESHOLD)
-				SStream_concat(O, "-0x%"PRIx64, -Imm);
-			else
-				SStream_concat(O, "-%"PRIu64, -Imm);
-		}
+		printInt64(O, Imm);
 
 		if (MI->csh->detail) {
 			MI->flat_insn->detail->sysz.operands[MI->flat_insn->detail->sysz.op_count].type = SYSZ_OP_IMM;
@@ -117,17 +97,7 @@ static void printU4ImmOperand(MCInst *MI, int OpNum, SStream *O)
 {
 	int64_t Value = MCOperand_getImm(MCInst_getOperand(MI, OpNum));
 	// assert(isUInt<4>(Value) && "Invalid u4imm argument");
-	if (Value >= 0) {
-		if (Value > HEX_THRESHOLD)
-			SStream_concat(O, "0x%"PRIx64, Value);
-		else
-			SStream_concat(O, "%"PRIu64, Value);
-	} else {
-		if (Value < -HEX_THRESHOLD)
-			SStream_concat(O, "-0x%"PRIx64, -Value);
-		else
-			SStream_concat(O, "-%"PRIu64, -Value);
-	}
+	printInt64(O, Value);
 
 	if (MI->csh->detail) {
 		MI->flat_insn->detail->sysz.operands[MI->flat_insn->detail->sysz.op_count].type = SYSZ_OP_IMM;
@@ -141,10 +111,7 @@ static void printU6ImmOperand(MCInst *MI, int OpNum, SStream *O)
 	uint32_t Value = (uint32_t)MCOperand_getImm(MCInst_getOperand(MI, OpNum));
 	// assert(isUInt<6>(Value) && "Invalid u6imm argument");
 
-	if (Value > HEX_THRESHOLD)
-		SStream_concat(O, "0x%x", Value);
-	else
-		SStream_concat(O, "%u", Value);
+	printUInt32(O, Value);
 
 	if (MI->csh->detail) {
 		MI->flat_insn->detail->sysz.operands[MI->flat_insn->detail->sysz.op_count].type = SYSZ_OP_IMM;
@@ -254,10 +221,7 @@ static void printU32ImmOperand(MCInst *MI, int OpNum, SStream *O)
 	uint32_t Value = (uint32_t)MCOperand_getImm(MCInst_getOperand(MI, OpNum));
 	// assert(isUInt<32>(Value) && "Invalid u32imm argument");
 
-	if (Value > HEX_THRESHOLD)
-		SStream_concat(O, "0x%x", Value);
-	else
-		SStream_concat(O, "%u", Value);
+	printUInt32(O, Value);
 
 	if (MI->csh->detail) {
 		MI->flat_insn->detail->sysz.operands[MI->flat_insn->detail->sysz.op_count].type = SYSZ_OP_IMM;
@@ -286,23 +250,8 @@ static void printPCRelOperand(MCInst *MI, int OpNum, SStream *O)
 
 	if (MCOperand_isImm(MO)) {
 		imm = (int32_t)MCOperand_getImm(MO);
-		if (imm == INT_MIN) {
-			// printf("ERROR: invalid Imm value\n");
-			return;
-		}
 
-		if (imm >= 0) {
-			if (imm > HEX_THRESHOLD)
-				SStream_concat(O, "0x%x", imm);
-			else
-				SStream_concat(O, "%u", imm);
-		} else {
-			if (imm < -HEX_THRESHOLD)
-				//cast first, then negate
-				SStream_concat(O, "-0x%x", -(uint32_t)imm);
-			else
-				SStream_concat(O, "-%u", -imm);
-		}
+		printInt32(O, imm);
 
 		if (MI->csh->detail) {
 			MI->flat_insn->detail->sysz.operands[MI->flat_insn->detail->sysz.op_count].type = SYSZ_OP_IMM;

--- a/arch/X86/X86ATTInstPrinter.c
+++ b/arch/X86/X86ATTInstPrinter.c
@@ -640,17 +640,7 @@ static void printMemReference(MCInst *MI, unsigned Op, SStream *O)
 			MI->flat_insn->detail->x86.operands[MI->flat_insn->detail->x86.op_count].mem.disp = DispVal;
 		if (DispVal) {
 			if (MCOperand_getReg(IndexReg) || MCOperand_getReg(BaseReg)) {
-				if (DispVal < 0) {
-					if (DispVal <  -HEX_THRESHOLD)
-						SStream_concat(O, "-0x%"PRIx64, -DispVal);
-					else
-						SStream_concat(O, "-%"PRIu64, -DispVal);
-				} else {
-					if (DispVal > HEX_THRESHOLD)
-						SStream_concat(O, "0x%"PRIx64, DispVal);
-					else
-						SStream_concat(O, "%"PRIu64, DispVal);
-				}
+				printInt64(O, DispVal);
 			} else {
 				// only immediate as address of memory
 				if (DispVal < 0) {

--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -275,18 +275,7 @@ static void _printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 		printRegName(O, MCOperand_getReg(Op));
 	} else if (MCOperand_isImm(Op)) {
 		int64_t imm = MCOperand_getImm(Op);
-		if (imm < 0) {
-			if (imm < -HEX_THRESHOLD)
-				SStream_concat(O, "-0x%"PRIx64, -imm);
-			else
-				SStream_concat(O, "-%"PRIu64, -imm);
-
-		} else {
-			if (imm > HEX_THRESHOLD)
-				SStream_concat(O, "0x%"PRIx64, imm);
-			else
-				SStream_concat(O, "%"PRIu64, imm);
-		}
+		printInt64(O, imm);
 	}
 }
 
@@ -597,20 +586,7 @@ static void printImm(int syntax, SStream *O, int64_t imm, bool positive)
 				SStream_concat(O, "%"PRIu64, imm);
 		}
 	} else {
-		if (imm < 0) {
-			if (imm == 0x8000000000000000LL)  // imm == -imm
-				SStream_concat0(O, "0x8000000000000000");
-			else if (imm < -HEX_THRESHOLD)
-				SStream_concat(O, "-0x%"PRIx64, -imm);
-			else
-				SStream_concat(O, "-%"PRIu64, -imm);
-
-		} else {
-			if (imm > HEX_THRESHOLD)
-				SStream_concat(O, "0x%"PRIx64, imm);
-			else
-				SStream_concat(O, "%"PRIu64, imm);
-		}
+		printInt64(O, imm);
 	}
 }
 

--- a/arch/XCore/XCoreInstPrinter.c
+++ b/arch/XCore/XCoreInstPrinter.c
@@ -208,17 +208,7 @@ static void _printOperand(MCInst *MI, MCOperand *MO, SStream *O)
 	} else if (MCOperand_isImm(MO)) {
 		int32_t Imm = (int32_t)MCOperand_getImm(MO);
 
-		if (Imm >= 0) {
-			if (Imm > HEX_THRESHOLD)
-				SStream_concat(O, "0x%x", Imm);
-			else
-				SStream_concat(O, "%u", Imm);
-		} else {
-			if (Imm < -HEX_THRESHOLD)
-				SStream_concat(O, "-0x%x", -Imm);
-			else
-				SStream_concat(O, "-%u", -Imm);
-		}
+		printInt32(O, Imm);
 
 		if (MI->csh->detail) {
 			if (MI->csh->doing_mem) {


### PR DESCRIPTION
in perticular, not to overflow -INT_MIN

Following #1164 

I do not think this is complete (there are still uses of HEX_THRESHOLD in arch directory), but it is already a big commit and deserves a review.