### PR TITLE
Better error reporting for python binding

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -216,16 +216,14 @@ _found = False
 def _load_lib(path):
     lib_file = join(path, _lib)
     #print("Trying to load %s" %lib_file)
-    try:
+    if os.path.exists(lib_file):
         return ctypes.cdll.LoadLibrary(lib_file)
-    except OSError:
+    else:
         # if we're on linux, try again with .so.3 extension
         if lib_file.endswith('.so'):
-            try:
+            if os.path.exists(lib_file + '.3'):
                 return ctypes.cdll.LoadLibrary(lib_file + '.3')
-            except OSError:
-                return None
-        return None
+    return None
 
 _cs = None
 


### PR DESCRIPTION
To diagnose issue with oss-fuzz building corpus

see https://github.com/google/oss-fuzz/pull/1548

Now we get the following error on oss-fuzz
```
Step #4: + ./test_corpus.py
Step #4: Traceback (most recent call last):
Step #4:   File "./test_corpus.py", line 5, in <module>
Step #4:     from capstone import *
Step #4:   File "build/bdist.linux-x86_64/egg/capstone/__init__.py", line 252, in <module>
Step #4: ImportError: ERROR: fail to load the dynamic library.
```

And I think this is not because of a missing file