### PR TITLE
Initialize X86 necessaryPrefixLocation

### DIFF
--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -483,6 +483,8 @@ static int readPrefixes(struct InternalInstruction *insn)
 	bool hasAdSize = false;
 	bool hasOpSize = false;
 
+	//initialize to an impossible value
+	insn->necessaryPrefixLocation = insn->readerCursor - 1;
 	while (isPrefix) {
 		if (insn->mode == MODE_64BIT) {
 			// eliminate consecutive redundant REX bytes in front

--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -484,7 +484,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 	bool hasOpSize = false;
 
 	//initialize to an impossible value
-	insn->necessaryPrefixLocation = -1;
+	insn->necessaryPrefixLocation = insn->readerCursor - 1;
 	while (isPrefix) {
 		if (insn->mode == MODE_64BIT) {
 			// eliminate consecutive redundant REX bytes in front

--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -484,7 +484,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 	bool hasOpSize = false;
 
 	//initialize to an impossible value
-	insn->necessaryPrefixLocation = insn->readerCursor - 1;
+	insn->necessaryPrefixLocation = -1;
 	while (isPrefix) {
 		if (insn->mode == MODE_64BIT) {
 			// eliminate consecutive redundant REX bytes in front


### PR DESCRIPTION
Found by oss-fuzz with newly set memory sanitizer

Reproducing sample is `666220`
`insn->necessaryPrefixLocation` is used with `isPrefixAtLocation(insn, 0x66, insn->necessaryPrefixLocation)` but not initialized before
Patch initializes it to a value that should never match in `isPrefixAtLocation`