### PR TITLE
Add Availability.h include to fix macOS SDK instrinsics

### DIFF
--- a/MCInst.c
+++ b/MCInst.c
@@ -2,6 +2,7 @@
 /* By Nguyen Anh Quynh <aquynh@gmail.com>, 2013-2014 */
 
 #if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <Availability.h>
 #include <libkern/libkern.h>
 #else
 #include <stdio.h>

--- a/SStream.c
+++ b/SStream.c
@@ -6,6 +6,7 @@
 #endif
 #include <stdarg.h>
 #if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <Availability.h>
 #include <libkern/libkern.h>
 #include <i386/limits.h>
 #else

--- a/arch/X86/X86ATTInstPrinter.c
+++ b/arch/X86/X86ATTInstPrinter.c
@@ -23,6 +23,7 @@
 #endif
 #include <platform.h>
 #if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <Availability.h>
 #include <libkern/libkern.h>
 #else
 #include <stdio.h>

--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -19,6 +19,10 @@
 
 #ifdef CAPSTONE_HAS_X86
 
+#if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <Availability.h>
+#endif
+
 #include <string.h>
 
 #include "../../cs_priv.h"

--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -22,6 +22,7 @@
 #endif
 #include <platform.h>
 #if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <Availability.h>
 #include <libkern/libkern.h>
 #else
 #include <stdio.h>

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -3,6 +3,10 @@
 
 #ifdef CAPSTONE_HAS_X86
 
+#if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <Availability.h>
+#endif
+
 #include <string.h>
 
 #include "X86Mapping.h"

--- a/cs.c
+++ b/cs.c
@@ -5,6 +5,7 @@
 #pragma warning(disable:28719)		// disable MSVC's warning on strcpy()
 #endif
 #if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <Availability.h>
 #include <libkern/libkern.h>
 #else
 #include <stddef.h>

--- a/utils.c
+++ b/utils.c
@@ -2,6 +2,7 @@
 /* By Nguyen Anh Quynh <aquynh@gmail.com>, 2013-2014 */
 
 #if defined(CAPSTONE_HAS_OSXKERNEL)
+#include <Availability.h>
 #include <libkern/libkern.h>
 #else
 #include <stdlib.h>


### PR DESCRIPTION
I thought my former 2 pull requests were all of it, but unfortunately not.

string.h in macOS SDK 10.13 looks like the following:

```C
extern void	*memcpy(void *, const void *, size_t);
…
#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_13
/* older deployment target */
#elif defined(KASAN) || (defined (_FORTIFY_SOURCE) && _FORTIFY_SOURCE == 0)
/* FORTIFY_SOURCE disabled */
#else /* _chk macros */
#if __has_builtin(__builtin___memcpy_chk)
#define memcpy(dest, src, len) __builtin___memcpy_chk(dest, src, len, __builtin_object_size(dest, 0))
#endif
```

It is supposed to replace memory routines like memcpy, memmove, strncpy, strncat, strlcat, strlcpy, strcpy, strcat, and bcopy with special chk versions which perform additional validation when targeting 10.13 and newer.

When targeting a kernel extension to macOS 10.12 or lower the code above is supposed to disable the overrides and use the original interfaces, since the 'chk' versions have only appeared in 10.13.

Unfortunately the __MAC_OS_X_VERSION_MIN_REQUIRED / __MAC_OS_X_VERSION_MIN_REQUIRED handling macros are only handled by Availability.h header, which is not implicitly included by string.h and this results in version checks being skipped effectively causing the kernel extension to import chk versions of the memory routines and failing to load on 10.12 and lower.

This patch adds explicit Availability.h inclusion where necessary. Sorry for extra trouble.