### PR TITLE
Adjust comments in arch headers for doxygen style.

### DIFF
--- a/include/capstone/arm.h
+++ b/include/capstone/arm.h
@@ -14,43 +14,43 @@ extern "C" {
 #pragma warning(disable:4201)
 #endif
 
-//> ARM shift type
+/// ARM shift type
 typedef enum arm_shifter {
 	ARM_SFT_INVALID = 0,
-	ARM_SFT_ASR,	// shift with immediate const
-	ARM_SFT_LSL,	// shift with immediate const
-	ARM_SFT_LSR,	// shift with immediate const
-	ARM_SFT_ROR,	// shift with immediate const
-	ARM_SFT_RRX,	// shift with immediate const
-	ARM_SFT_ASR_REG,	// shift with register
-	ARM_SFT_LSL_REG,	// shift with register
-	ARM_SFT_LSR_REG,	// shift with register
-	ARM_SFT_ROR_REG,	// shift with register
-	ARM_SFT_RRX_REG,	// shift with register
+	ARM_SFT_ASR,	///< shift with immediate const
+	ARM_SFT_LSL,	///< shift with immediate const
+	ARM_SFT_LSR,	///< shift with immediate const
+	ARM_SFT_ROR,	///< shift with immediate const
+	ARM_SFT_RRX,	///< shift with immediate const
+	ARM_SFT_ASR_REG,	///< shift with register
+	ARM_SFT_LSL_REG,	///< shift with register
+	ARM_SFT_LSR_REG,	///< shift with register
+	ARM_SFT_ROR_REG,	///< shift with register
+	ARM_SFT_RRX_REG,	///< shift with register
 } arm_shifter;
 
-//> ARM condition code
+/// ARM condition code
 typedef enum arm_cc {
 	ARM_CC_INVALID = 0,
-	ARM_CC_EQ,            // Equal                      Equal
-	ARM_CC_NE,            // Not equal                  Not equal, or unordered
-	ARM_CC_HS,            // Carry set                  >, ==, or unordered
-	ARM_CC_LO,            // Carry clear                Less than
-	ARM_CC_MI,            // Minus, negative            Less than
-	ARM_CC_PL,            // Plus, positive or zero     >, ==, or unordered
-	ARM_CC_VS,            // Overflow                   Unordered
-	ARM_CC_VC,            // No overflow                Not unordered
-	ARM_CC_HI,            // Unsigned higher            Greater than, or unordered
-	ARM_CC_LS,            // Unsigned lower or same     Less than or equal
-	ARM_CC_GE,            // Greater than or equal      Greater than or equal
-	ARM_CC_LT,            // Less than                  Less than, or unordered
-	ARM_CC_GT,            // Greater than               Greater than
-	ARM_CC_LE,            // Less than or equal         <, ==, or unordered
-	ARM_CC_AL             // Always (unconditional)     Always (unconditional)
+	ARM_CC_EQ,            ///< Equal                      Equal
+	ARM_CC_NE,            ///< Not equal                  Not equal, or unordered
+	ARM_CC_HS,            ///< Carry set                  >, ==, or unordered
+	ARM_CC_LO,            ///< Carry clear                Less than
+	ARM_CC_MI,            ///< Minus, negative            Less than
+	ARM_CC_PL,            ///< Plus, positive or zero     >, ==, or unordered
+	ARM_CC_VS,            ///< Overflow                   Unordered
+	ARM_CC_VC,            ///< No overflow                Not unordered
+	ARM_CC_HI,            ///< Unsigned higher            Greater than, or unordered
+	ARM_CC_LS,            ///< Unsigned lower or same     Less than or equal
+	ARM_CC_GE,            ///< Greater than or equal      Greater than or equal
+	ARM_CC_LT,            ///< Less than                  Less than, or unordered
+	ARM_CC_GT,            ///< Greater than               Greater than
+	ARM_CC_LE,            ///< Less than or equal         <, ==, or unordered
+	ARM_CC_AL             ///< Always (unconditional)     Always (unconditional)
 } arm_cc;
 
 typedef enum arm_sysreg {
-	//> Special registers for MSR
+	/// Special registers for MSR
 	ARM_SYSREG_INVALID = 0,
 
 	// SPSR* registers can be OR combined
@@ -135,8 +135,8 @@ typedef enum arm_sysreg {
 	ARM_SYSREG_SPSR_HYP,
 } arm_sysreg;
 
-//> The memory barrier constants map directly to the 4-bit encoding of
-//> the option field for Memory Barrier operations.
+/// The memory barrier constants map directly to the 4-bit encoding of
+/// the option field for Memory Barrier operations.
 typedef enum arm_mem_barrier {
 	ARM_MB_INVALID = 0,
 	ARM_MB_RESERVED_0,
@@ -157,24 +157,24 @@ typedef enum arm_mem_barrier {
 	ARM_MB_SY,
 } arm_mem_barrier;
 
-//> Operand type for instruction's operands
+/// Operand type for instruction's operands
 typedef enum arm_op_type {
-	ARM_OP_INVALID = 0, // = CS_OP_INVALID (Uninitialized).
-	ARM_OP_REG, // = CS_OP_REG (Register operand).
-	ARM_OP_IMM, // = CS_OP_IMM (Immediate operand).
-	ARM_OP_MEM, // = CS_OP_MEM (Memory operand).
-	ARM_OP_FP,  // = CS_OP_FP (Floating-Point operand).
-	ARM_OP_CIMM = 64, // C-Immediate (coprocessor registers)
-	ARM_OP_PIMM, // P-Immediate (coprocessor registers)
-	ARM_OP_SETEND,	// operand for SETEND instruction
-	ARM_OP_SYSREG,	// MSR/MRS special register operand
+	ARM_OP_INVALID = 0, ///< = CS_OP_INVALID (Uninitialized).
+	ARM_OP_REG, ///< = CS_OP_REG (Register operand).
+	ARM_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
+	ARM_OP_MEM, ///< = CS_OP_MEM (Memory operand).
+	ARM_OP_FP,  ///< = CS_OP_FP (Floating-Point operand).
+	ARM_OP_CIMM = 64, ///< C-Immediate (coprocessor registers)
+	ARM_OP_PIMM, ///< P-Immediate (coprocessor registers)
+	ARM_OP_SETEND,	///< operand for SETEND instruction
+	ARM_OP_SYSREG,	///< MSR/MRS special register operand
 } arm_op_type;
 
-//> Operand type for SETEND instruction
+/// Operand type for SETEND instruction
 typedef enum arm_setend_type {
-	ARM_SETEND_INVALID = 0,	// Uninitialized.
-	ARM_SETEND_BE,	// BE operand.
-	ARM_SETEND_LE, // LE operand
+	ARM_SETEND_INVALID = 0,	///< Uninitialized.
+	ARM_SETEND_BE,	///< BE operand.
+	ARM_SETEND_LE, ///< LE operand
 } arm_setend_type;
 
 typedef enum arm_cpsmode_type {
@@ -183,16 +183,16 @@ typedef enum arm_cpsmode_type {
 	ARM_CPSMODE_ID = 3
 } arm_cpsmode_type;
 
-//> Operand type for SETEND instruction
+/// Operand type for SETEND instruction
 typedef enum arm_cpsflag_type {
 	ARM_CPSFLAG_INVALID = 0,
 	ARM_CPSFLAG_F = 1,
 	ARM_CPSFLAG_I = 2,
 	ARM_CPSFLAG_A = 4,
-	ARM_CPSFLAG_NONE = 16,	// no flag
+	ARM_CPSFLAG_NONE = 16,	///< no flag
 } arm_cpsflag_type;
 
-//> Data type for elements of vector instructions.
+/// Data type for elements of vector instructions.
 typedef enum arm_vectordata_type {
 	ARM_VECTORDATA_INVALID = 0,
 
@@ -248,7 +248,7 @@ typedef enum arm_vectordata_type {
 	ARM_VECTORDATA_F64U32,	// f64.u32
 } arm_vectordata_type;
 
-//> ARM registers
+/// ARM registers
 typedef enum arm_reg {
 	ARM_REG_INVALID = 0,
 	ARM_REG_APSR,
@@ -364,7 +364,7 @@ typedef enum arm_reg {
 
 	ARM_REG_ENDING,		// <-- mark the end of the list or registers
 
-	//> alias registers
+	// alias registers
 	ARM_REG_R13 = ARM_REG_SP,
 	ARM_REG_R14 = ARM_REG_LR,
 	ARM_REG_R15 = ARM_REG_PC,
@@ -375,68 +375,69 @@ typedef enum arm_reg {
 	ARM_REG_IP = ARM_REG_R12,
 } arm_reg;
 
-// Instruction's operand referring to memory
-// This is associated with ARM_OP_MEM operand type above
+/// Instruction's operand referring to memory
+/// This is associated with ARM_OP_MEM operand type above
 typedef struct arm_op_mem {
-	arm_reg base;	// base register
-	arm_reg index;	// index register
-	int scale;	// scale for index register (can be 1, or -1)
-	int disp;	// displacement/offset value
-	int lshift;	// left-shift on index register, or 0 if irrelevant.
+	arm_reg base;	///< base register
+	arm_reg index;	///< index register
+	int scale;	///< scale for index register (can be 1, or -1)
+	int disp;	///< displacement/offset value
+	int lshift;	///< left-shift on index register, or 0 if irrelevant.
 } arm_op_mem;
 
-// Instruction operand
+/// Instruction operand
 typedef struct cs_arm_op {
-	int vector_index;	// Vector Index for some vector operands (or -1 if irrelevant)
+	int vector_index;	///< Vector Index for some vector operands (or -1 if irrelevant)
 
 	struct {
 		arm_shifter type;
 		unsigned int value;
 	} shift;
 
-	arm_op_type type;	// operand type
+	arm_op_type type;	///< operand type
 
 	union {
-		int reg;	// register value for REG/SYSREG operand
-		int32_t imm;			// immediate value for C-IMM, P-IMM or IMM operand
-		double fp;			// floating point value for FP operand
-		arm_op_mem mem;		// base/index/scale/disp value for MEM operand
-		arm_setend_type setend; // SETEND instruction's operand type
+		int reg;	///< register value for REG/SYSREG operand
+		int32_t imm;			///< immediate value for C-IMM, P-IMM or IMM operand
+		double fp;			///< floating point value for FP operand
+		arm_op_mem mem;		///< base/index/scale/disp value for MEM operand
+		arm_setend_type setend; ///< SETEND instruction's operand type
 	};
 
-	// in some instructions, an operand can be subtracted or added to
-	// the base register,
-	bool subtracted; // if TRUE, this operand is subtracted. otherwise, it is added.
+	/// in some instructions, an operand can be subtracted or added to
+	/// the base register,
+	/// if TRUE, this operand is subtracted. otherwise, it is added.
+	bool subtracted;
 
-	// How is this operand accessed? (READ, WRITE or READ|WRITE)
-	// This field is combined of cs_ac_type.
-	// NOTE: this field is irrelevant if engine is compiled in DIET mode.
+	/// How is this operand accessed? (READ, WRITE or READ|WRITE)
+	/// This field is combined of cs_ac_type.
+	/// NOTE: this field is irrelevant if engine is compiled in DIET mode.
 	uint8_t access;
 
-	// Neon lane index for NEON instructions (or -1 if irrelevant)
+	/// Neon lane index for NEON instructions (or -1 if irrelevant)
 	int8_t neon_lane;
 } cs_arm_op;
 
-// Instruction structure
+/// Instruction structure
 typedef struct cs_arm {
-	bool usermode;	// User-mode registers to be loaded (for LDM/STM instructions)
-	int vector_size; 	// Scalar size for vector instructions
-	arm_vectordata_type vector_data; // Data type for elements of vector instructions
-	arm_cpsmode_type cps_mode;	// CPS mode for CPS instruction
-	arm_cpsflag_type cps_flag;	// CPS mode for CPS instruction
-	arm_cc cc;			// conditional code for this insn
-	bool update_flags;	// does this insn update flags?
-	bool writeback;		// does this insn write-back?
-	arm_mem_barrier mem_barrier;	// Option for some memory barrier instructions
+	bool usermode;	///< User-mode registers to be loaded (for LDM/STM instructions)
+	int vector_size; 	///< Scalar size for vector instructions
+	arm_vectordata_type vector_data; ///< Data type for elements of vector instructions
+	arm_cpsmode_type cps_mode;	///< CPS mode for CPS instruction
+	arm_cpsflag_type cps_flag;	///< CPS mode for CPS instruction
+	arm_cc cc;			///< conditional code for this insn
+	bool update_flags;	///< does this insn update flags?
+	bool writeback;		///< does this insn write-back?
+	arm_mem_barrier mem_barrier;	///< Option for some memory barrier instructions
 
-	// Number of operands of this instruction, 
-	// or 0 when instruction has no operand.
+	/// Number of operands of this instruction,
+	/// or 0 when instruction has no operand.
 	uint8_t op_count;
 
-	cs_arm_op operands[36];	// operands for this instruction.
+	cs_arm_op operands[36];	///< operands for this instruction.
 } cs_arm;
 
-//> ARM instruction
+/// ARM instruction
 typedef enum arm_insn {
 	ARM_INS_INVALID = 0,
 
@@ -878,19 +879,19 @@ typedef enum arm_insn {
 	ARM_INS_ENDING,	// <-- mark the end of the list of instructions
 } arm_insn;
 
-//> Group of ARM instructions
+/// Group of ARM instructions
 typedef enum arm_insn_group {
-	ARM_GRP_INVALID = 0, // = CS_GRP_INVALID
+	ARM_GRP_INVALID = 0, ///< = CS_GRP_INVALID
 
-	//> Generic groups
+	// Generic groups
 	// all jump instructions (conditional+direct+indirect jumps)
-	ARM_GRP_JUMP,	// = CS_GRP_JUMP
-	ARM_GRP_CALL,	// = CS_GRP_CALL
-	ARM_GRP_INT = 4, // = CS_GRP_INT
-	ARM_GRP_PRIVILEGE = 6, // = CS_GRP_PRIVILEGE
-	ARM_GRP_BRANCH_RELATIVE, // = CS_GRP_BRANCH_RELATIVE
+	ARM_GRP_JUMP,	///< = CS_GRP_JUMP
+	ARM_GRP_CALL,	///< = CS_GRP_CALL
+	ARM_GRP_INT = 4, ///< = CS_GRP_INT
+	ARM_GRP_PRIVILEGE = 6, ///< = CS_GRP_PRIVILEGE
+	ARM_GRP_BRANCH_RELATIVE, ///< = CS_GRP_BRANCH_RELATIVE
 
-	//> Architecture-specific groups
+	// Architecture-specific groups
 	ARM_GRP_CRYPTO = 128,
 	ARM_GRP_DATABARRIER,
 	ARM_GRP_DIVIDE,

--- a/include/capstone/arm64.h
+++ b/include/capstone/arm64.h
@@ -14,7 +14,7 @@ extern "C" {
 #pragma warning(disable:4201)
 #endif
 
-//> ARM64 shift type
+/// ARM64 shift type
 typedef enum arm64_shifter {
 	ARM64_SFT_INVALID = 0,
 	ARM64_SFT_LSL = 1,
@@ -24,7 +24,7 @@ typedef enum arm64_shifter {
 	ARM64_SFT_ROR = 5,
 } arm64_shifter;
 
-//> ARM64 extender type
+/// ARM64 extender type
 typedef enum arm64_extender {
 	ARM64_EXT_INVALID = 0,
 	ARM64_EXT_UXTB = 1,
@@ -37,32 +37,32 @@ typedef enum arm64_extender {
 	ARM64_EXT_SXTX = 8,
 } arm64_extender;
 
-//> ARM64 condition code
+/// ARM64 condition code
 typedef enum arm64_cc {
 	ARM64_CC_INVALID = 0,
-	ARM64_CC_EQ = 1,     // Equal
-	ARM64_CC_NE = 2,     // Not equal:                 Not equal, or unordered
-	ARM64_CC_HS = 3,     // Unsigned higher or same:   >, ==, or unordered
-	ARM64_CC_LO = 4,     // Unsigned lower or same:    Less than
-	ARM64_CC_MI = 5,     // Minus, negative:           Less than
-	ARM64_CC_PL = 6,     // Plus, positive or zero:    >, ==, or unordered
-	ARM64_CC_VS = 7,     // Overflow:                  Unordered
-	ARM64_CC_VC = 8,     // No overflow:               Ordered
-	ARM64_CC_HI = 9,     // Unsigned higher:           Greater than, or unordered
-	ARM64_CC_LS = 10,     // Unsigned lower or same:    Less than or equal
-	ARM64_CC_GE = 11,     // Greater than or equal:     Greater than or equal
-	ARM64_CC_LT = 12,     // Less than:                 Less than, or unordered
-	ARM64_CC_GT = 13,     // Signed greater than:       Greater than
-	ARM64_CC_LE = 14,     // Signed less than or equal: <, ==, or unordered
-	ARM64_CC_AL = 15,     // Always (unconditional):    Always (unconditional)
-	ARM64_CC_NV = 16,     // Always (unconditional):   Always (unconditional)
-	// Note the NV exists purely to disassemble 0b1111. Execution
-	// is "always".
+	ARM64_CC_EQ = 1,     ///< Equal
+	ARM64_CC_NE = 2,     ///< Not equal:                 Not equal, or unordered
+	ARM64_CC_HS = 3,     ///< Unsigned higher or same:   >, ==, or unordered
+	ARM64_CC_LO = 4,     ///< Unsigned lower or same:    Less than
+	ARM64_CC_MI = 5,     ///< Minus, negative:           Less than
+	ARM64_CC_PL = 6,     ///< Plus, positive or zero:    >, ==, or unordered
+	ARM64_CC_VS = 7,     ///< Overflow:                  Unordered
+	ARM64_CC_VC = 8,     ///< No overflow:               Ordered
+	ARM64_CC_HI = 9,     ///< Unsigned higher:           Greater than, or unordered
+	ARM64_CC_LS = 10,     ///< Unsigned lower or same:    Less than or equal
+	ARM64_CC_GE = 11,     ///< Greater than or equal:     Greater than or equal
+	ARM64_CC_LT = 12,     ///< Less than:                 Less than, or unordered
+	ARM64_CC_GT = 13,     ///< Signed greater than:       Greater than
+	ARM64_CC_LE = 14,     ///< Signed less than or equal: <, ==, or unordered
+	ARM64_CC_AL = 15,     ///< Always (unconditional):    Always (unconditional)
+	ARM64_CC_NV = 16,     ///< Always (unconditional):   Always (unconditional)
+	//< Note the NV exists purely to disassemble 0b1111. Execution
+	//< is "always".
 } arm64_cc;
 
-//> System registers
+/// System registers
 typedef enum arm64_sysreg {
-	//> System registers for MRS
+	// System registers for MRS
 	ARM64_SYSREG_INVALID           = 0,
 	ARM64_SYSREG_MDCCSR_EL0        = 0x9808, // 10  011  0000  0001  000
 	ARM64_SYSREG_DBGDTRRX_EL0      = 0x9828, // 10  011  0000  0101  000
@@ -163,7 +163,7 @@ typedef enum arm64_sysreg {
 } arm64_sysreg;
 
 typedef enum arm64_msr_reg {
-	//> System registers for MSR
+	// System registers for MSR
 	ARM64_SYSREG_DBGDTRTX_EL0      = 0x9828, // 10  011  0000  0101  000
 	ARM64_SYSREG_OSLAR_EL1         = 0x8084, // 10  000  0001  0000  100
 	ARM64_SYSREG_PMSWINC_EL0       = 0xdce4,  // 11  011  1001  1100  100
@@ -181,7 +181,7 @@ typedef enum arm64_msr_reg {
 	ARM64_SYSREG_ICC_SGI0R_EL1     = 0xc65f, // 11  000  1100  1011  111
 } arm64_msr_reg;
 
-//> System PState Field (MSR instruction)
+/// System PState Field (MSR instruction)
 typedef enum arm64_pstate {
 	ARM64_PSTATE_INVALID = 0,
 	ARM64_PSTATE_SPSEL = 0x05,
@@ -189,7 +189,7 @@ typedef enum arm64_pstate {
 	ARM64_PSTATE_DAIFCLR = 0x1f
 } arm64_pstate;
 
-//> Vector arrangement specifier (for FloatingPoint/Advanced SIMD insn)
+/// Vector arrangement specifier (for FloatingPoint/Advanced SIMD insn)
 typedef enum arm64_vas {
 	ARM64_VAS_INVALID = 0,
 	ARM64_VAS_8B,
@@ -203,7 +203,7 @@ typedef enum arm64_vas {
 	ARM64_VAS_1Q,
 } arm64_vas;
 
-//> Vector element size specifier
+/// Vector element size specifier
 typedef enum arm64_vess {
 	ARM64_VESS_INVALID = 0,
 	ARM64_VESS_B,
@@ -212,7 +212,7 @@ typedef enum arm64_vess {
 	ARM64_VESS_D,
 } arm64_vess;
 
-//> Memory barrier operands
+/// Memory barrier operands
 typedef enum arm64_barrier_op {
 	ARM64_BARRIER_INVALID = 0,
 	ARM64_BARRIER_OSHLD = 0x1,
@@ -229,23 +229,23 @@ typedef enum arm64_barrier_op {
 	ARM64_BARRIER_SY =    0xf
 } arm64_barrier_op;
 
-//> Operand type for instruction's operands
+/// Operand type for instruction's operands
 typedef enum arm64_op_type {
-	ARM64_OP_INVALID = 0, // = CS_OP_INVALID (Uninitialized).
-	ARM64_OP_REG, // = CS_OP_REG (Register operand).
-	ARM64_OP_IMM, // = CS_OP_IMM (Immediate operand).
-	ARM64_OP_MEM, // = CS_OP_MEM (Memory operand).
-	ARM64_OP_FP,  // = CS_OP_FP (Floating-Point operand).
-	ARM64_OP_CIMM = 64, // C-Immediate
-	ARM64_OP_REG_MRS, // MRS register operand.
-	ARM64_OP_REG_MSR, // MSR register operand.
-	ARM64_OP_PSTATE, // PState operand.
-	ARM64_OP_SYS, // SYS operand for IC/DC/AT/TLBI instructions.
-	ARM64_OP_PREFETCH, // Prefetch operand (PRFM).
-	ARM64_OP_BARRIER, // Memory barrier operand (ISB/DMB/DSB instructions).
+	ARM64_OP_INVALID = 0, ///< = CS_OP_INVALID (Uninitialized).
+	ARM64_OP_REG, ///< = CS_OP_REG (Register operand).
+	ARM64_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
+	ARM64_OP_MEM, ///< = CS_OP_MEM (Memory operand).
+	ARM64_OP_FP,  ///< = CS_OP_FP (Floating-Point operand).
+	ARM64_OP_CIMM = 64, ///< C-Immediate
+	ARM64_OP_REG_MRS, ///< MRS register operand.
+	ARM64_OP_REG_MSR, ///< MSR register operand.
+	ARM64_OP_PSTATE, ///< PState operand.
+	ARM64_OP_SYS, ///< SYS operand for IC/DC/AT/TLBI instructions.
+	ARM64_OP_PREFETCH, ///< Prefetch operand (PRFM).
+	ARM64_OP_BARRIER, ///< Memory barrier operand (ISB/DMB/DSB instructions).
 } arm64_op_type;
 
-//> TLBI operations
+/// TLBI operations
 typedef enum arm64_tlbi_op {
 	ARM64_TLBI_INVALID = 0,
 	ARM64_TLBI_VMALLE1IS,
@@ -282,7 +282,7 @@ typedef enum arm64_tlbi_op {
 	ARM64_TLBI_VALE3,
 } arm64_tlbi_op;
 
-//> AT operations
+/// AT operations
 typedef enum arm64_at_op {
 	ARM64_AT_S1E1R,
 	ARM64_AT_S1E1W,
@@ -298,7 +298,7 @@ typedef enum arm64_at_op {
 	ARM64_AT_S1E3W,
 } arm64_at_op;
 
-//> DC operations
+/// DC operations
 typedef enum arm64_dc_op {
 	ARM64_DC_INVALID = 0,
 	ARM64_DC_ZVA,
@@ -311,7 +311,7 @@ typedef enum arm64_dc_op {
 	ARM64_DC_CISW,
 } arm64_dc_op;
 
-//> IC operations
+/// IC operations
 typedef enum arm64_ic_op {
 	ARM64_IC_INVALID = 0,
 	ARM64_IC_IALLUIS,
@@ -319,7 +319,7 @@ typedef enum arm64_ic_op {
 	ARM64_IC_IVAU,
 } arm64_ic_op;
 
-//> Prefetch operations (PRFM)
+/// Prefetch operations (PRFM)
 typedef enum arm64_prefetch_op {
 	ARM64_PRFM_INVALID = 0,
 	ARM64_PRFM_PLDL1KEEP = 0x00 + 1,
@@ -343,7 +343,7 @@ typedef enum arm64_prefetch_op {
 } arm64_prefetch_op;
 
 
-//> ARM64 registers
+/// ARM64 registers
 typedef enum arm64_reg {
 	ARM64_REG_INVALID = 0,
 
@@ -610,7 +610,7 @@ typedef enum arm64_reg {
 
 	ARM64_REG_ENDING,		// <-- mark the end of the list of registers
 
-	//> alias registers
+	// alias registers
 
 	ARM64_REG_IP0 = ARM64_REG_X16,
 	ARM64_REG_IP1 = ARM64_REG_X17,
@@ -618,56 +618,56 @@ typedef enum arm64_reg {
 	ARM64_REG_LR = ARM64_REG_X30,
 } arm64_reg;
 
-// Instruction's operand referring to memory
-// This is associated with ARM64_OP_MEM operand type above
+/// Instruction's operand referring to memory
+/// This is associated with ARM64_OP_MEM operand type above
 typedef struct arm64_op_mem {
-	arm64_reg base;	// base register
-	arm64_reg index;	// index register
-	int32_t disp;	// displacement/offset value
+	arm64_reg base;	///< base register
+	arm64_reg index;	///< index register
+	int32_t disp;	///< displacement/offset value
 } arm64_op_mem;
 
-// Instruction operand
+/// Instruction operand
 typedef struct cs_arm64_op {
-	int vector_index;	// Vector Index for some vector operands (or -1 if irrelevant)
-	arm64_vas vas;		// Vector Arrangement Specifier
-	arm64_vess vess;	// Vector Element Size Specifier
+	int vector_index;	///< Vector Index for some vector operands (or -1 if irrelevant)
+	arm64_vas vas;		///< Vector Arrangement Specifier
+	arm64_vess vess;	///< Vector Element Size Specifier
 	struct {
-		arm64_shifter type;	// shifter type of this operand
-		unsigned int value;	// shifter value of this operand
+		arm64_shifter type;	///< shifter type of this operand
+		unsigned int value;	///< shifter value of this operand
 	} shift;
-	arm64_extender ext;		// extender type of this operand
-	arm64_op_type type;	// operand type
+	arm64_extender ext;		///< extender type of this operand
+	arm64_op_type type;	///< operand type
 	union {
-		arm64_reg reg;	// register value for REG operand
-		int64_t imm;		// immediate value, or index for C-IMM or IMM operand
-		double fp;			// floating point value for FP operand
-		arm64_op_mem mem;		// base/index/scale/disp value for MEM operand
-		arm64_pstate pstate;		// PState field of MSR instruction.
-		unsigned int sys;  // IC/DC/AT/TLBI operation (see arm64_ic_op, arm64_dc_op, arm64_at_op, arm64_tlbi_op)
-		arm64_prefetch_op prefetch;  // PRFM operation.
-		arm64_barrier_op barrier;  // Memory barrier operation (ISB/DMB/DSB instructions).
+		arm64_reg reg;	///< register value for REG operand
+		int64_t imm;		///< immediate value, or index for C-IMM or IMM operand
+		double fp;			///< floating point value for FP operand
+		arm64_op_mem mem;		///< base/index/scale/disp value for MEM operand
+		arm64_pstate pstate;		///< PState field of MSR instruction.
+		unsigned int sys;  ///< IC/DC/AT/TLBI operation (see arm64_ic_op, arm64_dc_op, arm64_at_op, arm64_tlbi_op)
+		arm64_prefetch_op prefetch;  ///< PRFM operation.
+		arm64_barrier_op barrier;  ///< Memory barrier operation (ISB/DMB/DSB instructions).
 	};
 
-	// How is this operand accessed? (READ, WRITE or READ|WRITE)
-	// This field is combined of cs_ac_type.
-	// NOTE: this field is irrelevant if engine is compiled in DIET mode.
+	/// How is this operand accessed? (READ, WRITE or READ|WRITE)
+	/// This field is combined of cs_ac_type.
+	/// NOTE: this field is irrelevant if engine is compiled in DIET mode.
 	uint8_t access;
 } cs_arm64_op;
 
-// Instruction structure
+/// Instruction structure
 typedef struct cs_arm64 {
-	arm64_cc cc;	// conditional code for this insn
-	bool update_flags;	// does this insn update flags?
-	bool writeback;	// does this insn request writeback? 'True' means 'yes'
+	arm64_cc cc;	///< conditional code for this insn
+	bool update_flags;	///< does this insn update flags?
+	bool writeback;	///< does this insn request writeback? 'True' means 'yes'
 
-	// Number of operands of this instruction,
-	// or 0 when instruction has no operand.
+	/// Number of operands of this instruction,
+	/// or 0 when instruction has no operand.
 	uint8_t op_count;
 
-	cs_arm64_op operands[8]; // operands for this instruction.
+	cs_arm64_op operands[8]; ///< operands for this instruction.
 } cs_arm64;
 
-//> ARM64 instruction
+/// ARM64 instruction
 typedef enum arm64_insn {
 	ARM64_INS_INVALID = 0,
 
@@ -1135,20 +1135,20 @@ typedef enum arm64_insn {
 	ARM64_INS_ENDING,  // <-- mark the end of the list of insn
 } arm64_insn;
 
-//> Group of ARM64 instructions
+/// Group of ARM64 instructions
 typedef enum arm64_insn_group {
-	ARM64_GRP_INVALID = 0, // = CS_GRP_INVALID
+	ARM64_GRP_INVALID = 0, ///< = CS_GRP_INVALID
 
-	//> Generic groups
+	// Generic groups
 	// all jump instructions (conditional+direct+indirect jumps)
-	ARM64_GRP_JUMP,	// = CS_GRP_JUMP
+	ARM64_GRP_JUMP,	///< = CS_GRP_JUMP
 	ARM64_GRP_CALL,
 	ARM64_GRP_RET,
 	ARM64_GRP_INT,
-	ARM64_GRP_PRIVILEGE = 6, // = CS_GRP_PRIVILEGE
-	ARM64_GRP_BRANCH_RELATIVE, // = CS_GRP_BRANCH_RELATIVE
+	ARM64_GRP_PRIVILEGE = 6, ///< = CS_GRP_PRIVILEGE
+	ARM64_GRP_BRANCH_RELATIVE, ///< = CS_GRP_BRANCH_RELATIVE
 
-	//> Architecture-specific groups
+	// Architecture-specific groups
 	ARM64_GRP_CRYPTO = 128,
 	ARM64_GRP_FPARMV8,
 	ARM64_GRP_NEON,

--- a/include/capstone/evm.h
+++ b/include/capstone/evm.h
@@ -14,14 +14,14 @@ extern "C" {
 #pragma warning(disable:4201)
 #endif
 
-// Instruction structure
+/// Instruction structure
 typedef struct cs_evm {
-    unsigned char pop;    // number of items popped from the stack
-    unsigned char push;   // number of items pushed into the stack
-    unsigned int  fee;    // gas fee for the instruction
+    unsigned char pop;    ///< number of items popped from the stack
+    unsigned char push;   ///< number of items pushed into the stack
+    unsigned int  fee;    ///< gas fee for the instruction
 } cs_evm;
 
-//> EVM instruction
+/// EVM instruction
 typedef enum evm_insn {
 	EVM_INS_STOP = 0,
 	EVM_INS_ADD = 1,
@@ -163,22 +163,22 @@ typedef enum evm_insn {
 	EVM_INS_ENDING,   // <-- mark the end of the list of instructions
 } evm_insn;
 
-//> Group of EVM instructions
+/// Group of EVM instructions
 typedef enum evm_insn_group {
-	EVM_GRP_INVALID = 0, // = CS_GRP_INVALID
+	EVM_GRP_INVALID = 0, ///< = CS_GRP_INVALID
 
-	EVM_GRP_JUMP,          // all jump instructions
+	EVM_GRP_JUMP,          ///< all jump instructions
 
-	EVM_GRP_MATH = 8,      // math instructions
-	EVM_GRP_STACK_WRITE,   // instructions write to stack
-	EVM_GRP_STACK_READ,    // instructions read from stack
-	EVM_GRP_MEM_WRITE,     // instructions write to memory
-	EVM_GRP_MEM_READ,      // instructions read from memory
-	EVM_GRP_STORE_WRITE,   // instructions write to storage
-	EVM_GRP_STORE_READ,    // instructions read from storage
-	EVM_GRP_HALT,    // instructions halt execution
+	EVM_GRP_MATH = 8,      ///< math instructions
+	EVM_GRP_STACK_WRITE,   ///< instructions write to stack
+	EVM_GRP_STACK_READ,    ///< instructions read from stack
+	EVM_GRP_MEM_WRITE,     ///< instructions write to memory
+	EVM_GRP_MEM_READ,      ///< instructions read from memory
+	EVM_GRP_STORE_WRITE,   ///< instructions write to storage
+	EVM_GRP_STORE_READ,    ///< instructions read from storage
+	EVM_GRP_HALT,    ///< instructions halt execution
 
-	EVM_GRP_ENDING,   // <-- mark the end of the list of groups
+	EVM_GRP_ENDING,   ///< <-- mark the end of the list of groups
 } evm_insn_group;
 
 #ifdef __cplusplus

--- a/include/capstone/m680x.h
+++ b/include/capstone/m680x.h
@@ -16,162 +16,162 @@ extern "C" {
 
 #define M680X_OPERAND_COUNT 9
 
-//> M680X registers and special registers
+/// M680X registers and special registers
 typedef enum m680x_reg {
 	M680X_REG_INVALID = 0,
 
-	M680X_REG_A, // M6800/1/2/3/9, HD6301/9
-	M680X_REG_B, // M6800/1/2/3/9, HD6301/9
-	M680X_REG_E, // HD6309
-	M680X_REG_F, // HD6309
-	M680X_REG_0, // HD6309
+	M680X_REG_A, ///< M6800/1/2/3/9, HD6301/9
+	M680X_REG_B, ///< M6800/1/2/3/9, HD6301/9
+	M680X_REG_E, ///< HD6309
+	M680X_REG_F, ///< HD6309
+	M680X_REG_0, ///< HD6309
 
-	M680X_REG_D, // M6801/3/9, HD6301/9
-	M680X_REG_W, // HD6309
+	M680X_REG_D, ///< M6801/3/9, HD6301/9
+	M680X_REG_W, ///< HD6309
 
-	M680X_REG_CC, // M6800/1/2/3/9, M6301/9
-	M680X_REG_DP, // M6809/M6309
-	M680X_REG_MD, // M6309
+	M680X_REG_CC, ///< M6800/1/2/3/9, M6301/9
+	M680X_REG_DP, ///< M6809/M6309
+	M680X_REG_MD, ///< M6309
 
-	M680X_REG_HX, // M6808
-	M680X_REG_H, // M6808
-	M680X_REG_X, // M6800/1/2/3/9, M6301/9
-	M680X_REG_Y, // M6809/M6309
-	M680X_REG_S, // M6809/M6309
-	M680X_REG_U, // M6809/M6309
-	M680X_REG_V, // M6309
+	M680X_REG_HX, ///< M6808
+	M680X_REG_H, ///< M6808
+	M680X_REG_X, ///< M6800/1/2/3/9, M6301/9
+	M680X_REG_Y, ///< M6809/M6309
+	M680X_REG_S, ///< M6809/M6309
+	M680X_REG_U, ///< M6809/M6309
+	M680X_REG_V, ///< M6309
 
-	M680X_REG_Q, // M6309
+	M680X_REG_Q, ///< M6309
 
-	M680X_REG_PC, // M6800/1/2/3/9, M6301/9
+	M680X_REG_PC, ///< M6800/1/2/3/9, M6301/9
 
-	M680X_REG_TMP2, // CPU12
-	M680X_REG_TMP3, // CPU12
+	M680X_REG_TMP2, ///< CPU12
+	M680X_REG_TMP3, ///< CPU12
 
-	M680X_REG_ENDING,   // <-- mark the end of the list of registers
+	M680X_REG_ENDING,   ///< <-- mark the end of the list of registers
 } m680x_reg;
 
-//> Operand type for instruction's operands
+/// Operand type for instruction's operands
 typedef enum m680x_op_type {
-	M680X_OP_INVALID = 0, // = CS_OP_INVALID (Uninitialized).
-	M680X_OP_REGISTER,    // = Register operand.
-	M680X_OP_IMMEDIATE,   // = Immediate operand.
-	M680X_OP_INDEXED,     // = Indexed addressing operand.
-	M680X_OP_EXTENDED,    // = Extended addressing operand.
-	M680X_OP_DIRECT,      // = Direct addressing operand.
-	M680X_OP_RELATIVE,    // = Relative addressing operand.
-	M680X_OP_CONSTANT,    // = constant operand (Displayed as number only).
-				// Used e.g. for a bit index or page number.
+	M680X_OP_INVALID = 0, ///< = CS_OP_INVALID (Uninitialized).
+	M680X_OP_REGISTER,    ///< = Register operand.
+	M680X_OP_IMMEDIATE,   ///< = Immediate operand.
+	M680X_OP_INDEXED,     ///< = Indexed addressing operand.
+	M680X_OP_EXTENDED,    ///< = Extended addressing operand.
+	M680X_OP_DIRECT,      ///< = Direct addressing operand.
+	M680X_OP_RELATIVE,    ///< = Relative addressing operand.
+	M680X_OP_CONSTANT,    ///< = constant operand (Displayed as number only).
+				///< Used e.g. for a bit index or page number.
 } m680x_op_type;
 
-//> Supported bit values for mem.idx.offset_bits
+// Supported bit values for mem.idx.offset_bits
 #define M680X_OFFSET_NONE      0
 #define M680X_OFFSET_BITS_5    5
 #define M680X_OFFSET_BITS_8    8
 #define M680X_OFFSET_BITS_9    9
 #define M680X_OFFSET_BITS_16  16
 
-//> Supported bit flags for mem.idx.flags
-//> These flags can be comined
+// Supported bit flags for mem.idx.flags
+// These flags can be comined
 #define M680X_IDX_INDIRECT     1
 #define M680X_IDX_NO_COMMA     2
 #define M680X_IDX_POST_INC_DEC 4
 
-// Instruction's operand referring to indexed addressing
+/// Instruction's operand referring to indexed addressing
 typedef struct m680x_op_idx {
-	m680x_reg base_reg;	// base register (or M680X_REG_INVALID if
-				// irrelevant)
-	m680x_reg offset_reg;	// offset register (or M680X_REG_INVALID if
-				// irrelevant)
-	int16_t offset;		// 5-,8- or 16-bit offset. See also offset_bits.
-	uint16_t offset_addr;	// = offset addr. if base_reg == M680X_REG_PC.
-				// calculated as offset + PC
-	uint8_t offset_bits;	// offset width in bits for indexed addressing
-	int8_t inc_dec;		// inc. or dec. value:
-				//    0: no inc-/decrement
-				//    1 .. 8: increment by 1 .. 8
-				//    -1 .. -8: decrement by 1 .. 8
-				// if flag M680X_IDX_POST_INC_DEC set it is post
-				// inc-/decrement otherwise pre inc-/decrement
-	uint8_t flags;		// 8-bit flags (see above)
+	m680x_reg base_reg;	///< base register (or M680X_REG_INVALID if
+				///< irrelevant)
+	m680x_reg offset_reg;	///< offset register (or M680X_REG_INVALID if
+				///< irrelevant)
+	int16_t offset;		///< 5-,8- or 16-bit offset. See also offset_bits.
+	uint16_t offset_addr;	///< = offset addr. if base_reg == M680X_REG_PC.
+				///< calculated as offset + PC
+	uint8_t offset_bits;	///< offset width in bits for indexed addressing
+	int8_t inc_dec;		///< inc. or dec. value:
+				///<    0: no inc-/decrement
+				///<    1 .. 8: increment by 1 .. 8
+				///<    -1 .. -8: decrement by 1 .. 8
+				///< if flag M680X_IDX_POST_INC_DEC set it is post
+				///< inc-/decrement otherwise pre inc-/decrement
+	uint8_t flags;		///< 8-bit flags (see above)
 } m680x_op_idx;
 
-// Instruction's memory operand referring to relative addressing (Bcc/LBcc)
+/// Instruction's memory operand referring to relative addressing (Bcc/LBcc)
 typedef struct m680x_op_rel {
-	uint16_t address;	// The absolute address.
-				// calculated as PC + offset. PC is the first
-				// address after the instruction.
-	int16_t offset;		// the offset/displacement value
+	uint16_t address;	///< The absolute address.
+				///< calculated as PC + offset. PC is the first
+				///< address after the instruction.
+	int16_t offset;		///< the offset/displacement value
 } m680x_op_rel;
 
-// Instruction's operand referring to extended addressing
+/// Instruction's operand referring to extended addressing
 typedef struct m680x_op_ext {
-	uint16_t address;      // The absolute address
-	bool indirect;         // true if extended indirect addressing
+	uint16_t address;      ///< The absolute address
+	bool indirect;         ///< true if extended indirect addressing
 } m680x_op_ext;
 
-// Instruction operand
+/// Instruction operand
 typedef struct cs_m680x_op {
 	m680x_op_type type;
 	union {
-		int32_t imm;		// immediate value for IMM operand
-		m680x_reg reg;		// register value for REG operand
-		m680x_op_idx idx;	// Indexed addressing operand
-		m680x_op_rel rel;	// Relative address. operand (Bcc/LBcc)
-		m680x_op_ext ext;	// Extended address
-		uint8_t direct_addr;	// Direct address (lower 8-bit)
-		uint8_t const_val;	// constant value (bit index, page nr.)
+		int32_t imm;		///< immediate value for IMM operand
+		m680x_reg reg;		///< register value for REG operand
+		m680x_op_idx idx;	///< Indexed addressing operand
+		m680x_op_rel rel;	///< Relative address. operand (Bcc/LBcc)
+		m680x_op_ext ext;	///< Extended address
+		uint8_t direct_addr;	///<</ Direct address (lower 8-bit)
+		uint8_t const_val;	///< constant value (bit index, page nr.)
 	};
-	uint8_t size;			// size of this operand (in bytes)
-	// How is this operand accessed? (READ, WRITE or READ|WRITE)
-	// This field is combined of cs_ac_type.
-	// NOTE: this field is irrelevant if engine is compiled in DIET 
+	uint8_t size;			///< size of this operand (in bytes)
+	/// How is this operand accessed? (READ, WRITE or READ|WRITE)
+	/// This field is combined of cs_ac_type.
+	/// NOTE: this field is irrelevant if engine is compiled in DIET 
 	uint8_t access;
 } cs_m680x_op;
 
-//> Group of M680X instructions
+/// Group of M680X instructions
 typedef enum m680x_group_type {
-	M680X_GRP_INVALID = 0,	// = CS_GRP_INVALID
-	//> Generic groups
+	M680X_GRP_INVALID = 0,	/// = CS_GRP_INVALID
+	// Generic groups
 	// all jump instructions (conditional+direct+indirect jumps)
-	M680X_GRP_JUMP,		// = CS_GRP_JUMP
+	M680X_GRP_JUMP,		///< = CS_GRP_JUMP
 	// all call instructions
-	M680X_GRP_CALL,		// = CS_GRP_CALL
+	M680X_GRP_CALL,		///< = CS_GRP_CALL
 	// all return instructions
-	M680X_GRP_RET,		// = CS_GRP_RET
+	M680X_GRP_RET,		///< = CS_GRP_RET
 	// all interrupt instructions (int+syscall)
-	M680X_GRP_INT,		// = CS_GRP_INT
+	M680X_GRP_INT,		///< = CS_GRP_INT
 	// all interrupt return instructions
-	M680X_GRP_IRET,		// = CS_GRP_IRET
+	M680X_GRP_IRET,		///< = CS_GRP_IRET
 	// all privileged instructions
-	M680X_GRP_PRIV,		// = CS_GRP_PRIVILEDGE; not used
+	M680X_GRP_PRIV,		///< = CS_GRP_PRIVILEDGE; not used
 	// all relative branching instructions
-	M680X_GRP_BRAREL,	// = CS_GRP_BRANCH_RELATIVE
+	M680X_GRP_BRAREL,	///< = CS_GRP_BRANCH_RELATIVE
 
-	//> Architecture-specific groups
+	// Architecture-specific groups
 	M680X_GRP_ENDING,	// <-- mark the end of the list of groups
 } m680x_group_type;
 
-//> M680X instruction flags:
+// M680X instruction flags:
 
-// The first (register) operand is part of the
-// instruction mnemonic
+/// The first (register) operand is part of the
+/// instruction mnemonic
 #define M680X_FIRST_OP_IN_MNEM    1
-// The second (register) operand is part of the
-// instruction mnemonic
+/// The second (register) operand is part of the
+/// instruction mnemonic
 #define M680X_SECOND_OP_IN_MNEM   2
 
-// The M680X instruction and it's operands
+/// The M680X instruction and it's operands
 typedef struct cs_m680x {
-	uint8_t flags;		// See: M680X instruction flags
-	uint8_t op_count;	// number of operands for the instruction or 0
-	cs_m680x_op operands[M680X_OPERAND_COUNT]; // operands for this insn.
+	uint8_t flags;		///< See: M680X instruction flags
+	uint8_t op_count;	///< number of operands for the instruction or 0
+	cs_m680x_op operands[M680X_OPERAND_COUNT]; ///< operands for this insn.
 } cs_m680x;
 
-//> M680X instruction IDs
+/// M680X instruction IDs
 typedef enum m680x_insn {
 	M680X_INS_INVLD = 0,
-	M680X_INS_ABA, // M6800/1/2/3
+	M680X_INS_ABA, ///< M6800/1/2/3
 	M680X_INS_ABX,
 	M680X_INS_ABY,
 	M680X_INS_ADC,
@@ -199,16 +199,16 @@ typedef enum m680x_insn {
 	M680X_INS_ASL,
 	M680X_INS_ASLA,
 	M680X_INS_ASLB,
-	M680X_INS_ASLD, // or LSLD
+	M680X_INS_ASLD, ///< or LSLD
 	M680X_INS_ASR,
 	M680X_INS_ASRA,
 	M680X_INS_ASRB,
 	M680X_INS_ASRD,
 	M680X_INS_ASRX,
 	M680X_INS_BAND,
-	M680X_INS_BCC, // or BHS
+	M680X_INS_BCC, ///< or BHS
 	M680X_INS_BCLR,
-	M680X_INS_BCS, // or BLO
+	M680X_INS_BCS, ///< or BLO
 	M680X_INS_BEOR,
 	M680X_INS_BEQ,
 	M680X_INS_BGE,
@@ -245,12 +245,12 @@ typedef enum m680x_insn {
 	M680X_INS_BVC,
 	M680X_INS_BVS,
 	M680X_INS_CALL,
-	M680X_INS_CBA, // M6800/1/2/3
+	M680X_INS_CBA, ///< M6800/1/2/3
 	M680X_INS_CBEQ,
 	M680X_INS_CBEQA,
 	M680X_INS_CBEQX,
-	M680X_INS_CLC, // M6800/1/2/3
-	M680X_INS_CLI, // M6800/1/2/3
+	M680X_INS_CLC, ///< M6800/1/2/3
+	M680X_INS_CLI, ///< M6800/1/2/3
 	M680X_INS_CLR,
 	M680X_INS_CLRA,
 	M680X_INS_CLRB,
@@ -260,7 +260,7 @@ typedef enum m680x_insn {
 	M680X_INS_CLRH,
 	M680X_INS_CLRW,
 	M680X_INS_CLRX,
-	M680X_INS_CLV, // M6800/1/2/3
+	M680X_INS_CLV, ///< M6800/1/2/3
 	M680X_INS_CMP,
 	M680X_INS_CMPA,
 	M680X_INS_CMPB,
@@ -284,7 +284,7 @@ typedef enum m680x_insn {
 	M680X_INS_CPD,
 	M680X_INS_CPHX,
 	M680X_INS_CPS,
-	M680X_INS_CPX, // M6800/1/2/3
+	M680X_INS_CPX, ///< M6800/1/2/3
 	M680X_INS_CPY,
 	M680X_INS_CWAI,
 	M680X_INS_DAA,
@@ -301,8 +301,8 @@ typedef enum m680x_insn {
 	M680X_INS_DECF,
 	M680X_INS_DECW,
 	M680X_INS_DECX,
-	M680X_INS_DES, // M6800/1/2/3
-	M680X_INS_DEX, // M6800/1/2/3
+	M680X_INS_DES, ///< M6800/1/2/3
+	M680X_INS_DEX, ///< M6800/1/2/3
 	M680X_INS_DEY,
 	M680X_INS_DIV,
 	M680X_INS_DIVD,
@@ -338,13 +338,13 @@ typedef enum m680x_insn {
 	M680X_INS_INCF,
 	M680X_INS_INCW,
 	M680X_INS_INCX,
-	M680X_INS_INS, // M6800/1/2/3
-	M680X_INS_INX, // M6800/1/2/3
+	M680X_INS_INS, ///< M6800/1/2/3
+	M680X_INS_INX, ///< M6800/1/2/3
 	M680X_INS_INY,
 	M680X_INS_JMP,
 	M680X_INS_JSR,
-	M680X_INS_LBCC, // or LBHS
-	M680X_INS_LBCS, // or LBLO
+	M680X_INS_LBCC, ///< or LBHS
+	M680X_INS_LBCS, ///< or LBLO
 	M680X_INS_LBEQ,
 	M680X_INS_LBGE,
 	M680X_INS_LBGT,
@@ -361,8 +361,8 @@ typedef enum m680x_insn {
 	M680X_INS_LBVC,
 	M680X_INS_LBVS,
 	M680X_INS_LDA,
-	M680X_INS_LDAA, // M6800/1/2/3
-	M680X_INS_LDAB, // M6800/1/2/3
+	M680X_INS_LDAA, ///< M6800/1/2/3
+	M680X_INS_LDAB, ///< M6800/1/2/3
 	M680X_INS_LDB,
 	M680X_INS_LDBT,
 	M680X_INS_LDD,
@@ -388,7 +388,7 @@ typedef enum m680x_insn {
 	M680X_INS_LSR,
 	M680X_INS_LSRA,
 	M680X_INS_LSRB,
-	M680X_INS_LSRD, // or ASRD
+	M680X_INS_LSRD, ///< or ASRD
 	M680X_INS_LSRW,
 	M680X_INS_LSRX,
 	M680X_INS_MAXA,
@@ -410,14 +410,14 @@ typedef enum m680x_insn {
 	M680X_INS_NSA,
 	M680X_INS_OIM,
 	M680X_INS_ORA,
-	M680X_INS_ORAA, // M6800/1/2/3
-	M680X_INS_ORAB, // M6800/1/2/3
+	M680X_INS_ORAA, ///< M6800/1/2/3
+	M680X_INS_ORAB, ///< M6800/1/2/3
 	M680X_INS_ORB,
 	M680X_INS_ORCC,
 	M680X_INS_ORD,
 	M680X_INS_ORR,
-	M680X_INS_PSHA, // M6800/1/2/3
-	M680X_INS_PSHB, // M6800/1/2/3
+	M680X_INS_PSHA, ///< M6800/1/2/3
+	M680X_INS_PSHB, ///< M6800/1/2/3
 	M680X_INS_PSHC,
 	M680X_INS_PSHD,
 	M680X_INS_PSHH,
@@ -425,10 +425,10 @@ typedef enum m680x_insn {
 	M680X_INS_PSHSW,
 	M680X_INS_PSHU,
 	M680X_INS_PSHUW,
-	M680X_INS_PSHX, // M6800/1/2/3
+	M680X_INS_PSHX, ///< M6800/1/2/3
 	M680X_INS_PSHY,
-	M680X_INS_PULA, // M6800/1/2/3
-	M680X_INS_PULB, // M6800/1/2/3
+	M680X_INS_PULA, ///< M6800/1/2/3
+	M680X_INS_PULB, ///< M6800/1/2/3
 	M680X_INS_PULC,
 	M680X_INS_PULD,
 	M680X_INS_PULH,
@@ -436,7 +436,7 @@ typedef enum m680x_insn {
 	M680X_INS_PULSW,
 	M680X_INS_PULU,
 	M680X_INS_PULUW,
-	M680X_INS_PULX, // M6800/1/2/3
+	M680X_INS_PULX, ///< M6800/1/2/3
 	M680X_INS_PULY,
 	M680X_INS_REV,
 	M680X_INS_REVW,
@@ -456,7 +456,7 @@ typedef enum m680x_insn {
 	M680X_INS_RTC,
 	M680X_INS_RTI,
 	M680X_INS_RTS,
-	M680X_INS_SBA, // M6800/1/2/3
+	M680X_INS_SBA, ///< M6800/1/2/3
 	M680X_INS_SBC,
 	M680X_INS_SBCA,
 	M680X_INS_SBCB,
@@ -469,8 +469,8 @@ typedef enum m680x_insn {
 	M680X_INS_SEXW,
 	M680X_INS_SLP,
 	M680X_INS_STA,
-	M680X_INS_STAA, // M6800/1/2/3
-	M680X_INS_STAB, // M6800/1/2/3
+	M680X_INS_STAA, ///< M6800/1/2/3
+	M680X_INS_STAB, ///< M6800/1/2/3
 	M680X_INS_STB,
 	M680X_INS_STBT,
 	M680X_INS_STD,
@@ -496,10 +496,10 @@ typedef enum m680x_insn {
 	M680X_INS_SWI2,
 	M680X_INS_SWI3,
 	M680X_INS_SYNC,
-	M680X_INS_TAB, // M6800/1/2/3
-	M680X_INS_TAP, // M6800/1/2/3
+	M680X_INS_TAB, ///< M6800/1/2/3
+	M680X_INS_TAP, ///< M6800/1/2/3
 	M680X_INS_TAX,
-	M680X_INS_TBA, // M6800/1/2/3
+	M680X_INS_TBA, ///< M6800/1/2/3
 	M680X_INS_TBEQ,
 	M680X_INS_TBL,
 	M680X_INS_TBNE,
@@ -507,7 +507,7 @@ typedef enum m680x_insn {
 	M680X_INS_TFM,
 	M680X_INS_TFR,
 	M680X_INS_TIM,
-	M680X_INS_TPA, // M6800/1/2/3
+	M680X_INS_TPA, ///< M6800/1/2/3
 	M680X_INS_TST,
 	M680X_INS_TSTA,
 	M680X_INS_TSTB,
@@ -516,16 +516,16 @@ typedef enum m680x_insn {
 	M680X_INS_TSTF,
 	M680X_INS_TSTW,
 	M680X_INS_TSTX,
-	M680X_INS_TSX, // M6800/1/2/3
+	M680X_INS_TSX, ///< M6800/1/2/3
 	M680X_INS_TSY,
 	M680X_INS_TXA,
-	M680X_INS_TXS, // M6800/1/2/3
+	M680X_INS_TXS, ///< M6800/1/2/3
 	M680X_INS_TYS,
-	M680X_INS_WAI, // M6800/1/2/3
+	M680X_INS_WAI, ///< M6800/1/2/3
 	M680X_INS_WAIT,
 	M680X_INS_WAV,
 	M680X_INS_WAVR,
-	M680X_INS_XGDX, // HD6301
+	M680X_INS_XGDX, ///< HD6301
 	M680X_INS_XGDY,
 	M680X_INS_ENDING,   // <-- mark the end of the list of instructions
 } m680x_insn;

--- a/include/capstone/m68k.h
+++ b/include/capstone/m68k.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #define M68K_OPERAND_COUNT 4
 
-//> M68K registers and special registers
+/// M68K registers and special registers
 typedef enum m68k_reg {
 	M68K_REG_INVALID = 0,
 
@@ -75,118 +75,118 @@ typedef enum m68k_reg {
 	M68K_REG_ENDING,   // <-- mark the end of the list of registers
 } m68k_reg;
 
-//> M68K Addressing Modes
+/// M68K Addressing Modes
 typedef enum m68k_address_mode {
-	M68K_AM_NONE = 0,			// No address mode.
+	M68K_AM_NONE = 0,			///< No address mode.
 
-	M68K_AM_REG_DIRECT_DATA,		// Register Direct - Data
-	M68K_AM_REG_DIRECT_ADDR,		// Register Direct - Address
+	M68K_AM_REG_DIRECT_DATA,		///< Register Direct - Data
+	M68K_AM_REG_DIRECT_ADDR,		///< Register Direct - Address
 
-	M68K_AM_REGI_ADDR,				// Register Indirect - Address
-	M68K_AM_REGI_ADDR_POST_INC,		// Register Indirect - Address with Postincrement
-	M68K_AM_REGI_ADDR_PRE_DEC,		// Register Indirect - Address with Predecrement
-	M68K_AM_REGI_ADDR_DISP,			// Register Indirect - Address with Displacement
+	M68K_AM_REGI_ADDR,				///< Register Indirect - Address
+	M68K_AM_REGI_ADDR_POST_INC,		///< Register Indirect - Address with Postincrement
+	M68K_AM_REGI_ADDR_PRE_DEC,		///< Register Indirect - Address with Predecrement
+	M68K_AM_REGI_ADDR_DISP,			///< Register Indirect - Address with Displacement
 
-	M68K_AM_AREGI_INDEX_8_BIT_DISP,	// Address Register Indirect With Index- 8-bit displacement
-	M68K_AM_AREGI_INDEX_BASE_DISP,	// Address Register Indirect With Index- Base displacement
+	M68K_AM_AREGI_INDEX_8_BIT_DISP,	///< Address Register Indirect With Index- 8-bit displacement
+	M68K_AM_AREGI_INDEX_BASE_DISP,	///< Address Register Indirect With Index- Base displacement
 
-	M68K_AM_MEMI_POST_INDEX,		// Memory indirect - Postindex
-	M68K_AM_MEMI_PRE_INDEX,			// Memory indirect - Preindex
+	M68K_AM_MEMI_POST_INDEX,		///< Memory indirect - Postindex
+	M68K_AM_MEMI_PRE_INDEX,			///< Memory indirect - Preindex
 
-	M68K_AM_PCI_DISP,				// Program Counter Indirect - with Displacement
+	M68K_AM_PCI_DISP,				///< Program Counter Indirect - with Displacement
 
-	M68K_AM_PCI_INDEX_8_BIT_DISP,	// Program Counter Indirect with Index - with 8-Bit Displacement
-	M68K_AM_PCI_INDEX_BASE_DISP,	// Program Counter Indirect with Index - with Base Displacement
+	M68K_AM_PCI_INDEX_8_BIT_DISP,	///< Program Counter Indirect with Index - with 8-Bit Displacement
+	M68K_AM_PCI_INDEX_BASE_DISP,	///< Program Counter Indirect with Index - with Base Displacement
 
-	M68K_AM_PC_MEMI_POST_INDEX,		// Program Counter Memory Indirect - Postindexed
-	M68K_AM_PC_MEMI_PRE_INDEX,		// Program Counter Memory Indirect - Preindexed
+	M68K_AM_PC_MEMI_POST_INDEX,		///< Program Counter Memory Indirect - Postindexed
+	M68K_AM_PC_MEMI_PRE_INDEX,		///< Program Counter Memory Indirect - Preindexed
 
-	M68K_AM_ABSOLUTE_DATA_SHORT,	// Absolute Data Addressing  - Short
-	M68K_AM_ABSOLUTE_DATA_LONG,		// Absolute Data Addressing  - Long
-	M68K_AM_IMMEDIATE,              // Immediate value
+	M68K_AM_ABSOLUTE_DATA_SHORT,	///< Absolute Data Addressing  - Short
+	M68K_AM_ABSOLUTE_DATA_LONG,		///< Absolute Data Addressing  - Long
+	M68K_AM_IMMEDIATE,              ///< Immediate value
 
-	M68K_AM_BRANCH_DISPLACEMENT,    // Address as displacement from (PC+2) used by branches
+	M68K_AM_BRANCH_DISPLACEMENT,    ///< Address as displacement from (PC+2) used by branches
 } m68k_address_mode;
 
-//> Operand type for instruction's operands
+/// Operand type for instruction's operands
 typedef enum m68k_op_type {
-	M68K_OP_INVALID = 0, // = CS_OP_INVALID (Uninitialized).
-	M68K_OP_REG,         // = CS_OP_REG (Register operand).
-	M68K_OP_IMM,         // = CS_OP_IMM (Immediate operand).
-	M68K_OP_MEM,         // = CS_OP_MEM (Memory operand).
-	M68K_OP_FP_SINGLE,   // single precision Floating-Point operand
-	M68K_OP_FP_DOUBLE,   // double precision Floating-Point operand
-	M68K_OP_REG_BITS,    // Register bits move
-	M68K_OP_REG_PAIR,    // Register pair in the same op (upper 4 bits for first reg, lower for second)
-	M68K_OP_BR_DISP,     // Branch displacement
+	M68K_OP_INVALID = 0, ///< = CS_OP_INVALID (Uninitialized).
+	M68K_OP_REG,         ///< = CS_OP_REG (Register operand).
+	M68K_OP_IMM,         ///< = CS_OP_IMM (Immediate operand).
+	M68K_OP_MEM,         ///< = CS_OP_MEM (Memory operand).
+	M68K_OP_FP_SINGLE,   ///< single precision Floating-Point operand
+	M68K_OP_FP_DOUBLE,   ///< double precision Floating-Point operand
+	M68K_OP_REG_BITS,    ///< Register bits move
+	M68K_OP_REG_PAIR,    ///< Register pair in the same op (upper 4 bits for first reg, lower for second)
+	M68K_OP_BR_DISP,     ///< Branch displacement
 } m68k_op_type;
 
-// Instruction's operand referring to memory
-// This is associated with M68K_OP_MEM operand type above
+/// Instruction's operand referring to memory
+/// This is associated with M68K_OP_MEM operand type above
 typedef struct m68k_op_mem {
-	m68k_reg base_reg;      // base register (or M68K_REG_INVALID if irrelevant)
-	m68k_reg index_reg;     // index register (or M68K_REG_INVALID if irrelevant)
-	m68k_reg in_base_reg;   // indirect base register (or M68K_REG_INVALID if irrelevant)
-	uint32_t in_disp; 	    // indirect displacement
-	uint32_t out_disp;      // other displacement
-	int16_t disp;	        // displacement value
-	uint8_t scale;	        // scale for index register
-	uint8_t bitfield;       // set to true if the two values below should be used
-	uint8_t width;	        // used for bf* instructions
-	uint8_t offset;	        // used for bf* instructions
-	uint8_t index_size;     // 0 = w, 1 = l
+	m68k_reg base_reg;      ///< base register (or M68K_REG_INVALID if irrelevant)
+	m68k_reg index_reg;     ///< index register (or M68K_REG_INVALID if irrelevant)
+	m68k_reg in_base_reg;   ///< indirect base register (or M68K_REG_INVALID if irrelevant)
+	uint32_t in_disp; 	    ///< indirect displacement
+	uint32_t out_disp;      ///< other displacement
+	int16_t disp;	        ///< displacement value
+	uint8_t scale;	        ///< scale for index register
+	uint8_t bitfield;       ///< set to true if the two values below should be used
+	uint8_t width;	        ///< used for bf* instructions
+	uint8_t offset;	        ///< used for bf* instructions
+	uint8_t index_size;     ///< 0 = w, 1 = l
 } m68k_op_mem;
 
-//> Operand type for instruction's operands
+/// Operand type for instruction's operands
 typedef enum m68k_op_br_disp_size {
-	M68K_OP_BR_DISP_SIZE_INVALID = 0, // = CS_OP_INVALID (Uninitialized).
-	M68K_OP_BR_DISP_SIZE_BYTE = 1,    // signed 8-bit displacement
-	M68K_OP_BR_DISP_SIZE_WORD = 2,    // signed 16-bit displacement
-	M68K_OP_BR_DISP_SIZE_LONG = 4,    // signed 32-bit displacement
+	M68K_OP_BR_DISP_SIZE_INVALID = 0, ///< = CS_OP_INVALID (Uninitialized).
+	M68K_OP_BR_DISP_SIZE_BYTE = 1,    ///< signed 8-bit displacement
+	M68K_OP_BR_DISP_SIZE_WORD = 2,    ///< signed 16-bit displacement
+	M68K_OP_BR_DISP_SIZE_LONG = 4,    ///< signed 32-bit displacement
 } m68k_op_br_disp_size;
 
 typedef struct m68k_op_br_disp {
-	int32_t disp;	        // displacement value
-	uint8_t disp_size;		// Size from m68k_op_br_disp_size type above
+	int32_t disp;	        ///< displacement value
+	uint8_t disp_size;		///< Size from m68k_op_br_disp_size type above
 } m68k_op_br_disp;
 
-// Instruction operand
+/// Instruction operand
 typedef struct cs_m68k_op {
 	union {
-		uint64_t imm;               // immediate value for IMM operand
-		double dimm; 		    // double imm
-		float simm; 		    // float imm
-		m68k_reg reg;		    // register value for REG operand
-		struct {		    // register pair in one operand
+		uint64_t imm;               ///< immediate value for IMM operand
+		double dimm; 		    ///< double imm
+		float simm; 		    ///< float imm
+		m68k_reg reg;		    ///< register value for REG operand
+		struct {		    ///< register pair in one operand
 			m68k_reg reg_0;
 			m68k_reg reg_1;
 		} reg_pair;
 	};
 
-	m68k_op_mem mem; 	    // data when operand is targeting memory
-	m68k_op_br_disp br_disp; // data when operand is a branch displacement
-	uint32_t register_bits; // register bits for movem etc. (always in d0-d7, a0-a7, fp0 - fp7 order)
+	m68k_op_mem mem; 	    ///< data when operand is targeting memory
+	m68k_op_br_disp br_disp; ///< data when operand is a branch displacement
+	uint32_t register_bits; ///< register bits for movem etc. (always in d0-d7, a0-a7, fp0 - fp7 order)
 	m68k_op_type type;
-	m68k_address_mode address_mode;	// M68K addressing mode for this op
+	m68k_address_mode address_mode;	///< M68K addressing mode for this op
 } cs_m68k_op;
 
-// Operation size of the CPU instructions
+/// Operation size of the CPU instructions
 typedef enum m68k_cpu_size {
-	M68K_CPU_SIZE_NONE = 0,		// unsized or unspecified
-	M68K_CPU_SIZE_BYTE = 1,		// 1 byte in size
-	M68K_CPU_SIZE_WORD = 2,		// 2 bytes in size
-	M68K_CPU_SIZE_LONG = 4,		// 4 bytes in size
+	M68K_CPU_SIZE_NONE = 0,		///< unsized or unspecified
+	M68K_CPU_SIZE_BYTE = 1,		///< 1 byte in size
+	M68K_CPU_SIZE_WORD = 2,		///< 2 bytes in size
+	M68K_CPU_SIZE_LONG = 4,		///< 4 bytes in size
 } m68k_cpu_size;
 
-// Operation size of the FPU instructions (Notice that FPU instruction can also use CPU sizes if needed)
+/// Operation size of the FPU instructions (Notice that FPU instruction can also use CPU sizes if needed)
 typedef enum m68k_fpu_size {
-	M68K_FPU_SIZE_NONE = 0,		// unsized like fsave/frestore
-	M68K_FPU_SIZE_SINGLE = 4,		// 4 byte in size (single float)
-	M68K_FPU_SIZE_DOUBLE = 8,		// 8 byte in size (double)
-	M68K_FPU_SIZE_EXTENDED = 12,	// 12 byte in size (extended real format)
+	M68K_FPU_SIZE_NONE = 0,		///< unsized like fsave/frestore
+	M68K_FPU_SIZE_SINGLE = 4,		///< 4 byte in size (single float)
+	M68K_FPU_SIZE_DOUBLE = 8,		///< 8 byte in size (double)
+	M68K_FPU_SIZE_EXTENDED = 12,	///< 12 byte in size (extended real format)
 } m68k_fpu_size;
 
-// Type of size that is being used for the current instruction
+/// Type of size that is being used for the current instruction
 typedef enum m68k_size_type {
 	M68K_SIZE_TYPE_INVALID = 0,
 
@@ -194,7 +194,7 @@ typedef enum m68k_size_type {
 	M68K_SIZE_TYPE_FPU,
 } m68k_size_type;
 
-// Operation size of the current instruction (NOT the actually size of instruction)
+/// Operation size of the current instruction (NOT the actually size of instruction)
 typedef struct m68k_op_size {
 	m68k_size_type type;
 	union {
@@ -203,15 +203,15 @@ typedef struct m68k_op_size {
 	};
 } m68k_op_size;
 
-// The M68K instruction and it's operands
+/// The M68K instruction and it's operands
 typedef struct cs_m68k {
 	// Number of operands of this instruction or 0 when instruction has no operand.
-	cs_m68k_op operands[M68K_OPERAND_COUNT]; // operands for this instruction.
-	m68k_op_size op_size;	// size of data operand works on in bytes (.b, .w, .l, etc)
-	uint8_t op_count; // number of operands for the instruction
+	cs_m68k_op operands[M68K_OPERAND_COUNT]; ///< operands for this instruction.
+	m68k_op_size op_size;	///< size of data operand works on in bytes (.b, .w, .l, etc)
+	uint8_t op_count; ///< number of operands for the instruction
 } cs_m68k;
 
-//> M68K instruction
+/// M68K instruction
 typedef enum m68k_insn {
 	M68K_INS_INVALID = 0,
 
@@ -592,13 +592,13 @@ typedef enum m68k_insn {
 	M68K_INS_ENDING,   // <-- mark the end of the list of instructions
 } m68k_insn;
 
-//> Group of M68K instructions
+/// Group of M68K instructions
 typedef enum m68k_group_type {
-	M68K_GRP_INVALID = 0,  // CS_GRUP_INVALID
-	M68K_GRP_JUMP,  // = CS_GRP_JUMP
-	M68K_GRP_RET = 3,  // = CS_GRP_RET
-	M68K_GRP_IRET = 5, // = CS_GRP_IRET
-	M68K_GRP_BRANCH_RELATIVE = 7, // = CS_GRP_BRANCH_RELATIVE
+	M68K_GRP_INVALID = 0,  ///< CS_GRUP_INVALID
+	M68K_GRP_JUMP,  ///< = CS_GRP_JUMP
+	M68K_GRP_RET = 3,  ///< = CS_GRP_RET
+	M68K_GRP_IRET = 5, ///< = CS_GRP_IRET
+	M68K_GRP_BRANCH_RELATIVE = 7, ///< = CS_GRP_BRANCH_RELATIVE
 
 	M68K_GRP_ENDING,// <-- mark the end of the list of groups
 } m68k_group_type;

--- a/include/capstone/mips.h
+++ b/include/capstone/mips.h
@@ -18,18 +18,18 @@ extern "C" {
 #pragma warning(disable:4201)
 #endif
 
-//> Operand type for instruction's operands
+/// Operand type for instruction's operands
 typedef enum mips_op_type {
-	MIPS_OP_INVALID = 0, // = CS_OP_INVALID (Uninitialized).
-	MIPS_OP_REG, // = CS_OP_REG (Register operand).
-	MIPS_OP_IMM, // = CS_OP_IMM (Immediate operand).
-	MIPS_OP_MEM, // = CS_OP_MEM (Memory operand).
+	MIPS_OP_INVALID = 0, ///< = CS_OP_INVALID (Uninitialized).
+	MIPS_OP_REG, ///< = CS_OP_REG (Register operand).
+	MIPS_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
+	MIPS_OP_MEM, ///< = CS_OP_MEM (Memory operand).
 } mips_op_type;
 
-//> MIPS registers
+/// MIPS registers
 typedef enum mips_reg {
 	MIPS_REG_INVALID = 0,
-	//> General purpose registers
+	// General purpose registers
 	MIPS_REG_PC,
 
 	MIPS_REG_0,
@@ -65,7 +65,7 @@ typedef enum mips_reg {
 	MIPS_REG_30,
 	MIPS_REG_31,
 
-	//> DSP registers
+	// DSP registers
 	MIPS_REG_DSPCCOND,
 	MIPS_REG_DSPCARRY,
 	MIPS_REG_DSPEFI,
@@ -78,13 +78,13 @@ typedef enum mips_reg {
 	MIPS_REG_DSPPOS,
 	MIPS_REG_DSPSCOUNT,
 
-	//> ACC registers
+	// ACC registers
 	MIPS_REG_AC0,
 	MIPS_REG_AC1,
 	MIPS_REG_AC2,
 	MIPS_REG_AC3,
 
-	//> COP registers
+	// COP registers
 	MIPS_REG_CC0,
 	MIPS_REG_CC1,
 	MIPS_REG_CC2,
@@ -94,7 +94,7 @@ typedef enum mips_reg {
 	MIPS_REG_CC6,
 	MIPS_REG_CC7,
 
-	//> FPU registers
+	// FPU registers
 	MIPS_REG_F0,
 	MIPS_REG_F1,
 	MIPS_REG_F2,
@@ -137,7 +137,7 @@ typedef enum mips_reg {
 	MIPS_REG_FCC6,
 	MIPS_REG_FCC7,
 
-	//> AFPR128
+	// AFPR128
 	MIPS_REG_W0,
 	MIPS_REG_W1,
 	MIPS_REG_W2,
@@ -229,32 +229,32 @@ typedef enum mips_reg {
 	MIPS_REG_LO3 = MIPS_REG_HI3,
 } mips_reg;
 
-// Instruction's operand referring to memory
-// This is associated with MIPS_OP_MEM operand type above
+/// Instruction's operand referring to memory
+/// This is associated with MIPS_OP_MEM operand type above
 typedef struct mips_op_mem {
-	mips_reg base;	// base register
-	int64_t disp;	// displacement/offset value
+	mips_reg base;	///< base register
+	int64_t disp;	///< displacement/offset value
 } mips_op_mem;
 
-// Instruction operand
+/// Instruction operand
 typedef struct cs_mips_op {
-	mips_op_type type;	// operand type
+	mips_op_type type;	///< operand type
 	union {
-		mips_reg reg;		// register value for REG operand
-		int64_t imm;		// immediate value for IMM operand
-		mips_op_mem mem;	// base/index/scale/disp value for MEM operand
+		mips_reg reg;		///< register value for REG operand
+		int64_t imm;		///< immediate value for IMM operand
+		mips_op_mem mem;	///< base/index/scale/disp value for MEM operand
 	};
 } cs_mips_op;
 
-// Instruction structure
+/// Instruction structure
 typedef struct cs_mips {
-	// Number of operands of this instruction, 
-	// or 0 when instruction has no operand.
+	/// Number of operands of this instruction,
+	/// or 0 when instruction has no operand.
 	uint8_t op_count;
-	cs_mips_op operands[10]; // operands for this instruction.
+	cs_mips_op operands[10]; ///< operands for this instruction.
 } cs_mips;
 
-//> MIPS instruction
+/// MIPS instruction
 typedef enum mips_insn {
 	MIPS_INS_INVALID = 0,
 
@@ -891,27 +891,27 @@ typedef enum mips_insn {
 	MIPS_INS_ENDING,
 } mips_insn;
 
-//> Group of MIPS instructions
+/// Group of MIPS instructions
 typedef enum mips_insn_group {
-	MIPS_GRP_INVALID = 0, // = CS_GRP_INVALID
+	MIPS_GRP_INVALID = 0, ///< = CS_GRP_INVALID
 
-	//> Generic groups
+	// Generic groups
 	// all jump instructions (conditional+direct+indirect jumps)
-	MIPS_GRP_JUMP,	// = CS_GRP_JUMP
+	MIPS_GRP_JUMP,	///< = CS_GRP_JUMP
 	// all call instructions
-	MIPS_GRP_CALL,	// = CS_GRP_CALL
+	MIPS_GRP_CALL,	///< = CS_GRP_CALL
 	// all return instructions
-	MIPS_GRP_RET,	// = CS_GRP_RET
+	MIPS_GRP_RET,	///< = CS_GRP_RET
 	// all interrupt instructions (int+syscall)
-	MIPS_GRP_INT,	// = CS_GRP_INT
+	MIPS_GRP_INT,	///< = CS_GRP_INT
 	// all interrupt return instructions
-	MIPS_GRP_IRET,	// = CS_GRP_IRET
+	MIPS_GRP_IRET,	///< = CS_GRP_IRET
 	// all privileged instructions
-	MIPS_GRP_PRIVILEGE,	// = CS_GRP_PRIVILEGE
+	MIPS_GRP_PRIVILEGE,	///< = CS_GRP_PRIVILEGE
 	// all relative branching instructions
-	MIPS_GRP_BRANCH_RELATIVE, // = CS_GRP_BRANCH_RELATIVE
+	MIPS_GRP_BRANCH_RELATIVE, ///< = CS_GRP_BRANCH_RELATIVE
 
-	//> Architecture-specific groups
+	// Architecture-specific groups
 	MIPS_GRP_BITCOUNT = 128,
 	MIPS_GRP_DSP,
 	MIPS_GRP_DSPR2,

--- a/include/capstone/ppc.h
+++ b/include/capstone/ppc.h
@@ -14,7 +14,7 @@ extern "C" {
 #pragma warning(disable:4201)
 #endif
 
-//> PPC branch codes for some branch instructions
+/// PPC branch codes for some branch instructions
 typedef enum ppc_bc {
 	PPC_BC_INVALID  = 0,
 	PPC_BC_LT       = (0 << 5) | 12,
@@ -27,27 +27,27 @@ typedef enum ppc_bc {
 	PPC_BC_NU       = (3 << 5) |  4,
 
 	// extra conditions
-	PPC_BC_SO = (4 << 5) | 12,	// summary overflow
-	PPC_BC_NS = (4 << 5) | 4,	// not summary overflow
+	PPC_BC_SO = (4 << 5) | 12,	///< summary overflow
+	PPC_BC_NS = (4 << 5) | 4,	///< not summary overflow
 } ppc_bc;
 
-//> PPC branch hint for some branch instructions
+/// PPC branch hint for some branch instructions
 typedef enum ppc_bh {
-	PPC_BH_INVALID = 0,	// no hint
-	PPC_BH_PLUS,	// PLUS hint
-	PPC_BH_MINUS,	// MINUS hint
+	PPC_BH_INVALID = 0,	///< no hint
+	PPC_BH_PLUS,	///< PLUS hint
+	PPC_BH_MINUS,	///< MINUS hint
 } ppc_bh;
 
-//> Operand type for instruction's operands
+/// Operand type for instruction's operands
 typedef enum ppc_op_type {
-	PPC_OP_INVALID = 0, // = CS_OP_INVALID (Uninitialized).
-	PPC_OP_REG, // = CS_OP_REG (Register operand).
-	PPC_OP_IMM, // = CS_OP_IMM (Immediate operand).
-	PPC_OP_MEM, // = CS_OP_MEM (Memory operand).
-	PPC_OP_CRX = 64,	// Condition Register field
+	PPC_OP_INVALID = 0, ///< = CS_OP_INVALID (Uninitialized).
+	PPC_OP_REG, ///< = CS_OP_REG (Register operand).
+	PPC_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
+	PPC_OP_MEM, ///< = CS_OP_MEM (Memory operand).
+	PPC_OP_CRX = 64,	///< Condition Register field
 } ppc_op_type;
 
-//> PPC registers
+/// PPC registers
 typedef enum ppc_reg {
 	PPC_REG_INVALID = 0,
 
@@ -266,11 +266,11 @@ typedef enum ppc_reg {
 	PPC_REG_ENDING,   // <-- mark the end of the list of registers
 } ppc_reg;
 
-// Instruction's operand referring to memory
-// This is associated with PPC_OP_MEM operand type above
+/// Instruction's operand referring to memory
+/// This is associated with PPC_OP_MEM operand type above
 typedef struct ppc_op_mem {
-	ppc_reg base;	// base register
-	int32_t disp;	// displacement/offset value
+	ppc_reg base;	///< base register
+	int32_t disp;	///< displacement/offset value
 } ppc_op_mem;
 
 typedef struct ppc_op_crx {
@@ -279,35 +279,35 @@ typedef struct ppc_op_crx {
 	ppc_bc cond;
 } ppc_op_crx;
 
-// Instruction operand
+/// Instruction operand
 typedef struct cs_ppc_op {
-	ppc_op_type type;	// operand type
+	ppc_op_type type;	///< operand type
 	union {
-		ppc_reg reg;	// register value for REG operand
-		int64_t imm;		// immediate value for IMM operand
-		ppc_op_mem mem;		// base/disp value for MEM operand
-		ppc_op_crx crx;		// operand with condition register
+		ppc_reg reg;	///< register value for REG operand
+		int64_t imm;		///< immediate value for IMM operand
+		ppc_op_mem mem;		///< base/disp value for MEM operand
+		ppc_op_crx crx;		///< operand with condition register
 	};
 } cs_ppc_op;
 
-// Instruction structure
+/// Instruction structure
 typedef struct cs_ppc {
-	// branch code for branch instructions
+	/// branch code for branch instructions
 	ppc_bc bc;
 
-	// branch hint for branch instructions
+	/// branch hint for branch instructions
 	ppc_bh bh;
 
-	// if update_cr0 = True, then this 'dot' insn updates CR0
+	/// if update_cr0 = True, then this 'dot' insn updates CR0
 	bool update_cr0;
 
-	// Number of operands of this instruction, 
-	// or 0 when instruction has no operand.
+	/// Number of operands of this instruction,
+	/// or 0 when instruction has no operand.
 	uint8_t op_count;
-	cs_ppc_op operands[8]; // operands for this instruction.
+	cs_ppc_op operands[8]; ///< operands for this instruction.
 } cs_ppc;
 
-//> PPC instruction
+/// PPC instruction
 typedef enum ppc_insn {
 	PPC_INS_INVALID = 0,
 
@@ -1429,15 +1429,15 @@ typedef enum ppc_insn {
 	PPC_INS_ENDING,   // <-- mark the end of the list of instructions
 } ppc_insn;
 
-//> Group of PPC instructions
+/// Group of PPC instructions
 typedef enum ppc_insn_group {
-	PPC_GRP_INVALID = 0, // = CS_GRP_INVALID
+	PPC_GRP_INVALID = 0, ///< = CS_GRP_INVALID
 
-	//> Generic groups
+	// Generic groups
 	// all jump instructions (conditional+direct+indirect jumps)
-	PPC_GRP_JUMP,	// = CS_GRP_JUMP
+	PPC_GRP_JUMP,	///< = CS_GRP_JUMP
 
-	//> Architecture-specific groups
+	// Architecture-specific groups
 	PPC_GRP_ALTIVEC = 128,
 	PPC_GRP_MODE32,
 	PPC_GRP_MODE64,

--- a/include/capstone/sparc.h
+++ b/include/capstone/sparc.h
@@ -18,63 +18,63 @@ extern "C" {
 #pragma warning(disable:4201)
 #endif
 
-//> Enums corresponding to Sparc condition codes, both icc's and fcc's.
+/// Enums corresponding to Sparc condition codes, both icc's and fcc's.
 typedef enum sparc_cc {
-	SPARC_CC_INVALID = 0,	// invalid CC (default)
-	//> Integer condition codes
-	SPARC_CC_ICC_A   =  8+256,  // Always
-	SPARC_CC_ICC_N   =  0+256,  // Never
-	SPARC_CC_ICC_NE  =  9+256,  // Not Equal
-	SPARC_CC_ICC_E   =  1+256,  // Equal
-	SPARC_CC_ICC_G   = 10+256,  // Greater
-	SPARC_CC_ICC_LE  =  2+256,  // Less or Equal
-	SPARC_CC_ICC_GE  = 11+256,  // Greater or Equal
-	SPARC_CC_ICC_L   =  3+256,  // Less
-	SPARC_CC_ICC_GU  = 12+256,  // Greater Unsigned
-	SPARC_CC_ICC_LEU =  4+256,  // Less or Equal Unsigned
-	SPARC_CC_ICC_CC  = 13+256,  // Carry Clear/Great or Equal Unsigned
-	SPARC_CC_ICC_CS  =  5+256,  // Carry Set/Less Unsigned
-	SPARC_CC_ICC_POS = 14+256,  // Positive
-	SPARC_CC_ICC_NEG =  6+256,  // Negative
-	SPARC_CC_ICC_VC  = 15+256,  // Overflow Clear
-	SPARC_CC_ICC_VS  =  7+256,  // Overflow Set
+	SPARC_CC_INVALID = 0,	///< invalid CC (default)
+	// Integer condition codes
+	SPARC_CC_ICC_A   =  8+256,  ///< Always
+	SPARC_CC_ICC_N   =  0+256,  ///< Never
+	SPARC_CC_ICC_NE  =  9+256,  ///< Not Equal
+	SPARC_CC_ICC_E   =  1+256,  ///< Equal
+	SPARC_CC_ICC_G   = 10+256,  ///< Greater
+	SPARC_CC_ICC_LE  =  2+256,  ///< Less or Equal
+	SPARC_CC_ICC_GE  = 11+256,  ///< Greater or Equal
+	SPARC_CC_ICC_L   =  3+256,  ///< Less
+	SPARC_CC_ICC_GU  = 12+256,  ///< Greater Unsigned
+	SPARC_CC_ICC_LEU =  4+256,  ///< Less or Equal Unsigned
+	SPARC_CC_ICC_CC  = 13+256,  ///< Carry Clear/Great or Equal Unsigned
+	SPARC_CC_ICC_CS  =  5+256,  ///< Carry Set/Less Unsigned
+	SPARC_CC_ICC_POS = 14+256,  ///< Positive
+	SPARC_CC_ICC_NEG =  6+256,  ///< Negative
+	SPARC_CC_ICC_VC  = 15+256,  ///< Overflow Clear
+	SPARC_CC_ICC_VS  =  7+256,  ///< Overflow Set
 
-	//> Floating condition codes
-	SPARC_CC_FCC_A   =  8+16+256,  // Always
-	SPARC_CC_FCC_N   =  0+16+256,  // Never
-	SPARC_CC_FCC_U   =  7+16+256,  // Unordered
-	SPARC_CC_FCC_G   =  6+16+256,  // Greater
-	SPARC_CC_FCC_UG  =  5+16+256,  // Unordered or Greater
-	SPARC_CC_FCC_L   =  4+16+256,  // Less
-	SPARC_CC_FCC_UL  =  3+16+256,  // Unordered or Less
-	SPARC_CC_FCC_LG  =  2+16+256,  // Less or Greater
-	SPARC_CC_FCC_NE  =  1+16+256,  // Not Equal
-	SPARC_CC_FCC_E   =  9+16+256,  // Equal
-	SPARC_CC_FCC_UE  = 10+16+256,  // Unordered or Equal
-	SPARC_CC_FCC_GE  = 11+16+256,  // Greater or Equal
-	SPARC_CC_FCC_UGE = 12+16+256,  // Unordered or Greater or Equal
-	SPARC_CC_FCC_LE  = 13+16+256,  // Less or Equal
-	SPARC_CC_FCC_ULE = 14+16+256,  // Unordered or Less or Equal
-	SPARC_CC_FCC_O   = 15+16+256,  // Ordered
+	// Floating condition codes
+	SPARC_CC_FCC_A   =  8+16+256,  ///< Always
+	SPARC_CC_FCC_N   =  0+16+256,  ///< Never
+	SPARC_CC_FCC_U   =  7+16+256,  ///< Unordered
+	SPARC_CC_FCC_G   =  6+16+256,  ///< Greater
+	SPARC_CC_FCC_UG  =  5+16+256,  ///< Unordered or Greater
+	SPARC_CC_FCC_L   =  4+16+256,  ///< Less
+	SPARC_CC_FCC_UL  =  3+16+256,  ///< Unordered or Less
+	SPARC_CC_FCC_LG  =  2+16+256,  ///< Less or Greater
+	SPARC_CC_FCC_NE  =  1+16+256,  ///< Not Equal
+	SPARC_CC_FCC_E   =  9+16+256,  ///< Equal
+	SPARC_CC_FCC_UE  = 10+16+256,  ///< Unordered or Equal
+	SPARC_CC_FCC_GE  = 11+16+256,  ///< Greater or Equal
+	SPARC_CC_FCC_UGE = 12+16+256,  ///< Unordered or Greater or Equal
+	SPARC_CC_FCC_LE  = 13+16+256,  ///< Less or Equal
+	SPARC_CC_FCC_ULE = 14+16+256,  ///< Unordered or Less or Equal
+	SPARC_CC_FCC_O   = 15+16+256,  ///< Ordered
 } sparc_cc;
 
-//> Branch hint
+/// Branch hint
 typedef enum sparc_hint {
-	SPARC_HINT_INVALID = 0,	// no hint
-	SPARC_HINT_A	= 1 << 0,	// annul delay slot instruction
-	SPARC_HINT_PT	= 1 << 1,	// branch taken
-	SPARC_HINT_PN	= 1 << 2,	// branch NOT taken
+	SPARC_HINT_INVALID = 0,	///< no hint
+	SPARC_HINT_A	= 1 << 0,	///< annul delay slot instruction
+	SPARC_HINT_PT	= 1 << 1,	///< branch taken
+	SPARC_HINT_PN	= 1 << 2,	///< branch NOT taken
 } sparc_hint;
 
-//> Operand type for instruction's operands
+/// Operand type for instruction's operands
 typedef enum sparc_op_type {
-	SPARC_OP_INVALID = 0, // = CS_OP_INVALID (Uninitialized).
-	SPARC_OP_REG, // = CS_OP_REG (Register operand).
-	SPARC_OP_IMM, // = CS_OP_IMM (Immediate operand).
-	SPARC_OP_MEM, // = CS_OP_MEM (Memory operand).
+	SPARC_OP_INVALID = 0, ///< = CS_OP_INVALID (Uninitialized).
+	SPARC_OP_REG, ///< = CS_OP_REG (Register operand).
+	SPARC_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
+	SPARC_OP_MEM, ///< = CS_OP_MEM (Memory operand).
 } sparc_op_type;
 
-//> SPARC registers
+/// SPARC registers
 typedef enum sparc_reg {
 	SPARC_REG_INVALID = 0,
 
@@ -175,37 +175,37 @@ typedef enum sparc_reg {
 	SPARC_REG_I6 = SPARC_REG_FP,
 } sparc_reg;
 
-// Instruction's operand referring to memory
-// This is associated with SPARC_OP_MEM operand type above
+/// Instruction's operand referring to memory
+/// This is associated with SPARC_OP_MEM operand type above
 typedef struct sparc_op_mem {
-	uint8_t base;		// base register, can be safely interpreted as
-				// a value of type `sparc_reg`, but it is only
-				// one byte wide
-	uint8_t index;		// index register, same conditions apply here
-	int32_t disp;		// displacement/offset value
+	uint8_t base;		///< base register, can be safely interpreted as
+				///< a value of type `sparc_reg`, but it is only
+				///< one byte wide
+	uint8_t index;		///< index register, same conditions apply here
+	int32_t disp;		///< displacement/offset value
 } sparc_op_mem;
 
-// Instruction operand
+/// Instruction operand
 typedef struct cs_sparc_op {
-	sparc_op_type type;	// operand type
+	sparc_op_type type;	///< operand type
 	union {
-		sparc_reg reg;	// register value for REG operand
-		int64_t imm;		// immediate value for IMM operand
-		sparc_op_mem mem;		// base/disp value for MEM operand
+		sparc_reg reg;	///< register value for REG operand
+		int64_t imm;		///< immediate value for IMM operand
+		sparc_op_mem mem;		///< base/disp value for MEM operand
 	};
 } cs_sparc_op;
 
-// Instruction structure
+/// Instruction structure
 typedef struct cs_sparc {
-	sparc_cc cc;	// code condition for this insn
-	sparc_hint hint;	// branch hint: encoding as bitwise OR of sparc_hint.
-	// Number of operands of this instruction, 
-	// or 0 when instruction has no operand.
+	sparc_cc cc;	///< code condition for this insn
+	sparc_hint hint;	///< branch hint: encoding as bitwise OR of sparc_hint.
+	/// Number of operands of this instruction,
+	/// or 0 when instruction has no operand.
 	uint8_t op_count;
-	cs_sparc_op operands[4]; // operands for this instruction.
+	cs_sparc_op operands[4]; ///< operands for this instruction.
 } cs_sparc;
 
-//> SPARC instruction
+/// SPARC instruction
 typedef enum sparc_insn {
 	SPARC_INS_INVALID = 0,
 
@@ -493,15 +493,15 @@ typedef enum sparc_insn {
 	SPARC_INS_ENDING,   // <-- mark the end of the list of instructions
 } sparc_insn;
 
-//> Group of SPARC instructions
+/// Group of SPARC instructions
 typedef enum sparc_insn_group {
-	SPARC_GRP_INVALID = 0, // = CS_GRP_INVALID
+	SPARC_GRP_INVALID = 0, ///< = CS_GRP_INVALID
 
-	//> Generic groups
+	// Generic groups
 	// all jump instructions (conditional+direct+indirect jumps)
-	SPARC_GRP_JUMP,	// = CS_GRP_JUMP
+	SPARC_GRP_JUMP,	///< = CS_GRP_JUMP
 
-	//> Architecture-specific groups
+	// Architecture-specific groups
 	SPARC_GRP_HARDQUAD = 128,
 	SPARC_GRP_V9,
 	SPARC_GRP_VIS,

--- a/include/capstone/systemz.h
+++ b/include/capstone/systemz.h
@@ -14,9 +14,9 @@ extern "C" {
 #pragma warning(disable:4201)
 #endif
 
-//> Enums corresponding to SystemZ condition codes
+/// Enums corresponding to SystemZ condition codes
 typedef enum sysz_cc {
-	SYSZ_CC_INVALID = 0,	// invalid CC (default)
+	SYSZ_CC_INVALID = 0,	///< invalid CC (default)
 
 	SYSZ_CC_O,
 	SYSZ_CC_H,
@@ -34,16 +34,16 @@ typedef enum sysz_cc {
 	SYSZ_CC_NO,
 } sysz_cc;
 
-//> Operand type for instruction's operands
+/// Operand type for instruction's operands
 typedef enum sysz_op_type {
-	SYSZ_OP_INVALID = 0, // = CS_OP_INVALID (Uninitialized).
-	SYSZ_OP_REG, // = CS_OP_REG (Register operand).
-	SYSZ_OP_IMM, // = CS_OP_IMM (Immediate operand).
-	SYSZ_OP_MEM, // = CS_OP_MEM (Memory operand).
-	SYSZ_OP_ACREG = 64,	// Access register operand.
+	SYSZ_OP_INVALID = 0, ///< = CS_OP_INVALID (Uninitialized).
+	SYSZ_OP_REG, ///< = CS_OP_REG (Register operand).
+	SYSZ_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
+	SYSZ_OP_MEM, ///< = CS_OP_MEM (Memory operand).
+	SYSZ_OP_ACREG = 64,	///< Access register operand.
 } sysz_op_type;
 
-//> SystemZ registers
+/// SystemZ registers
 typedef enum sysz_reg {
 	SYSZ_REG_INVALID = 0,
 
@@ -86,37 +86,37 @@ typedef enum sysz_reg {
 	SYSZ_REG_ENDING,
 } sysz_reg;
 
-// Instruction's operand referring to memory
-// This is associated with SYSZ_OP_MEM operand type above
+/// Instruction's operand referring to memory
+/// This is associated with SYSZ_OP_MEM operand type above
 typedef struct sysz_op_mem {
-	uint8_t base;		// base register, can be safely interpreted as
-				// a value of type `sysz_reg`, but it is only
-				// one byte wide
-	uint8_t index;		// index register, same conditions apply here
-	uint64_t length;	// BDLAddr operand
-	int64_t disp;	// displacement/offset value
+	uint8_t base;		///< base register, can be safely interpreted as
+				///< a value of type `sysz_reg`, but it is only
+				///< one byte wide
+	uint8_t index;		///< index register, same conditions apply here
+	uint64_t length;	///< BDLAddr operand
+	int64_t disp;	///< displacement/offset value
 } sysz_op_mem;
 
-// Instruction operand
+/// Instruction operand
 typedef struct cs_sysz_op {
-	sysz_op_type type;	// operand type
+	sysz_op_type type;	///< operand type
 	union {
-		sysz_reg reg;		// register value for REG operand
-		int64_t imm;		// immediate value for IMM operand
-		sysz_op_mem mem;	// base/disp value for MEM operand
+		sysz_reg reg;		///< register value for REG operand
+		int64_t imm;		///< immediate value for IMM operand
+		sysz_op_mem mem;	///< base/disp value for MEM operand
 	};
 } cs_sysz_op;
 
 // Instruction structure
 typedef struct cs_sysz {
-	sysz_cc cc;		// Code condition
-	// Number of operands of this instruction, 
-	// or 0 when instruction has no operand.
+	sysz_cc cc;		///< Code condition
+	/// Number of operands of this instruction,
+	/// or 0 when instruction has no operand.
 	uint8_t op_count;
-	cs_sysz_op operands[6]; // operands for this instruction.
+	cs_sysz_op operands[6]; ///< operands for this instruction.
 } cs_sysz;
 
-//> SystemZ instruction
+/// SystemZ instruction
 typedef enum sysz_insn {
 	SYSZ_INS_INVALID = 0,
 
@@ -805,15 +805,15 @@ typedef enum sysz_insn {
 	SYSZ_INS_ENDING,   // <-- mark the end of the list of instructions
 } sysz_insn;
 
-//> Group of SystemZ instructions
+/// Group of SystemZ instructions
 typedef enum sysz_insn_group {
-	SYSZ_GRP_INVALID = 0, // = CS_GRP_INVALID
+	SYSZ_GRP_INVALID = 0, ///< = CS_GRP_INVALID
 
-	//> Generic groups
+	// Generic groups
 	// all jump instructions (conditional+direct+indirect jumps)
-	SYSZ_GRP_JUMP,	// = CS_GRP_JUMP
+	SYSZ_GRP_JUMP,	///< = CS_GRP_JUMP
 
-	//> Architecture-specific groups
+	// Architecture-specific groups
 	SYSZ_GRP_DISTINCTOPS = 128,
 	SYSZ_GRP_FPEXTENSION,
 	SYSZ_GRP_HIGHWORD,

--- a/include/capstone/tms320c64x.h
+++ b/include/capstone/tms320c64x.h
@@ -16,11 +16,11 @@ extern "C" {
 #endif
 
 typedef enum tms320c64x_op_type {
-	TMS320C64X_OP_INVALID = 0, // = CS_OP_INVALID (Uninitialized).
-	TMS320C64X_OP_REG, // = CS_OP_REG (Register operand).
-	TMS320C64X_OP_IMM, // = CS_OP_IMM (Immediate operand).
-	TMS320C64X_OP_MEM, // = CS_OP_MEM (Memory operand).
-	TMS320C64X_OP_REGPAIR = 64, // Register pair for double word ops
+	TMS320C64X_OP_INVALID = 0, ///< = CS_OP_INVALID (Uninitialized).
+	TMS320C64X_OP_REG, ///< = CS_OP_REG (Register operand).
+	TMS320C64X_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
+	TMS320C64X_OP_MEM, ///< = CS_OP_MEM (Memory operand).
+	TMS320C64X_OP_REGPAIR = 64, ///< Register pair for double word ops
 } tms320c64x_op_type;
 
 typedef enum tms320c64x_mem_disp {
@@ -43,27 +43,27 @@ typedef enum tms320c64x_mem_mod {
 } tms320c64x_mem_mod;
 
 typedef struct tms320c64x_op_mem {
-	unsigned int	base;	// base register
-	unsigned int	disp;	// displacement/offset value
-	unsigned int	unit;	// unit of base and offset register
-	unsigned int	scaled;	// offset scaled
-	unsigned int	disptype;	// displacement type
-	unsigned int	direction;	// direction
-	unsigned int	modify;	// modification
+	unsigned int	base;	///< base register
+	unsigned int	disp;	///< displacement/offset value
+	unsigned int	unit;	///< unit of base and offset register
+	unsigned int	scaled;	///< offset scaled
+	unsigned int	disptype;	///< displacement type
+	unsigned int	direction;	///< direction
+	unsigned int	modify;	///< modification
 } tms320c64x_op_mem;
 
 typedef struct cs_tms320c64x_op {
-	tms320c64x_op_type type;	// operand type
+	tms320c64x_op_type type;	///< operand type
 	union {
-		unsigned int reg;	// register value for REG operand or first register for REGPAIR operand
-		int32_t imm;		// immediate value for IMM operand
-		tms320c64x_op_mem mem;		// base/disp value for MEM operand
+		unsigned int reg;	///< register value for REG operand or first register for REGPAIR operand
+		int32_t imm;		///< immediate value for IMM operand
+		tms320c64x_op_mem mem;		///< base/disp value for MEM operand
 	};
 } cs_tms320c64x_op;
 
 typedef struct cs_tms320c64x {
 	uint8_t op_count;
-	cs_tms320c64x_op operands[8]; // operands for this instruction.
+	cs_tms320c64x_op operands[8]; ///< operands for this instruction.
 	struct {
 		unsigned int reg;
 		unsigned int zero;
@@ -329,9 +329,9 @@ typedef enum tms320c64x_insn {
 } tms320c64x_insn;
 
 typedef enum tms320c64x_insn_group {
-	TMS320C64X_GRP_INVALID = 0, // = CS_GRP_INVALID
+	TMS320C64X_GRP_INVALID = 0, ///< = CS_GRP_INVALID
 
-	TMS320C64X_GRP_JUMP,	// = CS_GRP_JUMP
+	TMS320C64X_GRP_JUMP,	///< = CS_GRP_JUMP
 
 	TMS320C64X_GRP_FUNIT_D = 128,
 	TMS320C64X_GRP_FUNIT_L,

--- a/include/capstone/x86.h
+++ b/include/capstone/x86.h
@@ -10,12 +10,12 @@ extern "C" {
 
 #include "platform.h"
 
-// Calculate relative address for X86-64, given cs_insn structure
+/// Calculate relative address for X86-64, given cs_insn structure
 #define X86_REL_ADDR(insn) (((insn).detail->x86.operands[0].type == X86_OP_IMM) \
 	? (uint64_t)((insn).detail->x86.operands[0].imm) \
 	: (((insn).address + (insn).size) + (uint64_t)(insn).detail->x86.disp))
 
-//> X86 registers
+/// X86 registers
 typedef enum x86_reg {
 	X86_REG_INVALID = 0,
 	X86_REG_AH, X86_REG_AL, X86_REG_AX, X86_REG_BH, X86_REG_BL,
@@ -71,7 +71,7 @@ typedef enum x86_reg {
 	X86_REG_ENDING		// <-- mark the end of the list of registers
 } x86_reg;
 
-//> Sub-flags of EFLAGS
+// Sub-flags of EFLAGS
 #define X86_EFLAGS_MODIFY_AF (1ULL << 0)
 #define X86_EFLAGS_MODIFY_CF (1ULL << 1)
 #define X86_EFLAGS_MODIFY_SF (1ULL << 2)
@@ -154,17 +154,17 @@ typedef enum x86_reg {
 #define X86_FPU_FLAGS_TEST_C3 (1ULL << 19)
 
 
-//> Operand type for instruction's operands
+/// Operand type for instruction's operands
 typedef enum x86_op_type {
-	X86_OP_INVALID = 0, // = CS_OP_INVALID (Uninitialized).
-	X86_OP_REG, // = CS_OP_REG (Register operand).
-	X86_OP_IMM, // = CS_OP_IMM (Immediate operand).
-	X86_OP_MEM, // = CS_OP_MEM (Memory operand).
+	X86_OP_INVALID = 0, ///< = CS_OP_INVALID (Uninitialized).
+	X86_OP_REG, ///< = CS_OP_REG (Register operand).
+	X86_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
+	X86_OP_MEM, ///< = CS_OP_MEM (Memory operand).
 } x86_op_type;
 
-//> XOP Code Condition type
+/// XOP Code Condition type
 typedef enum x86_xop_cc {
-	X86_XOP_CC_INVALID = 0,	// Uninitialized.
+	X86_XOP_CC_INVALID = 0,	///< Uninitialized.
 	X86_XOP_CC_LT,
 	X86_XOP_CC_LE,
 	X86_XOP_CC_GT,
@@ -175,18 +175,18 @@ typedef enum x86_xop_cc {
 	X86_XOP_CC_TRUE,
 } x86_xop_cc;
 
-//> AVX broadcast type
+/// AVX broadcast type
 typedef enum x86_avx_bcast {
-	X86_AVX_BCAST_INVALID = 0,	// Uninitialized.
-	X86_AVX_BCAST_2,	// AVX512 broadcast type {1to2}
-	X86_AVX_BCAST_4,	// AVX512 broadcast type {1to4}
-	X86_AVX_BCAST_8,	// AVX512 broadcast type {1to8}
-	X86_AVX_BCAST_16,	// AVX512 broadcast type {1to16}
+	X86_AVX_BCAST_INVALID = 0,	///< Uninitialized.
+	X86_AVX_BCAST_2,	///< AVX512 broadcast type {1to2}
+	X86_AVX_BCAST_4,	///< AVX512 broadcast type {1to4}
+	X86_AVX_BCAST_8,	///< AVX512 broadcast type {1to8}
+	X86_AVX_BCAST_16,	///< AVX512 broadcast type {1to16}
 } x86_avx_bcast;
 
-//> SSE Code Condition type
+/// SSE Code Condition type
 typedef enum x86_sse_cc {
-	X86_SSE_CC_INVALID = 0,	// Uninitialized.
+	X86_SSE_CC_INVALID = 0,	///< Uninitialized.
 	X86_SSE_CC_EQ,
 	X86_SSE_CC_LT,
 	X86_SSE_CC_LE,
@@ -197,9 +197,9 @@ typedef enum x86_sse_cc {
 	X86_SSE_CC_ORD,
 } x86_sse_cc;
 
-//> AVX Code Condition type
+/// AVX Code Condition type
 typedef enum x86_avx_cc {
-	X86_AVX_CC_INVALID = 0,	// Uninitialized.
+	X86_AVX_CC_INVALID = 0,	///< Uninitialized.
 	X86_AVX_CC_EQ,
 	X86_AVX_CC_LT,
 	X86_AVX_CC_LE,
@@ -234,153 +234,153 @@ typedef enum x86_avx_cc {
 	X86_AVX_CC_TRUE_US,
 } x86_avx_cc;
 
-//> AVX static rounding mode type
+/// AVX static rounding mode type
 typedef enum x86_avx_rm {
-	X86_AVX_RM_INVALID = 0,	// Uninitialized.
-	X86_AVX_RM_RN,	// Round to nearest
-	X86_AVX_RM_RD,	// Round down
-	X86_AVX_RM_RU,	// Round up
-	X86_AVX_RM_RZ,	// Round toward zero
+	X86_AVX_RM_INVALID = 0,	///< Uninitialized.
+	X86_AVX_RM_RN,	///< Round to nearest
+	X86_AVX_RM_RD,	///< Round down
+	X86_AVX_RM_RU,	///< Round up
+	X86_AVX_RM_RZ,	///< Round toward zero
 } x86_avx_rm;
 
-//> Instruction prefixes - to be used in cs_x86.prefix[]
+/// Instruction prefixes - to be used in cs_x86.prefix[]
 typedef enum x86_prefix {
-	X86_PREFIX_LOCK		= 	0xf0,	// lock (cs_x86.prefix[0]
-	X86_PREFIX_REP		= 	0xf3,	// rep (cs_x86.prefix[0]
-	X86_PREFIX_REPE		= 	0xf3,	// repe/repz (cs_x86.prefix[0]
-	X86_PREFIX_REPNE	= 	0xf2,	// repne/repnz (cs_x86.prefix[0]
+	X86_PREFIX_LOCK		= 	0xf0,	///< lock (cs_x86.prefix[0]
+	X86_PREFIX_REP		= 	0xf3,	///< rep (cs_x86.prefix[0]
+	X86_PREFIX_REPE		= 	0xf3,	///< repe/repz (cs_x86.prefix[0]
+	X86_PREFIX_REPNE	= 	0xf2,	///< repne/repnz (cs_x86.prefix[0]
 
-	X86_PREFIX_CS		= 	0x2e,	// segment override CS (cs_x86.prefix[1]
-	X86_PREFIX_SS		= 	0x36,	// segment override SS (cs_x86.prefix[1]
-	X86_PREFIX_DS		= 	0x3e,	// segment override DS (cs_x86.prefix[1]
-	X86_PREFIX_ES		= 	0x26,	// segment override ES (cs_x86.prefix[1]
-	X86_PREFIX_FS		= 	0x64,	// segment override FS (cs_x86.prefix[1]
-	X86_PREFIX_GS		= 	0x65,	// segment override GS (cs_x86.prefix[1]
+	X86_PREFIX_CS		= 	0x2e,	///< segment override CS (cs_x86.prefix[1]
+	X86_PREFIX_SS		= 	0x36,	///< segment override SS (cs_x86.prefix[1]
+	X86_PREFIX_DS		= 	0x3e,	///< segment override DS (cs_x86.prefix[1]
+	X86_PREFIX_ES		= 	0x26,	///< segment override ES (cs_x86.prefix[1]
+	X86_PREFIX_FS		= 	0x64,	///< segment override FS (cs_x86.prefix[1]
+	X86_PREFIX_GS		= 	0x65,	///< segment override GS (cs_x86.prefix[1]
 
-	X86_PREFIX_OPSIZE	=	0x66,	// operand-size override (cs_x86.prefix[2]
-	X86_PREFIX_ADDRSIZE	=	0x67,	// address-size override (cs_x86.prefix[3]
+	X86_PREFIX_OPSIZE	=	0x66,	///< operand-size override (cs_x86.prefix[2]
+	X86_PREFIX_ADDRSIZE	=	0x67,	///< address-size override (cs_x86.prefix[3]
 } x86_prefix;
 
-// Instruction's operand referring to memory
-// This is associated with X86_OP_MEM operand type above
+/// Instruction's operand referring to memory
+/// This is associated with X86_OP_MEM operand type above
 typedef struct x86_op_mem {
-	x86_reg segment; // segment register (or X86_REG_INVALID if irrelevant)
-	x86_reg base;	// base register (or X86_REG_INVALID if irrelevant)
-	x86_reg index;	// index register (or X86_REG_INVALID if irrelevant)
-	int scale;	// scale for index register
-	int64_t disp;	// displacement value
+	x86_reg segment; ///< segment register (or X86_REG_INVALID if irrelevant)
+	x86_reg base;	///< base register (or X86_REG_INVALID if irrelevant)
+	x86_reg index;	///< index register (or X86_REG_INVALID if irrelevant)
+	int scale;	///< scale for index register
+	int64_t disp;	///< displacement value
 } x86_op_mem;
 
-// Instruction operand
+/// Instruction operand
 typedef struct cs_x86_op {
-		x86_op_type type;	// operand type
+		x86_op_type type;	///< operand type
 		union {
-			x86_reg reg;	  // register value for REG operand
-			int64_t imm;		// immediate value for IMM operand
-			x86_op_mem mem;		// base/index/scale/disp value for MEM operand
+			x86_reg reg;	  ///< register value for REG operand
+			int64_t imm;		///< immediate value for IMM operand
+			x86_op_mem mem;		///< base/index/scale/disp value for MEM operand
 		};
 
-		// size of this operand (in bytes).
+		/// size of this operand (in bytes).
 		uint8_t size;
 
-		// How is this operand accessed? (READ, WRITE or READ|WRITE)
-		// This field is combined of cs_ac_type.
-		// NOTE: this field is irrelevant if engine is compiled in DIET mode.
+		/// How is this operand accessed? (READ, WRITE or READ|WRITE)
+		/// This field is combined of cs_ac_type.
+		/// NOTE: this field is irrelevant if engine is compiled in DIET mode.
 		uint8_t access;
 
-		// AVX broadcast type, or 0 if irrelevant
+		/// AVX broadcast type, or 0 if irrelevant
 		x86_avx_bcast avx_bcast;
 
-		// AVX zero opmask {z}
+		/// AVX zero opmask {z}
 		bool avx_zero_opmask;
 } cs_x86_op;
 
 typedef struct cs_x86_encoding {
-	// ModR/M offset, or 0 when irrelevant
+	/// ModR/M offset, or 0 when irrelevant
 	uint8_t modrm_offset;
 
-	// Displacement offset, or 0 when irrelevant.
+	/// Displacement offset, or 0 when irrelevant.
 	uint8_t disp_offset;
 	uint8_t disp_size;
 
-	// Immediate offset, or 0 when irrelevant.
+	/// Immediate offset, or 0 when irrelevant.
 	uint8_t imm_offset;
 	uint8_t imm_size;
 } cs_x86_encoding;
 
-// Instruction structure
+/// Instruction structure
 typedef struct cs_x86 {
-	// Instruction prefix, which can be up to 4 bytes.
-	// A prefix byte gets value 0 when irrelevant.
-	// prefix[0] indicates REP/REPNE/LOCK prefix (See X86_PREFIX_REP/REPNE/LOCK above)
-	// prefix[1] indicates segment override (irrelevant for x86_64):
-	// See X86_PREFIX_CS/SS/DS/ES/FS/GS above.
-	// prefix[2] indicates operand-size override (X86_PREFIX_OPSIZE)
-	// prefix[3] indicates address-size override (X86_PREFIX_ADDRSIZE)
+	/// Instruction prefix, which can be up to 4 bytes.
+	/// A prefix byte gets value 0 when irrelevant.
+	/// prefix[0] indicates REP/REPNE/LOCK prefix (See X86_PREFIX_REP/REPNE/LOCK above)
+	/// prefix[1] indicates segment override (irrelevant for x86_64):
+	/// See X86_PREFIX_CS/SS/DS/ES/FS/GS above.
+	/// prefix[2] indicates operand-size override (X86_PREFIX_OPSIZE)
+	/// prefix[3] indicates address-size override (X86_PREFIX_ADDRSIZE)
 	uint8_t prefix[4];
 
-	// Instruction opcode, which can be from 1 to 4 bytes in size.
-	// This contains VEX opcode as well.
-	// An trailing opcode byte gets value 0 when irrelevant.
+	/// Instruction opcode, which can be from 1 to 4 bytes in size.
+	/// This contains VEX opcode as well.
+	/// An trailing opcode byte gets value 0 when irrelevant.
 	uint8_t opcode[4];
 
-	// REX prefix: only a non-zero value is relevant for x86_64
+	/// REX prefix: only a non-zero value is relevant for x86_64
 	uint8_t rex;
 
-	// Address size, which can be overridden with above prefix[5].
+	/// Address size, which can be overridden with above prefix[5].
 	uint8_t addr_size;
 
-	// ModR/M byte
+	/// ModR/M byte
 	uint8_t modrm;
 
-	// SIB value, or 0 when irrelevant.
+	/// SIB value, or 0 when irrelevant.
 	uint8_t sib;
 
-	// Displacement value, valid if encoding.disp_offset != 0
+	/// Displacement value, valid if encoding.disp_offset != 0
 	int64_t disp;
 
-	// SIB index register, or X86_REG_INVALID when irrelevant.
+	/// SIB index register, or X86_REG_INVALID when irrelevant.
 	x86_reg sib_index;
-	// SIB scale, only applicable if sib_index is valid.
+	/// SIB scale, only applicable if sib_index is valid.
 	int8_t sib_scale;
-	// SIB base register, or X86_REG_INVALID when irrelevant.
+	/// SIB base register, or X86_REG_INVALID when irrelevant.
 	x86_reg sib_base;
 
-	// XOP Code Condition
+	/// XOP Code Condition
 	x86_xop_cc xop_cc;
 
-	// SSE Code Condition
+	/// SSE Code Condition
 	x86_sse_cc sse_cc;
 
-	// AVX Code Condition
+	/// AVX Code Condition
 	x86_avx_cc avx_cc;
 
-	// AVX Suppress all Exception
+	/// AVX Suppress all Exception
 	bool avx_sae;
 
-	// AVX static rounding mode
+	/// AVX static rounding mode
 	x86_avx_rm avx_rm;
 
 	
 	union {
-		// EFLAGS updated by this instruction.
-		// This can be formed from OR combination of X86_EFLAGS_* symbols in x86.h
+		/// EFLAGS updated by this instruction.
+		/// This can be formed from OR combination of X86_EFLAGS_* symbols in x86.h
 		uint64_t eflags;
-		// FPU_FLAGS updated by this instruction.
-		// This can be formed from OR combination of X86_FPU_FLAGS_* symbols in x86.h
+		/// FPU_FLAGS updated by this instruction.
+		/// This can be formed from OR combination of X86_FPU_FLAGS_* symbols in x86.h
 		uint64_t fpu_flags;
 	};
 
-	// Number of operands of this instruction,
-	// or 0 when instruction has no operand.
+	/// Number of operands of this instruction,
+	/// or 0 when instruction has no operand.
 	uint8_t op_count;
 
-	cs_x86_op operands[8];	// operands for this instruction.
+	cs_x86_op operands[8];	///< operands for this instruction.
 
-	cs_x86_encoding encoding;  // encoding information
+	cs_x86_encoding encoding;  ///< encoding information
 } cs_x86;
 
-//> X86 instructions
+/// X86 instructions
 typedef enum x86_insn {
 	X86_INS_INVALID = 0,
 
@@ -1898,28 +1898,28 @@ typedef enum x86_insn {
 	X86_INS_ENDING, // mark the end of the list of insn
 } x86_insn;
 
-//> Group of X86 instructions
+/// Group of X86 instructions
 typedef enum  x86_insn_group {
-	X86_GRP_INVALID = 0, // = CS_GRP_INVALID
+	X86_GRP_INVALID = 0, ///< = CS_GRP_INVALID
 
-	//> Generic groups
+	// Generic groups
 	// all jump instructions (conditional+direct+indirect jumps)
-	X86_GRP_JUMP,	// = CS_GRP_JUMP
+	X86_GRP_JUMP,	///< = CS_GRP_JUMP
 	// all call instructions
-	X86_GRP_CALL,	// = CS_GRP_CALL
+	X86_GRP_CALL,	///< = CS_GRP_CALL
 	// all return instructions
-	X86_GRP_RET,	// = CS_GRP_RET
+	X86_GRP_RET,	///< = CS_GRP_RET
 	// all interrupt instructions (int+syscall)
-	X86_GRP_INT,	// = CS_GRP_INT
+	X86_GRP_INT,	///< = CS_GRP_INT
 	// all interrupt return instructions
-	X86_GRP_IRET,	// = CS_GRP_IRET
+	X86_GRP_IRET,	///< = CS_GRP_IRET
 	// all privileged instructions
-	X86_GRP_PRIVILEGE,	// = CS_GRP_PRIVILEGE
+	X86_GRP_PRIVILEGE,	///< = CS_GRP_PRIVILEGE
 	// all relative branching instructions
-	X86_GRP_BRANCH_RELATIVE, // = CS_GRP_BRANCH_RELATIVE
+	X86_GRP_BRANCH_RELATIVE, ///< = CS_GRP_BRANCH_RELATIVE
 
-	//> Architecture-specific groups
-	X86_GRP_VM = 128,	// all virtualization instructions (VT-x + AMD-V)
+	// Architecture-specific groups
+	X86_GRP_VM = 128,	///< all virtualization instructions (VT-x + AMD-V)
 	X86_GRP_3DNOW,
 	X86_GRP_AES,
 	X86_GRP_ADX,

--- a/include/capstone/xcore.h
+++ b/include/capstone/xcore.h
@@ -14,15 +14,15 @@ extern "C" {
 #pragma warning(disable:4201)
 #endif
 
-//> Operand type for instruction's operands
+/// Operand type for instruction's operands
 typedef enum xcore_op_type {
-	XCORE_OP_INVALID = 0, // = CS_OP_INVALID (Uninitialized).
-	XCORE_OP_REG, // = CS_OP_REG (Register operand).
-	XCORE_OP_IMM, // = CS_OP_IMM (Immediate operand).
-	XCORE_OP_MEM, // = CS_OP_MEM (Memory operand).
+	XCORE_OP_INVALID = 0, ///< = CS_OP_INVALID (Uninitialized).
+	XCORE_OP_REG, ///< = CS_OP_REG (Register operand).
+	XCORE_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
+	XCORE_OP_MEM, ///< = CS_OP_MEM (Memory operand).
 } xcore_op_type;
 
-//> XCore registers
+/// XCore registers
 typedef enum xcore_reg {
 	XCORE_REG_INVALID = 0,
 
@@ -43,53 +43,53 @@ typedef enum xcore_reg {
 	XCORE_REG_R10,
 	XCORE_REG_R11,
 
-	//> pseudo registers
-	XCORE_REG_PC,	// pc
+	// pseudo registers
+	XCORE_REG_PC,	///< pc
 
 	// internal thread registers
 	// see The-XMOS-XS1-Architecture(X7879A).pdf
-	XCORE_REG_SCP,	// save pc
-	XCORE_REG_SSR,	// save status
-	XCORE_REG_ET,	// exception type
-	XCORE_REG_ED,	// exception data
-	XCORE_REG_SED,	// save exception data
-	XCORE_REG_KEP,	// kernel entry pointer
-	XCORE_REG_KSP,	// kernel stack pointer
-	XCORE_REG_ID,	// thread ID
+	XCORE_REG_SCP,	///< save pc
+	XCORE_REG_SSR,	//< save status
+	XCORE_REG_ET,	//< exception type
+	XCORE_REG_ED,	//< exception data
+	XCORE_REG_SED,	//< save exception data
+	XCORE_REG_KEP,	//< kernel entry pointer
+	XCORE_REG_KSP,	//< kernel stack pointer
+	XCORE_REG_ID,	//< thread ID
 
 	XCORE_REG_ENDING,	// <-- mark the end of the list of registers
 } xcore_reg;
 
-// Instruction's operand referring to memory
-// This is associated with XCORE_OP_MEM operand type above
+/// Instruction's operand referring to memory
+/// This is associated with XCORE_OP_MEM operand type above
 typedef struct xcore_op_mem {
-	uint8_t base;		// base register, can be safely interpreted as
-				// a value of type `xcore_reg`, but it is only
-				// one byte wide
-	uint8_t index;		// index register, same conditions apply here
-	int32_t disp;	// displacement/offset value
-	int     direct;	// +1: forward, -1: backward
+	uint8_t base;		///< base register, can be safely interpreted as
+				///< a value of type `xcore_reg`, but it is only
+				///< one byte wide
+	uint8_t index;		///< index register, same conditions apply here
+	int32_t disp;	///< displacement/offset value
+	int     direct;	///< +1: forward, -1: backward
 } xcore_op_mem;
 
-// Instruction operand
+/// Instruction operand
 typedef struct cs_xcore_op {
-	xcore_op_type type;	// operand type
+	xcore_op_type type;	///< operand type
 	union {
-		xcore_reg reg;	// register value for REG operand
-		int32_t imm;		// immediate value for IMM operand
-		xcore_op_mem mem;		// base/disp value for MEM operand
+		xcore_reg reg;	///< register value for REG operand
+		int32_t imm;		///< immediate value for IMM operand
+		xcore_op_mem mem;		///< base/disp value for MEM operand
 	};
 } cs_xcore_op;
 
-// Instruction structure
+/// Instruction structure
 typedef struct cs_xcore {
-	// Number of operands of this instruction, 
-	// or 0 when instruction has no operand.
+	/// Number of operands of this instruction,
+	/// or 0 when instruction has no operand.
 	uint8_t op_count;
-	cs_xcore_op operands[8]; // operands for this instruction.
+	cs_xcore_op operands[8]; ///< operands for this instruction.
 } cs_xcore;
 
-//> XCore instruction
+/// XCore instruction
 typedef enum xcore_insn {
 	XCORE_INS_INVALID = 0,
 
@@ -217,13 +217,13 @@ typedef enum xcore_insn {
 	XCORE_INS_ENDING,   // <-- mark the end of the list of instructions
 } xcore_insn;
 
-//> Group of XCore instructions
+/// Group of XCore instructions
 typedef enum xcore_insn_group {
-	XCORE_GRP_INVALID = 0, // = CS_GRP_INVALID
+	XCORE_GRP_INVALID = 0, ///< = CS_GRP_INVALID
 
-	//> Generic groups
+	// Generic groups
 	// all jump instructions (conditional+direct+indirect jumps)
-	XCORE_GRP_JUMP,	// = CS_GRP_JUMP
+	XCORE_GRP_JUMP,	///< = CS_GRP_JUMP
 
 	XCORE_GRP_ENDING,   // <-- mark the end of the list of groups
 } xcore_insn_group;


### PR DESCRIPTION
This is following up on #1249.