### PR TITLE
Correct register access flag for movdqa

### DIFF
--- a/arch/X86/X86MappingInsnOp.inc
+++ b/arch/X86/X86MappingInsnOp.inc
@@ -5995,7 +5995,7 @@
 },
 {	/* X86_MOVDQAmr, X86_INS_MOVDQA: movdqa	$dst, $src */
 	0,
-	{ CS_AC_READ, CS_AC_READ, 0 }
+	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_MOVDQArm, X86_INS_MOVDQA: movdqa	$dst, $src */
 	0,


### PR DESCRIPTION
Correct register access flag for the movdqa instruction