### PR TITLE
arch/X86: fix strncpy usage

### DIFF
--- a/arch/X86/X86ATTInstPrinter.c
+++ b/arch/X86/X86ATTInstPrinter.c
@@ -881,7 +881,7 @@ void X86_ATT_printInst(MCInst *MI, SStream *OS, void *info)
 
 	// perhaps this instruction does not need printer
 	if (MI->assembly[0]) {
-		strncpy(OS->buffer, MI->assembly, sizeof(MI->assembly));
+		strncpy(OS->buffer, MI->assembly, sizeof(OS->buffer));
 		return;
 	}
 

--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -742,7 +742,7 @@ void X86_Intel_printInst(MCInst *MI, SStream *O, void *Info)
 
 	// perhaps this instruction does not need printer
 	if (MI->assembly[0]) {
-		strncpy(O->buffer, MI->assembly, sizeof(MI->assembly));
+		strncpy(O->buffer, MI->assembly, sizeof(O->buffer));
 		return;
 	}
 


### PR DESCRIPTION
The `n` parameter should be the size of the destination buffer, not the
source one.