### PR TITLE
Makefile: fix 'make uninstall DESTDIR=foo' for #1311

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,7 @@ endif
 
 uninstall:
 	rm -rf $(DESTDIR)$(INCDIR)/$(LIBNAME)
-	rm -f $(DESTDIR)$(LIBDIR)/lib$(LIBNAME).*
+	rm -f $(LIBDIR)/lib$(LIBNAME).*
 	rm -f $(PKGCFGDIR)/$(LIBNAME).pc
 	rm -f $(BINDIR)/cstool
 


### PR DESCRIPTION
Uninstall was prepending `$(DESTDIR)` twice to libdir:

```Makefile
LIBDIR = $(DESTDIR)$(PREFIX)/$(LIBDIRARCH)
...
uninstall:
    ...
    rm -f $(DESTDIR)$(LIBDIR)/lib$(LIBNAME).*
```

The change drops prefixing on `uninstall` site.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>