### PR TITLE
Fix arm thb instruction shift value

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,15 @@
 This file details the changelog of Capstone.
 
 ---------------------------------
+Version 4.x: **SETDATE**
+
+
+[ Arm ]
+
+- Fix 4.0 regression: the `tbh [r0, r1, lsl #1]` instruction sets the operand.shift.value back again (see #1317)
+
+
+---------------------------------
 Version 4.0: December 18th, 2018
 
 

--- a/arch/ARM/ARMInstPrinter.c
+++ b/arch/ARM/ARMInstPrinter.c
@@ -1077,6 +1077,8 @@ static void printAddrModeTBH(MCInst *MI, unsigned Op, SStream *O)
 		MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].mem.index = MCOperand_getReg(MO2);
 	SStream_concat0(O, ", lsl #1]");
 	if (MI->csh->detail) {
+		MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].shift.type = ARM_SFT_LSL;
+		MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].shift.value = 1;
 		MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].mem.lshift = 1;
 	}
 	set_mem_access(MI, false);

--- a/include/capstone/arm.h
+++ b/include/capstone/arm.h
@@ -382,7 +382,9 @@ typedef struct arm_op_mem {
 	arm_reg index;	///< index register
 	int scale;	///< scale for index register (can be 1, or -1)
 	int disp;	///< displacement/offset value
-	int lshift;	///< left-shift on index register, or 0 if irrelevant.
+	/// left-shift on index register, or 0 if irrelevant
+	/// NOTE: this value can also be fetched via operand.shift.value
+	int lshift;
 } arm_op_mem;
 
 /// Instruction operand


### PR DESCRIPTION
For a more detailed description, see issue #1317.

Release 4.0.0 introduced a new field for ARM operands: `operand.mem.lshift`. This field was supposed to be a bug fix for #246. The #246 issue has been fixed in the meantime and the proper shift value was stored in `operand.shift.value`.

The 4.0.0 changes created a regression in which `operand.shift.value` was not set for a `tbh [r0, r1, lsl #1]` instruction on ARM and the value was set in a `operand.mem.lshift` field instead.

As the regression broke some of users codebase (e.g. in [manticore](trailofbits/manticore#1312) project), we fix it by setting `operand.shift.value` back again.

As a result, the shift value is set in two fields: `operand.shift.value` and `operand.mem.lshift`.

As the `operand.shift` also stores a `.type` field, we might want to deprecate `operand.mem.lshift` in the future.
