### PR TITLE
Correct use of strncpy function

### DIFF
--- a/arch/Sparc/SparcInstPrinter.c
+++ b/arch/Sparc/SparcInstPrinter.c
@@ -358,8 +358,8 @@ void Sparc_printInst(MCInst *MI, SStream *O, void *Info)
 	mnem = printAliasInstr(MI, O, Info);
 	if (mnem) {
 		// fixup instruction id due to the change in alias instruction
-		strncpy(instr, mnem, strlen(mnem));
-		instr[strlen(mnem)] = '\0';
+		strncpy(instr, mnem, sizeof(instr));
+		instr[sizeof(instr) - 1] = '\0';
 		// does this contains hint with a coma?
 		p = strchr(instr, ',');
 		if (p)


### PR DESCRIPTION
Fix the -Wstringop-overflow warning on GCC, similar to #1243

The last argument should be the max size of the destination, not the
source buffer. A null byte is added to the end of the destination buffer
since `strncpy` only adds one if it does not truncate the source.