### PR TITLE
Add default case in MOS65XX instruction length helper

### DIFF
--- a/arch/MOS65XX/MOS65XXDisassembler.c
+++ b/arch/MOS65XX/MOS65XXDisassembler.c
@@ -373,6 +373,8 @@ static int getInstructionLength(mos65xx_address_mode am)
 		case MOS65XX_AM_INDY:
 		case MOS65XX_AM_IND:
 			return 3;
+		default:
+			return 1;
 	}
 }
 


### PR DESCRIPTION
<img width="436" alt="screenshot 2019-01-02 at 02 55 39" src="https://user-images.githubusercontent.com/917142/50578394-e89c6880-0e39-11e9-90fe-6088ab4a1d56.png">
