### PR TITLE
Remove i386 from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,8 +270,8 @@ VERSION_EXT =
 
 IS_APPLE := $(shell $(CC) -dM -E - < /dev/null 2> /dev/null | grep __apple_build_version__ | wc -l | tr -d " ")
 ifeq ($(IS_APPLE),1)
-# on MacOS, compile in Universal format by default
-MACOS_UNIVERSAL ?= yes
+# on MacOS, do not build in Universal format by default
+MACOS_UNIVERSAL ?= no
 ifeq ($(MACOS_UNIVERSAL),yes)
 CFLAGS += $(foreach arch,$(LIBARCHS),-arch $(arch))
 LDFLAGS += $(foreach arch,$(LIBARCHS),-arch $(arch))

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Capstone offers some unparalleled features:
 - Provide semantics of the disassembled instruction, such as list of implicit
   registers read & written.
 
-- Implemented in pure C language, with lightweight bindings for PHP, PowerShell,
-  Emacs, Haskell, Perl, Python, Ruby, C#, NodeJS, Java, GO, C++, OCaml, Lua,
-  Rust, Delphi, Free Pascal & Vala ready either in main code, or provided
-  externally by the community).
+- Implemented in pure C language, with lightweight bindings for Clojure, F#,
+  Common Lisp, Visual Basic, PHP, PowerShell, Emacs, Haskell, Perl, Python,
+  Ruby, C#, NodeJS, Java, GO, C++, OCaml, Lua, Rust, Delphi, Free Pascal & Vala
+  ready either in main code, or provided externally by the community).
 
 - Native support for all popular platforms: Windows, Mac OSX, iOS, Android,
-  Linux, *BSD, Solaris, etc.
+  Linux, \*BSD, Solaris, etc.
 
 - Thread-safe by design.
 

--- a/arch/AArch64/AArch64Disassembler.c
+++ b/arch/AArch64/AArch64Disassembler.c
@@ -1626,7 +1626,7 @@ static DecodeStatus DecodeTestAndBranch(MCInst *Inst, uint32_t insn,
 {
 	uint32_t Rt = fieldFromInstruction(insn, 0, 5);
 	uint32_t bit = fieldFromInstruction(insn, 31, 1) << 5;
-	uint32_t dst = fieldFromInstruction(insn, 5, 14);
+	uint64_t dst = fieldFromInstruction(insn, 5, 14);
 
 	bit |= fieldFromInstruction(insn, 19, 5);
 

--- a/arch/AArch64/AArch64Mapping.c
+++ b/arch/AArch64/AArch64Mapping.c
@@ -283,7 +283,7 @@ static name_map reg_name_maps[] = {
 const char *AArch64_reg_name(csh handle, unsigned int reg)
 {
 #ifndef CAPSTONE_DIET
-	if (reg >= ARM64_REG_ENDING)
+	if (reg >= ARR_SIZE(reg_name_maps))
 		return NULL;
 
 	return reg_name_maps[reg].name;

--- a/arch/ARM/ARMMapping.c
+++ b/arch/ARM/ARMMapping.c
@@ -245,7 +245,7 @@ static name_map reg_name_maps2[] = {
 const char *ARM_reg_name(csh handle, unsigned int reg)
 {
 #ifndef CAPSTONE_DIET
-	if (reg >= ARM_REG_ENDING)
+	if (reg >= ARR_SIZE(reg_name_maps))
 		return NULL;
 
 	return reg_name_maps[reg].name;
@@ -257,7 +257,7 @@ const char *ARM_reg_name(csh handle, unsigned int reg)
 const char *ARM_reg_name2(csh handle, unsigned int reg)
 {
 #ifndef CAPSTONE_DIET
-	if (reg >= ARM_REG_ENDING)
+	if (reg >= ARR_SIZE(reg_name_maps2))
 		return NULL;
 
 	return reg_name_maps2[reg].name;

--- a/arch/EVM/EVMMapping.c
+++ b/arch/EVM/EVMMapping.c
@@ -44,7 +44,7 @@ void EVM_get_insn_id(cs_struct *h, cs_insn *insn, unsigned int id)
 }
 
 #ifndef CAPSTONE_DIET
-static name_map insn_name_maps[] = {
+static name_map insn_name_maps[256] = {
 	{ EVM_INS_STOP, "stop" },
 	{ EVM_INS_ADD, "add" },
 	{ EVM_INS_MUL, "mul" },

--- a/arch/EVM/EVMMappingInsn.inc
+++ b/arch/EVM/EVMMappingInsn.inc
@@ -32,6 +32,7 @@
 { 0, 0, 0xffffffff }, // unused
 { 0, 0, 0xffffffff }, // unused
 { 0, 0, 0xffffffff }, // unused
+{ 0, 0, 0xffffffff }, // unused
 { 2, 1, 30 }, // SHA3
 { 0, 0, 0xffffffff }, // unused
 { 0, 0, 0xffffffff }, // unused
@@ -165,7 +166,6 @@
 { 4, 0, 1125 }, // LOG2
 { 5, 0, 1500 }, // LOG3
 { 6, 0, 1875 }, // LOG4
-{ 0, 0, 0xffffffff }, // unused
 { 0, 0, 0xffffffff }, // unused
 { 0, 0, 0xffffffff }, // unused
 { 0, 0, 0xffffffff }, // unused

--- a/arch/M680X/M680XInstPrinter.c
+++ b/arch/M680X/M680XInstPrinter.c
@@ -299,7 +299,7 @@ const char *M680X_reg_name(csh handle, unsigned int reg)
 {
 #ifndef CAPSTONE_DIET
 
-	if (reg >= M680X_REG_ENDING)
+	if (reg >= ARR_SIZE(s_reg_names))
 		return NULL;
 
 	return s_reg_names[(int)reg];

--- a/arch/M68K/M68KInstPrinter.c
+++ b/arch/M68K/M68KInstPrinter.c
@@ -338,6 +338,9 @@ const char* M68K_reg_name(csh handle, unsigned int reg)
 #ifdef CAPSTONE_DIET
 	return NULL;
 #else
+	if (reg >= ARR_SIZE(s_reg_names)) {
+		return NULL;
+	}
 	return s_reg_names[(int)reg];
 #endif
 }

--- a/arch/Mips/MipsMapping.c
+++ b/arch/Mips/MipsMapping.c
@@ -201,7 +201,7 @@ static name_map reg_name_maps[] = {
 const char *Mips_reg_name(csh handle, unsigned int reg)
 {
 #ifndef CAPSTONE_DIET
-	if (reg >= MIPS_REG_ENDING)
+	if (reg >= ARR_SIZE(reg_name_maps))
 		return NULL;
 
 	return reg_name_maps[reg].name;

--- a/arch/PowerPC/PPCMapping.c
+++ b/arch/PowerPC/PPCMapping.c
@@ -234,7 +234,7 @@ static name_map reg_name_maps[] = {
 const char *PPC_reg_name(csh handle, unsigned int reg)
 {
 #ifndef CAPSTONE_DIET
-	if (reg >= PPC_REG_ENDING)
+	if (reg >= ARR_SIZE(reg_name_maps))
 		return NULL;
 
 	return reg_name_maps[reg].name;

--- a/arch/Sparc/SparcMapping.c
+++ b/arch/Sparc/SparcMapping.c
@@ -112,7 +112,7 @@ static name_map reg_name_maps[] = {
 const char *Sparc_reg_name(csh handle, unsigned int reg)
 {
 #ifndef CAPSTONE_DIET
-	if (reg >= SPARC_REG_ENDING)
+	if (reg >= ARR_SIZE(reg_name_maps))
 		return NULL;
 
 	return reg_name_maps[reg].name;

--- a/arch/SystemZ/SystemZMapping.c
+++ b/arch/SystemZ/SystemZMapping.c
@@ -57,7 +57,7 @@ static name_map reg_name_maps[] = {
 const char *SystemZ_reg_name(csh handle, unsigned int reg)
 {
 #ifndef CAPSTONE_DIET
-	if (reg >= SYSZ_REG_ENDING)
+	if (reg >= ARR_SIZE(reg_name_maps))
 		return NULL;
 
 	return reg_name_maps[reg].name;

--- a/arch/TMS320C64x/TMS320C64xInstPrinter.c
+++ b/arch/TMS320C64x/TMS320C64xInstPrinter.c
@@ -30,10 +30,10 @@ void TMS320C64x_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci)
 	int i;
 	cs_tms320c64x *tms320c64x;
 
-	if(mci->csh->detail) {
+	if (mci->csh->detail) {
 		tms320c64x = &mci->flat_insn->detail->tms320c64x;
 
-		for(i = 0; i < insn->detail->groups_count; i++) {
+		for (i = 0; i < insn->detail->groups_count; i++) {
 			switch(insn->detail->groups[i]) {
 				case TMS320C64X_GRP_FUNIT_D:
 					unit = TMS320C64X_FUNIT_D;
@@ -51,34 +51,33 @@ void TMS320C64x_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci)
 					unit = TMS320C64X_FUNIT_NO;
 					break;
 			}
-			if(unit != 0)
+			if (unit != 0)
 				break;
 		}
 		tms320c64x->funit.unit = unit;
 
 		SStream_Init(&ss);
-		if(tms320c64x->condition.reg != TMS320C64X_REG_INVALID)
+		if (tms320c64x->condition.reg != TMS320C64X_REG_INVALID)
 			SStream_concat(&ss, "[%c%s]|", (tms320c64x->condition.zero == 1) ? '!' : '|', cs_reg_name(ud, tms320c64x->condition.reg));
 		else
 			SStream_concat0(&ss, "||||||");
 
 		p = strchr(insn_asm, '\t');
-		if(p != NULL)
+		if (p != NULL)
 			*p++ = '\0';
 
 		SStream_concat0(&ss, insn_asm);
-		if((p != NULL) && (((p2 = strchr(p, '[')) != NULL) || ((p2 = strchr(p, '(')) != NULL))) {
-			while((p2 > p) && ((*p2 != 'A') && (*p2 != 'B')))
+		if ((p != NULL) && (((p2 = strchr(p, '[')) != NULL) || ((p2 = strchr(p, '(')) != NULL))) {
+			while ((p2 > p) && ((*p2 != 'A') && (*p2 != 'B')))
 				p2--;
-            if(p2 == p) {
-                strcpy(insn_asm, "Invalid!");
-                return;
-            } else {
-			    if(*p2 == 'A')
-				    strcpy(tmp, "1T");
-			    else
-				    strcpy(tmp, "2T");
-            }
+			if (p2 == p) {
+				strcpy(insn_asm, "Invalid!");
+				return;
+			}
+			if (*p2 == 'A')
+				strcpy(tmp, "1T");
+			else
+				strcpy(tmp, "2T");
 		} else {
 			tmp[0] = '\0';
 		}
@@ -96,13 +95,13 @@ void TMS320C64x_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci)
 				SStream_concat(&ss, ".S%s%u", tmp, tms320c64x->funit.side);
 				break;
 		}
-		if(tms320c64x->funit.crosspath > 0)
+		if (tms320c64x->funit.crosspath > 0)
 			SStream_concat0(&ss, "X");
 
-		if(p != NULL)
+		if (p != NULL)
 			SStream_concat(&ss, "\t%s", p);
 
-		if(tms320c64x->parallel != 0)
+		if (tms320c64x->parallel != 0)
 			SStream_concat(&ss, "\t||");
 
 		/* insn_asm is a buffer from an SStream, so there should be enough space */
@@ -121,9 +120,9 @@ static void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 	MCOperand *Op = MCInst_getOperand(MI, OpNo);
 	unsigned reg;
 
-	if(MCOperand_isReg(Op)) {
+	if (MCOperand_isReg(Op)) {
 		reg = MCOperand_getReg(Op);
-		if((MCInst_getOpcode(MI) == TMS320C64x_MVC_s1_rr) && (OpNo == 1)) {
+		if ((MCInst_getOpcode(MI) == TMS320C64x_MVC_s1_rr) && (OpNo == 1)) {
 			switch(reg) {
 				case TMS320C64X_REG_EFR:
 					SStream_concat0(O, "EFR");
@@ -139,7 +138,7 @@ static void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 			SStream_concat0(O, getRegisterName(reg));
 		}
 
-		if(MI->csh->detail) {
+		if (MI->csh->detail) {
 			MI->flat_insn->detail->tms320c64x.operands[MI->flat_insn->detail->tms320c64x.op_count].type = TMS320C64X_OP_REG;
 			MI->flat_insn->detail->tms320c64x.operands[MI->flat_insn->detail->tms320c64x.op_count].reg = reg;
 			MI->flat_insn->detail->tms320c64x.op_count++;
@@ -147,19 +146,19 @@ static void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 	} else if (MCOperand_isImm(Op)) {
 		int64_t Imm = MCOperand_getImm(Op);
 
-		if(Imm >= 0) {
-			if(Imm > HEX_THRESHOLD)
+		if (Imm >= 0) {
+			if (Imm > HEX_THRESHOLD)
 				SStream_concat(O, "0x%"PRIx64, Imm);
 			else
 				SStream_concat(O, "%"PRIu64, Imm);
 		} else {
-			if(Imm < -HEX_THRESHOLD)
+			if (Imm < -HEX_THRESHOLD)
 				SStream_concat(O, "-0x%"PRIx64, -Imm);
 			else
 				SStream_concat(O, "-%"PRIu64, -Imm);
 		}
 
-		if(MI->csh->detail) {
+		if (MI->csh->detail) {
 			MI->flat_insn->detail->tms320c64x.operands[MI->flat_insn->detail->tms320c64x.op_count].type = TMS320C64X_OP_IMM;
 			MI->flat_insn->detail->tms320c64x.operands[MI->flat_insn->detail->tms320c64x.op_count].imm = Imm;
 			MI->flat_insn->detail->tms320c64x.op_count++;
@@ -181,7 +180,7 @@ static void printMemOperand(MCInst *MI, unsigned OpNo, SStream *O)
 	mode = (Val >> 1) & 0xf;
 	unit = Val & 1;
 
-	if(scaled) {
+	if (scaled) {
 		st = '[';
 		nd = ']';
 	} else {
@@ -228,7 +227,7 @@ static void printMemOperand(MCInst *MI, unsigned OpNo, SStream *O)
 			break;
 	}
 
-	if(MI->csh->detail) {
+	if (MI->csh->detail) {
 		tms320c64x = &MI->flat_insn->detail->tms320c64x;
 
 		tms320c64x->operands[tms320c64x->op_count].type = TMS320C64X_OP_MEM;
@@ -314,7 +313,7 @@ static void printMemOperand2(MCInst *MI, unsigned OpNo, SStream *O)
 	offset = (Val >> 7) & 0x7fff;
 	SStream_concat(O, "*+%s[0x%x]", getRegisterName(basereg), offset);
 
-	if(MI->csh->detail) {
+	if (MI->csh->detail) {
 		tms320c64x = &MI->flat_insn->detail->tms320c64x;
 
 		tms320c64x->operands[tms320c64x->op_count].type = TMS320C64X_OP_MEM;
@@ -336,7 +335,7 @@ static void printRegPair(MCInst *MI, unsigned OpNo, SStream *O)
 
 	SStream_concat(O, "%s:%s", getRegisterName(reg + 1), getRegisterName(reg));
 
-	if(MI->csh->detail) {
+	if (MI->csh->detail) {
 		tms320c64x = &MI->flat_insn->detail->tms320c64x;
 
 		tms320c64x->operands[tms320c64x->op_count].type = TMS320C64X_OP_REGPAIR;
@@ -358,7 +357,7 @@ static bool printAliasInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 		case TMS320C64x_ADD_l1_ipp:
 		/* ADD.S -i, x, y -> SUB.S x, i, y */
 		case TMS320C64x_ADD_s1_irr:
-			if((MCInst_getNumOperands(MI) == 3) &&
+			if ((MCInst_getNumOperands(MI) == 3) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 0)) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 1)) &&
 				MCOperand_isImm(MCInst_getOperand(MI, 2)) &&
@@ -393,7 +392,7 @@ static bool printAliasInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 		case TMS320C64x_ADD_s1_irr:
 		/* OR.S 0, x, y -> MV.S x, y */
 		case TMS320C64x_OR_s1_irr:
-			if((MCInst_getNumOperands(MI) == 3) &&
+			if ((MCInst_getNumOperands(MI) == 3) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 0)) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 1)) &&
 				MCOperand_isImm(MCInst_getOperand(MI, 2)) &&
@@ -418,7 +417,7 @@ static bool printAliasInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 		case TMS320C64x_XOR_l1_irr:
 		/* XOR.S -1, x, y -> NOT.S x, y */
 		case TMS320C64x_XOR_s1_irr:
-			if((MCInst_getNumOperands(MI) == 3) &&
+			if ((MCInst_getNumOperands(MI) == 3) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 0)) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 1)) &&
 				MCOperand_isImm(MCInst_getOperand(MI, 2)) &&
@@ -441,7 +440,7 @@ static bool printAliasInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 		case TMS320C64x_MVK_d1_rr:
 		/* MVK.L 0, x -> ZERO.L x */
 		case TMS320C64x_MVK_l2_ir:
-			if((MCInst_getNumOperands(MI) == 2) &&
+			if ((MCInst_getNumOperands(MI) == 2) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 0)) &&
 				MCOperand_isImm(MCInst_getOperand(MI, 1)) &&
 				(MCOperand_getImm(MCInst_getOperand(MI, 1)) == 0)) {
@@ -461,7 +460,7 @@ static bool printAliasInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 		case TMS320C64x_SUB_l1_rrp_x1:
 		/* SUB.S x, x, y -> ZERO.S y */
 		case TMS320C64x_SUB_s1_rrr:
-			if((MCInst_getNumOperands(MI) == 3) &&
+			if ((MCInst_getNumOperands(MI) == 3) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 0)) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 1)) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 2)) &&
@@ -483,7 +482,7 @@ static bool printAliasInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 		case TMS320C64x_SUB_l1_ipp:
 		/* SUB.S 0, x, y -> NEG.S x, y */
 		case TMS320C64x_SUB_s1_irr:
-			if((MCInst_getNumOperands(MI) == 3) &&
+			if ((MCInst_getNumOperands(MI) == 3) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 0)) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 1)) &&
 				MCOperand_isImm(MCInst_getOperand(MI, 2)) &&
@@ -506,7 +505,7 @@ static bool printAliasInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 		case TMS320C64x_PACKLH2_l1_rrr_x2:
 		/* PACKLH2.S x, x, y -> SWAP2.S x, y */
 		case TMS320C64x_PACKLH2_s1_rrr:
-			if((MCInst_getNumOperands(MI) == 3) &&
+			if ((MCInst_getNumOperands(MI) == 3) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 0)) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 1)) &&
 				MCOperand_isReg(MCInst_getOperand(MI, 2)) &&
@@ -528,7 +527,7 @@ static bool printAliasInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 		/* NOP 16 -> IDLE */
 		/* NOP 1 -> NOP */
 		case TMS320C64x_NOP_n:
-			if((MCInst_getNumOperands(MI) == 1) &&
+			if ((MCInst_getNumOperands(MI) == 1) &&
 				MCOperand_isImm(MCInst_getOperand(MI, 0)) &&
 				(MCOperand_getReg(MCInst_getOperand(MI, 0)) == 16)) {
 
@@ -539,7 +538,7 @@ static bool printAliasInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
 				return true;
 			}
-			if((MCInst_getNumOperands(MI) == 1) &&
+			if ((MCInst_getNumOperands(MI) == 1) &&
 				MCOperand_isImm(MCInst_getOperand(MI, 0)) &&
 				(MCOperand_getReg(MCInst_getOperand(MI, 0)) == 1)) {
 
@@ -557,7 +556,7 @@ static bool printAliasInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
 void TMS320C64x_printInst(MCInst *MI, SStream *O, void *Info)
 {
-	if(!printAliasInstruction(MI, O, Info))
+	if (!printAliasInstruction(MI, O, Info))
 		printInstruction(MI, O, Info);
 }
 

--- a/arch/TMS320C64x/TMS320C64xMapping.c
+++ b/arch/TMS320C64x/TMS320C64xMapping.c
@@ -110,7 +110,7 @@ static name_map reg_name_maps[] = {
 const char *TMS320C64x_reg_name(csh handle, unsigned int reg)
 {
 #ifndef CAPSTONE_DIET
-	if (reg >= TMS320C64X_REG_ENDING)
+	if (reg >= ARR_SIZE(reg_name_maps))
 		return NULL;
 
 	return reg_name_maps[reg].name;

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -828,7 +828,7 @@ const char *X86_reg_name(csh handle, unsigned int reg)
 #ifndef CAPSTONE_DIET
 	cs_struct *ud = (cs_struct *)handle;
 
-	if (reg >= X86_REG_ENDING)
+	if (reg >= ARR_SIZE(reg_name_maps))
 		return NULL;
 
 	if (reg == X86_REG_EFLAGS) {

--- a/arch/X86/X86MappingInsnOp.inc
+++ b/arch/X86/X86MappingInsnOp.inc
@@ -5995,7 +5995,7 @@
 },
 {	/* X86_MOVDQAmr, X86_INS_MOVDQA: movdqa	$dst, $src */
 	0,
-	{ CS_AC_READ, CS_AC_READ, 0 }
+	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_MOVDQArm, X86_INS_MOVDQA: movdqa	$dst, $src */
 	0,

--- a/arch/XCore/XCoreMapping.c
+++ b/arch/XCore/XCoreMapping.c
@@ -49,7 +49,7 @@ static name_map reg_name_maps[] = {
 const char *XCore_reg_name(csh handle, unsigned int reg)
 {
 #ifndef CAPSTONE_DIET
-	if (reg >= XCORE_REG_ENDING)
+	if (reg >= ARR_SIZE(reg_name_maps))
 		return NULL;
 
 	return reg_name_maps[reg].name;

--- a/cstool/cstool.c
+++ b/cstool/cstool.c
@@ -395,6 +395,7 @@ int main(int argc, char **argv)
 	}
 
 	cs_close(&handle);
+	free(assembly);
 
 	return 0;
 }

--- a/cstool/cstool.c
+++ b/cstool/cstool.c
@@ -74,7 +74,7 @@ void print_insn_detail_evm(csh handle, cs_insn *ins);
 
 static void print_details(csh handle, cs_arch arch, cs_mode md, cs_insn *ins);
 
-void print_string_hex(char *comment, unsigned char *str, size_t len)
+void print_string_hex(const char *comment, unsigned char *str, size_t len)
 {
 	unsigned char *c;
 

--- a/cstool/cstool_evm.c
+++ b/cstool/cstool_evm.c
@@ -8,7 +8,6 @@ void print_string_hex(char *comment, unsigned char *str, size_t len);
 void print_insn_detail_evm(csh handle, cs_insn *ins)
 {
 	cs_evm *evm;
-	int i;
 
 	// detail can be NULL on "data" instruction if SKIPDATA option is turned ON
 	if (ins->detail == NULL)

--- a/cstool/cstool_m680x.c
+++ b/cstool/cstool_m680x.c
@@ -60,7 +60,7 @@ void print_insn_detail_m680x(csh handle, cs_insn *insn)
 
 	for (i = 0; i < m680x->op_count; i++) {
 		cs_m680x_op *op = &(m680x->operands[i]);
-		char *comment;
+		const char *comment;
 
 		switch ((int)op->type) {
 		default:
@@ -131,9 +131,9 @@ void print_insn_detail_m680x(csh handle, cs_insn *insn)
 			}
 
 			if (op->idx.inc_dec) {
-				char *post_pre = op->idx.flags &
+				const char *post_pre = op->idx.flags &
 					M680X_IDX_POST_INC_DEC ? "post" : "pre";
-				char *inc_dec = (op->idx.inc_dec > 0) ?
+				const char *inc_dec = (op->idx.inc_dec > 0) ?
 					"increment" : "decrement";
 
 				printf("\t\t\t%s %s: %d\n", post_pre, inc_dec,

--- a/cstool/cstool_tms320c64x.c
+++ b/cstool/cstool_tms320c64x.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <capstone/capstone.h>
 
-void print_string_hex(char *comment, unsigned char *str, size_t len);
+void print_string_hex(const char *comment, unsigned char *str, size_t len);
 
 void print_insn_detail_tms320c64x(csh handle, cs_insn *ins)
 {

--- a/cstool/cstool_x86.c
+++ b/cstool/cstool_x86.c
@@ -5,9 +5,9 @@
 
 #include <capstone/capstone.h>
 
-void print_string_hex(char *comment, unsigned char *str, size_t len);
+void print_string_hex(const char *comment, unsigned char *str, size_t len);
 
-static char *get_eflag_name(uint64_t flag)
+static const char *get_eflag_name(uint64_t flag)
 {
 	switch(flag) {
 		default:
@@ -129,7 +129,7 @@ static char *get_eflag_name(uint64_t flag)
 	}
 }
 
-static char *get_fpu_flag_name(uint64_t flag)
+static const char *get_fpu_flag_name(uint64_t flag)
 {
 	switch (flag) {
 		default:

--- a/cstool/getopt.h
+++ b/cstool/getopt.h
@@ -6,7 +6,7 @@ int opterr = 1, /* if error message should be printed */
 optind = 1, /* index into parent argv vector */
 optopt, /* character checked for validity */
 optreset; /* reset getopt */
-char *optarg; /* argument associated with option */
+const char *optarg; /* argument associated with option */
 
 #define BADCH (int)'?'
 #define BADARG (int)':'
@@ -19,7 +19,7 @@ char *optarg; /* argument associated with option */
 int
 getopt (int nargc, char * const nargv[], const char *ostr)
 {
-	static char *place = EMSG;              /* option letter processing */
+	static const char *place = EMSG;              /* option letter processing */
 	const char *oli;                        /* option letter list index */
 
 	if (optreset || !*place) {              /* update scanning pointer */

--- a/make.sh
+++ b/make.sh
@@ -129,6 +129,7 @@ case "$TARGET" in
   "ios_armv7s" ) build_iOS armv7s $*;;
   "ios_arm64" ) build_iOS arm64 $*;;
   "osx-kernel" ) CAPSTONE_USE_SYS_DYN_MEM=yes CAPSTONE_HAS_OSXKERNEL=yes CAPSTONE_ARCHS=x86 CAPSTONE_SHARED=no CAPSTONE_BUILD_CORE_ONLY=yes ${MAKE} $*;;
+  "mac-universal" ) MACOS_UNIVERSAL=yes ${MAKE} $*;;
   "mac-universal-no" ) MACOS_UNIVERSAL=no ${MAKE} $*;;
   * )
     echo "Usage: $0 ["`grep '^  "' $0 | cut -d '"' -f 2 | tr "\\n" "|"`"]"

--- a/tests/test_arm.c
+++ b/tests/test_arm.c
@@ -14,11 +14,11 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 	int syntax;
 };
 
-static void print_string_hex(char *comment, unsigned char *str, size_t len)
+static void print_string_hex(const char *comment, unsigned char *str, size_t len)
 {
 	unsigned char *c;
 

--- a/tests/test_arm64.c
+++ b/tests/test_arm64.c
@@ -14,10 +14,10 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 };
 
-static void print_string_hex(char *comment, unsigned char *str, size_t len)
+static void print_string_hex(const char *comment, unsigned char *str, size_t len)
 {
 	unsigned char *c;
 

--- a/tests/test_basic.c
+++ b/tests/test_basic.c
@@ -12,7 +12,7 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 	cs_opt_type opt_type;
 	cs_opt_value opt_value;
 };
@@ -91,7 +91,7 @@ static void test()
 		cs_mode mode;
 		unsigned char *code;
 		size_t size;
-		char *comment;
+		const char *comment;
 		cs_opt_type opt_type;
 		cs_opt_value opt_value;
 	};

--- a/tests/test_detail.c
+++ b/tests/test_detail.c
@@ -12,7 +12,7 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 	cs_opt_type opt_type;
 	cs_opt_value opt_value;
 };

--- a/tests/test_evm.c
+++ b/tests/test_evm.c
@@ -14,10 +14,10 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 };
 
-static void print_string_hex(char *comment, unsigned char *str, size_t len)
+static void print_string_hex(const char *comment, unsigned char *str, size_t len)
 {
 	unsigned char *c;
 

--- a/tests/test_iter.c
+++ b/tests/test_iter.c
@@ -13,7 +13,7 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 	cs_opt_type opt_type;
 	cs_opt_value opt_value;
 };

--- a/tests/test_m680x.c
+++ b/tests/test_m680x.c
@@ -16,10 +16,10 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 };
 
-static void print_string_hex(char *comment, unsigned char *str, size_t len)
+static void print_string_hex(const char *comment, unsigned char *str, size_t len)
 {
 	unsigned char *c;
 
@@ -85,7 +85,7 @@ static void print_insn_detail(csh handle, cs_insn *insn)
 
 	for (i = 0; i < m680x->op_count; i++) {
 		cs_m680x_op *op = &(m680x->operands[i]);
-		char *comment;
+		const char *comment;
 
 		switch ((int)op->type) {
 		default:
@@ -157,9 +157,9 @@ static void print_insn_detail(csh handle, cs_insn *insn)
 			}
 
 			if (op->idx.inc_dec) {
-				char *post_pre = op->idx.flags &
+				const char *post_pre = op->idx.flags &
 					M680X_IDX_POST_INC_DEC ? "post" : "pre";
-				char *inc_dec = (op->idx.inc_dec > 0) ?
+				const char *inc_dec = (op->idx.inc_dec > 0) ?
 					"increment" : "decrement";
 
 				printf("\t\t\t%s %s: %d\n", post_pre, inc_dec,
@@ -328,7 +328,7 @@ static void test()
 	cs_insn *insn;
 	int i;
 	size_t count;
-	char *nine_spaces = "         ";
+	const char *nine_spaces = "         ";
 
 	if (!consistency_checks())
 		abort();

--- a/tests/test_m68k.c
+++ b/tests/test_m68k.c
@@ -11,12 +11,12 @@ struct platform {
 	cs_mode mode;
 	unsigned char* code;
 	size_t size;
-	char* comment;
+	const char* comment;
 };
 
 static csh handle;
 
-static void print_string_hex(char* comment, unsigned char* str, size_t len)
+static void print_string_hex(const char* comment, unsigned char* str, size_t len)
 {
 	unsigned char *c;
 

--- a/tests/test_mips.c
+++ b/tests/test_mips.c
@@ -12,12 +12,12 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 };
 
 static csh handle;
 
-static void print_string_hex(char *comment, unsigned char *str, size_t len)
+static void print_string_hex(const char *comment, unsigned char *str, size_t len)
 {
 	unsigned char *c;
 

--- a/tests/test_ppc.c
+++ b/tests/test_ppc.c
@@ -11,12 +11,12 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 };
 
 static csh handle;
 
-static void print_string_hex(char *comment, unsigned char *str, size_t len)
+static void print_string_hex(const char *comment, unsigned char *str, size_t len)
 {
 	unsigned char *c;
 

--- a/tests/test_skipdata.c
+++ b/tests/test_skipdata.c
@@ -12,7 +12,7 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 	cs_opt_type opt_type;
 	cs_opt_value opt_value;
 	cs_opt_type opt_skipdata;

--- a/tests/test_sparc.c
+++ b/tests/test_sparc.c
@@ -11,12 +11,12 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 };
 
 static csh handle;
 
-static void print_string_hex(char *comment, unsigned char *str, size_t len)
+static void print_string_hex(const char *comment, unsigned char *str, size_t len)
 {
 	unsigned char *c;
 

--- a/tests/test_systemz.c
+++ b/tests/test_systemz.c
@@ -11,12 +11,12 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 };
 
 static csh handle;
 
-static void print_string_hex(char *comment, unsigned char *str, size_t len)
+static void print_string_hex(const char *comment, unsigned char *str, size_t len)
 {
 	unsigned char *c;
 

--- a/tests/test_tms320c64x.c
+++ b/tests/test_tms320c64x.c
@@ -10,12 +10,12 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 };
 
 static csh handle;
 
-static void print_string_hex(char *comment, unsigned char *str, size_t len)
+static void print_string_hex(const char *comment, unsigned char *str, size_t len)
 {
 	unsigned char *c;
 

--- a/tests/test_x86.c
+++ b/tests/test_x86.c
@@ -14,12 +14,12 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 	cs_opt_type opt_type;
 	cs_opt_value opt_value;
 };
 
-static void print_string_hex(char *comment, unsigned char *str, size_t len)
+static void print_string_hex(const char *comment, unsigned char *str, size_t len)
 {
 	unsigned char *c;
 
@@ -31,7 +31,7 @@ static void print_string_hex(char *comment, unsigned char *str, size_t len)
 	printf("\n");
 }
 
-static char *get_eflag_name(uint64_t flag)
+static const char *get_eflag_name(uint64_t flag)
 {
 	switch(flag) {
 		default:

--- a/tests/test_xcore.c
+++ b/tests/test_xcore.c
@@ -11,12 +11,12 @@ struct platform {
 	cs_mode mode;
 	unsigned char *code;
 	size_t size;
-	char *comment;
+	const char *comment;
 };
 
 static csh handle;
 
-static void print_string_hex(char *comment, unsigned char *str, size_t len)
+static void print_string_hex(const char *comment, unsigned char *str, size_t len)
 {
 	unsigned char *c;
 


### PR DESCRIPTION
macOS 10.14 (Mojave) deprecated support for `i386`

Also see #1235 for more detail.