### PR TITLE
Refactor confusing if for xacquire/xrelease

### DIFF
--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -543,9 +543,8 @@ static int readPrefixes(struct InternalInstruction *insn)
 			 * - it is followed by an xchg instruction
 			 * then it should be disassembled as a xacquire/xrelease not repne/rep.
 			 */
-			if ((byte == 0xf2 || byte == 0xf3) &&
-					((nextByte == 0xf0) |
-					 ((nextByte & 0xfe) == 0x86 || (nextByte & 0xf8) == 0x90)))
+			if (((nextByte == 0xf0) ||
+				((nextByte & 0xfe) == 0x86 || (nextByte & 0xf8) == 0x90)))
 				insn->xAcquireRelease = true;
 			/*
 			 * Also if the byte is 0xf3, and the following condition is met:


### PR DESCRIPTION
Sync with [upstream](https://github.com/llvm-mirror/llvm/blob/7cdce81/lib/Target/X86/Disassembler/X86DisassemblerDecoder.cpp#L362). The first check is done above, and the or operator was mistakenly replaced by a bitwise or operator. Was causing a warning for me.