### PR TITLE
Init cs_detail

### DIFF
--- a/arch/AArch64/AArch64Disassembler.c
+++ b/arch/AArch64/AArch64Disassembler.c
@@ -233,7 +233,7 @@ static DecodeStatus _getInstruction(cs_struct *ud, MCInst *MI,
 	}
 
 	if (MI->flat_insn->detail) {
-		memset(MI->flat_insn->detail, 0, sizeof(cs_detail));
+		memset(MI->flat_insn->detail, 0, offsetof(cs_detail, arm64)+sizeof(cs_arm64));
 		for (i = 0; i < ARR_SIZE(MI->flat_insn->detail->arm64.operands); i++)
 			MI->flat_insn->detail->arm64.operands[i].vector_index = -1;
 	}

--- a/arch/ARM/ARMDisassembler.c
+++ b/arch/ARM/ARMDisassembler.c
@@ -475,7 +475,7 @@ static DecodeStatus _ARM_getInstruction(cs_struct *ud, MCInst *MI, const uint8_t
 		return MCDisassembler_Fail;
 
 	if (MI->flat_insn->detail) {
-		memset(&MI->flat_insn->detail->arm, 0, sizeof(cs_arm));
+		memset(MI->flat_insn->detail, 0, offsetof(cs_detail, arm)+sizeof(cs_arm));
 		for (i = 0; i < ARR_SIZE(MI->flat_insn->detail->arm.operands); i++) {
 			MI->flat_insn->detail->arm.operands[i].vector_index = -1;
 			MI->flat_insn->detail->arm.operands[i].neon_lane = -1;
@@ -718,7 +718,7 @@ static DecodeStatus _Thumb_getInstruction(cs_struct *ud, MCInst *MI, const uint8
 		return MCDisassembler_Fail;
 
 	if (MI->flat_insn->detail) {
-		memset(&MI->flat_insn->detail->arm, 0, sizeof(cs_arm));
+		memset(MI->flat_insn->detail, 0, offsetof(cs_detail, arm)+sizeof(cs_arm));
 		for (i = 0; i < ARR_SIZE(MI->flat_insn->detail->arm.operands); i++) {
 			MI->flat_insn->detail->arm.operands[i].vector_index = -1;
 			MI->flat_insn->detail->arm.operands[i].neon_lane = -1;

--- a/arch/EVM/EVMDisassembler.c
+++ b/arch/EVM/EVMDisassembler.c
@@ -2,6 +2,8 @@
 /* By Nguyen Anh Quynh, 2018 */
 
 #include <string.h>
+#include <stddef.h> // offsetof macro
+                    // alternatively #include "../../utils.h" like everyone else
 
 #include "EVMDisassembler.h"
 #include "EVMMapping.h"
@@ -296,12 +298,8 @@ bool EVM_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 		*size = 1;
 
 	if (MI->flat_insn->detail) {
-		memset(&MI->flat_insn->detail->evm, 0, sizeof(cs_evm));
+		memset(MI->flat_insn->detail, 0, offsetof(cs_detail, evm)+sizeof(cs_evm));
 		EVM_get_insn_id((cs_struct *)ud, MI->flat_insn, opcode);
-
-		MI->flat_insn->detail->regs_read_count = 0;
-		MI->flat_insn->detail->regs_write_count = 0;
-		MI->flat_insn->detail->groups_count = 0;
 
 		if (MI->flat_insn->detail->evm.pop) {
 			MI->flat_insn->detail->groups[MI->flat_insn->detail->groups_count] = EVM_GRP_STACK_READ;

--- a/arch/M680X/M680XDisassembler.c
+++ b/arch/M680X/M680XDisassembler.c
@@ -1802,9 +1802,7 @@ static unsigned int m680x_disassemble(MCInst *MI, m680x_info *info,
 	e_access_mode access_mode;
 
 	if (detail != NULL) {
-		detail->regs_read_count = 0;
-		detail->regs_write_count = 0;
-		detail->groups_count = 0;
+		memset(detail, 0, offsetof(cs_detail, m680x)+sizeof(cs_m680x));
 	}
 
 	memset(&insn_description, 0, sizeof(insn_description));

--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -4061,6 +4061,10 @@ bool M68K_getInstruction(csh ud, const uint8_t* code, size_t code_len, MCInst* i
 		return false;
 	}
 
+	if (instr->flat_insn->detail) {
+		memset(instr->flat_insn->detail, 0, offsetof(cs_detail, m68k)+sizeof(cs_m68k));
+	}
+
 	info->groups_count = 0;
 	info->regs_read_count = 0;
 	info->regs_write_count = 0;

--- a/arch/Mips/MipsDisassembler.c
+++ b/arch/Mips/MipsDisassembler.c
@@ -412,7 +412,7 @@ static DecodeStatus MipsDisassembler_getInstruction(int mode, MCInst *instr,
 	DecodeStatus Result;
 
 	if (instr->flat_insn->detail) {
-		memset(instr->flat_insn->detail, 0, sizeof(cs_detail));
+		memset(instr->flat_insn->detail, 0, offsetof(cs_detail, mips)+sizeof(cs_mips));
 	}
 
 	if (mode & CS_MODE_MICRO) {

--- a/arch/PowerPC/PPCDisassembler.c
+++ b/arch/PowerPC/PPCDisassembler.c
@@ -371,7 +371,7 @@ static DecodeStatus getInstruction(MCInst *MI,
 			(code[1] <<  8) | (code[0] <<  0);
 
 	if (MI->flat_insn->detail) {
-		memset(MI->flat_insn->detail, 0, sizeof(cs_detail));
+		memset(MI->flat_insn->detail, 0, offsetof(cs_detail, ppc)+sizeof(cs_ppc));
 	}
 
 	if (MI->csh->mode & CS_MODE_QPX) {

--- a/arch/Sparc/SparcDisassembler.c
+++ b/arch/Sparc/SparcDisassembler.c
@@ -228,7 +228,7 @@ bool Sparc_getInstruction(csh ud, const uint8_t *code, size_t code_len, MCInst *
 		return false;
 
 	if (MI->flat_insn->detail) {
-		memset(MI->flat_insn->detail, 0, sizeof(cs_detail));
+		memset(MI->flat_insn->detail, 0, offsetof(cs_detail, sparc)+sizeof(cs_sparc));
 	}
 
 	Result = decodeInstruction_4(DecoderTableSparc32, MI, Insn, address,

--- a/arch/SystemZ/SystemZDisassembler.c
+++ b/arch/SystemZ/SystemZDisassembler.c
@@ -321,7 +321,7 @@ bool SystemZ_getInstruction(csh ud, const uint8_t *code, size_t code_len, MCInst
 		return false;
 
 	if (MI->flat_insn->detail) {
-		memset(MI->flat_insn->detail, 0, sizeof(cs_detail));
+		memset(MI->flat_insn->detail, 0, offsetof(cs_detail, sysz)+sizeof(cs_sysz));
 	}
 
 	// Construct the instruction.

--- a/arch/TMS320C64x/TMS320C64xDisassembler.c
+++ b/arch/TMS320C64x/TMS320C64xDisassembler.c
@@ -592,7 +592,7 @@ bool TMS320C64x_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 	}
 
 	if(MI->flat_insn->detail)
-		memset(MI->flat_insn->detail, 0, sizeof(cs_detail));
+		memset(MI->flat_insn->detail, 0, offsetof(cs_detail, tms320c64x)+sizeof(cs_tms320c64x));
 
 	insn = (code[3] << 0) | (code[2] << 8) | (code[1] << 16) | (code[0] << 24);
 	result = decodeInstruction_4(DecoderTable32, MI, insn, address, info, 0);

--- a/arch/XCore/XCoreDisassembler.c
+++ b/arch/XCore/XCoreDisassembler.c
@@ -738,7 +738,7 @@ bool XCore_getInstruction(csh ud, const uint8_t *code, size_t code_len, MCInst *
 	}
 
 	if (MI->flat_insn->detail) {
-		memset(MI->flat_insn->detail, 0, sizeof(cs_detail));
+		memset(MI->flat_insn->detail, 0, offsetof(cs_detail, xcore)+sizeof(cs_xcore));
 	}
 
 	// Calling the auto-generated decoder function.

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -278,6 +278,8 @@ typedef struct cs_opt_skipdata {
 #include "evm.h"
 
 // NOTE: All information in cs_detail is only available when CS_OPT_DETAIL = CS_OPT_ON
+// Initialized as memset(., 0, offsetof(cs_detail, ARCH)+sizeof(cs_ARCH)) by ARCH_getInstruction in arch/ARCH/ARCHDisassembler.c
+// if cs_detail changes, in particular if a field is added after the union, update arch/ARCH/ARCHDisassembler.c accordingly
 typedef struct cs_detail {
 	uint16_t regs_read[12]; // list of implicit registers read by this insn
 	uint8_t regs_read_count; // number of implicit registers read by this insn

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -278,8 +278,10 @@ typedef struct cs_opt_skipdata {
 #include "evm.h"
 
 // NOTE: All information in cs_detail is only available when CS_OPT_DETAIL = CS_OPT_ON
-// Initialized as memset(., 0, offsetof(cs_detail, ARCH)+sizeof(cs_ARCH)) by ARCH_getInstruction in arch/ARCH/ARCHDisassembler.c
-// if cs_detail changes, in particular if a field is added after the union, update arch/ARCH/ARCHDisassembler.c accordingly
+// Initialized as memset(., 0, offsetof(cs_detail, ARCH)+sizeof(cs_ARCH))
+// by ARCH_getInstruction in arch/ARCH/ARCHDisassembler.c
+// if cs_detail changes, in particular if a field is added after the union,
+// then update arch/ARCH/ARCHDisassembler.c accordingly
 typedef struct cs_detail {
 	uint16_t regs_read[12]; // list of implicit registers read by this insn
 	uint8_t regs_read_count; // number of implicit registers read by this insn


### PR DESCRIPTION
As @aquynh requested in #1125

M68K and M680X use a private struct and did not initialize cs_detail, there might be a performance penalty for those arch (but I feel it is still better to initialize structs).