### PR TITLE
arch/X86: add "cs:" prefix for relative near jmp/calls in x16

### DIFF
--- a/arch/X86/X86ATTInstPrinter.c
+++ b/arch/X86/X86ATTInstPrinter.c
@@ -616,6 +616,9 @@ static void printPCRelImm(MCInst *MI, unsigned OpNo, SStream *O)
 		if (MI->Opcode == X86_CALLpcrel16 || MI->Opcode == X86_JMP_2)
 			imm = imm & 0xffff;
 
+		if (MI->csh->mode == CS_MODE_16)
+			SStream_concat(O, "cs:");
+
 		if (imm < 0) {
 			SStream_concat(O, "0x%"PRIx64, imm);
 		} else {

--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -824,6 +824,9 @@ static void printPCRelImm(MCInst *MI, unsigned OpNo, SStream *O)
 		if (MI->Opcode == X86_CALLpcrel16 || MI->Opcode == X86_JMP_2)
 			imm = imm & 0xffff;
 
+		if (MI->csh->mode == CS_MODE_16)
+			SStream_concat(O, "cs:");
+
 		printImm(MI->csh->syntax, O, imm, true);
 
 		if (MI->csh->detail) {


### PR DESCRIPTION
I think this should supersede https://github.com/aquynh/capstone/pull/1216