### PR TITLE
make.sh: fix ./make.sh ios issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ V ?= 0
 
 OS := $(shell uname)
 ifeq ($(OS),Darwin)
-LIBARCHS = x86_64
+LIBARCHS ?= x86_64
 PREFIX ?= /usr/local
 endif
 

--- a/make.sh
+++ b/make.sh
@@ -59,7 +59,7 @@ build_iOS() {
   fi
   export CC="$IOS_CC"
   export LIBARCHS="$IOS_ARCHS"
-  CFLAGS="$IOS_CFLAGS" LDFLAGS="$IOS_LDFLAGS" ${MAKE}
+  CFLAGS="$IOS_CFLAGS" LDFLAGS="$IOS_LDFLAGS" MACOS_UNIVERSAL=yes ${MAKE}
 }
 
 install() {


### PR DESCRIPTION
Fix issue when run ./make ios
error: Unsupported architecture #1170