### PR TITLE
Outputs in travis the offending case from corpus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,7 +497,7 @@ fuzztest:
 
 fuzzallcorp:
 ifneq ($(wildcard suite/fuzz/corpus-libFuzzer-capstone_fuzz_disasmnext-latest),)
-	./suite/fuzz/fuzz_bindisasm suite/fuzz/corpus-libFuzzer-capstone_fuzz_disasmnext-latest/
+	./suite/fuzz/fuzz_bindisasm suite/fuzz/corpus-libFuzzer-capstone_fuzz_disasmnext-latest/ > fuzz_bindisasm.log && tail -3 fuzz_bindisasm.log
 else
 	@echo "Skipping tests on whole corpus"
 endif

--- a/suite/fuzz/driverbin.c
+++ b/suite/fuzz/driverbin.c
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
         if (dir->d_type != DT_REG) {
             continue;
         }
-        //printf("Running %s\n", dir->d_name);
+        printf("Running %s\n", dir->d_name);
         fp = fopen(dir->d_name, "rb");
         if (fp == NULL) {
             r = 3;
@@ -71,6 +71,7 @@ int main(int argc, char** argv)
         fclose(fp);
     }
     closedir(d);
+    printf("Ok : whole directory finished\n");
     return r;
 }
 


### PR DESCRIPTION
Following https://github.com/aquynh/capstone/pull/1360#issuecomment-460014924

Is it ok to use `fuzz_bindisasm.log` as a temporary result file ?