### PR TITLE
arm64: Fix TestAndBranch sign extend

### DIFF
--- a/arch/AArch64/AArch64Disassembler.c
+++ b/arch/AArch64/AArch64Disassembler.c
@@ -1626,7 +1626,7 @@ static DecodeStatus DecodeTestAndBranch(MCInst *Inst, uint32_t insn,
 {
 	uint32_t Rt = fieldFromInstruction(insn, 0, 5);
 	uint32_t bit = fieldFromInstruction(insn, 31, 1) << 5;
-	uint32_t dst = fieldFromInstruction(insn, 5, 14);
+	uint64_t dst = fieldFromInstruction(insn, 5, 14);
 
 	bit |= fieldFromInstruction(insn, 19, 5);
 


### PR DESCRIPTION
should fix https://github.com/aquynh/capstone/issues/1144

tested using radare2 test suite, in which there's already a test for this issue

<img width="697" alt="screen shot 2018-07-20 at 01 12 20" src="https://user-images.githubusercontent.com/4139069/42975296-a7c841b8-8bbb-11e8-86fb-0b7859266542.png">
