### PR TITLE
Fixed TMS320C64x failed to print instructions

### DIFF
--- a/arch/TMS320C64x/TMS320C64xInstPrinter.c
+++ b/arch/TMS320C64x/TMS320C64xInstPrinter.c
@@ -68,13 +68,13 @@ void TMS320C64x_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci)
 
 		SStream_concat0(&ss, insn_asm);
 		if ((p != NULL) && (((p2 = strchr(p, '[')) != NULL) || ((p2 = strchr(p, '(')) != NULL))) {
-			while ((p2 > p) && ((*p2 != 'A') && (*p2 != 'B')))
+			while ((p2 > p) && ((*p2 != 'a') && (*p2 != 'b')))
 				p2--;
 			if (p2 == p) {
 				strcpy(insn_asm, "Invalid!");
 				return;
 			}
-			if (*p2 == 'A')
+			if (*p2 == 'a')
 				strcpy(tmp, "1T");
 			else
 				strcpy(tmp, "2T");


### PR DESCRIPTION
Fixes https://github.com/aquynh/capstone/issues/1366

This bug is caused by the incomplete refactor in
https://github.com/aquynh/capstone/commit/290828fc31df2ef60edd489df40af895907bae21#diff-c4736ee38f19ddccf2c25119ef7abf24.