### PR TITLE
Extends Mips number of operands

### DIFF
--- a/include/capstone/mips.h
+++ b/include/capstone/mips.h
@@ -251,7 +251,7 @@ typedef struct cs_mips {
 	// Number of operands of this instruction, 
 	// or 0 when instruction has no operand.
 	uint8_t op_count;
-	cs_mips_op operands[8]; // operands for this instruction.
+	cs_mips_op operands[10]; // operands for this instruction.
 } cs_mips;
 
 //> MIPS instruction


### PR DESCRIPTION
for CS_MODE_MIPS32R6

Found by oss-fuzz

With `(cs_mode)(CS_MODE_MIPS32R6 + CS_MODE_MICRO + CS_MODE_BIG_ENDIAN)`
`21 20 d4 20` is `swm32           $s0, $s1, $s2, $s3, $s4, $s5, $s6, $fp, 0x420($zero)`
`23 20 5e 20` is `lwm32           $s0, $s1, $s2, $s3, $s4, $s5, $s6, $fp, $ra, -0x1e0($zero)`

They have 9 and 10 operands (instead of 8 previous limit)