### PR TITLE
fix include path in pkg-config template

### DIFF
--- a/capstone.pc.in
+++ b/capstone.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=${prefix}/lib@LIBSUFFIX@
-includedir=${prefix}/include
+includedir=${prefix}/include/capstone
 
 Name: capstone
 Description: Capstone disassembly engine


### PR DESCRIPTION
The include path used in the pkg-config template was missing the last path component. In fact the header are under `<install_prefix>/include/capstone` and not `<install_prefix>/include`