### PR TITLE
Fix a few registry access mode mappings

### DIFF
--- a/arch/X86/X86MappingInsnOp.inc
+++ b/arch/X86/X86MappingInsnOp.inc
@@ -5947,7 +5947,7 @@
 },
 {	/* X86_MOVBE16mr, X86_INS_MOVBE: movbe{w}	$dst, $src */
 	0,
-	{ CS_AC_READ, CS_AC_READ, 0 }
+	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_MOVBE16rm, X86_INS_MOVBE: movbe{w}	$dst, $src */
 	0,
@@ -5955,7 +5955,7 @@
 },
 {	/* X86_MOVBE32mr, X86_INS_MOVBE: movbe{l}	$dst, $src */
 	0,
-	{ CS_AC_READ, CS_AC_READ, 0 }
+	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_MOVBE32rm, X86_INS_MOVBE: movbe{l}	$dst, $src */
 	0,
@@ -5963,7 +5963,7 @@
 },
 {	/* X86_MOVBE64mr, X86_INS_MOVBE: movbe{q}	$dst, $src */
 	0,
-	{ CS_AC_READ, CS_AC_READ, 0 }
+	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 {	/* X86_MOVBE64rm, X86_INS_MOVBE: movbe{q}	$dst, $src */
 	0,


### PR DESCRIPTION

Fix registry access mode mapping for movbe16mr, movbe32mr and movbe64mr