### PR TITLE
Initializes to 0 X86 immediateOffset

### DIFF
--- a/arch/X86/X86DisassemblerDecoder.h
+++ b/arch/X86/X86DisassemblerDecoder.h
@@ -605,6 +605,11 @@ typedef struct InternalInstruction {
   /* The value of the vector extension prefix(EVEX/VEX/XOP), if present */
   uint8_t vectorExtensionPrefix[4];
 
+  /* Offsets from the start of the instruction to the pieces of data, which is
+     needed to find relocation entries for adding symbolic operands */
+  uint8_t displacementOffset;
+  uint8_t immediateOffset;
+
   // end-of-zero-members
 
   /* Reader interface (C) */
@@ -645,11 +650,6 @@ typedef struct InternalInstruction {
   uint8_t immediateSize;
 
   uint8_t immSize;	// immediate size for X86_OP_IMM operand
-
-  /* Offsets from the start of the instruction to the pieces of data, which is
-     needed to find relocation entries for adding symbolic operands */
-  uint8_t displacementOffset;
-  uint8_t immediateOffset;
 
   /* opcode state */
 


### PR DESCRIPTION
Found by os-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9167

The fix is to put the field `immediateOffset` in the first fields : those which are set to zero