### PR TITLE
Fix include path in pkg-config for Makefile too (#1339).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,7 +514,7 @@ define generate-pkgcfg
 	echo 'Description: Capstone disassembly engine' >> $(PKGCFGF)
 	echo 'Version: $(PKG_VERSION)' >> $(PKGCFGF)
 	echo 'libdir=$(LIBDIR)' >> $(PKGCFGF)
-	echo 'includedir=$(INCDIR)' >> $(PKGCFGF)
+	echo 'includedir=$(INCDIR)/capstone' >> $(PKGCFGF)
 	echo 'archive=$${libdir}/libcapstone.a' >> $(PKGCFGF)
 	echo 'Libs: -L$${libdir} -lcapstone' >> $(PKGCFGF)
 	echo 'Cflags: -I$${includedir}' >> $(PKGCFGF)


### PR DESCRIPTION
Commit 0a39b785d3 fixed the pkg-config include path when using cmake.
However it didn't fix it for the Makefile.  This fixes the Makefile
path.

Signed-off-by: Richard W.M. Jones <rjones@redhat.com>