### PR TITLE
Avoids overflow in getRegisterName for TMS320C64x

### DIFF
--- a/arch/TMS320C64x/TMS320C64xDisassembler.c
+++ b/arch/TMS320C64x/TMS320C64xDisassembler.c
@@ -272,6 +272,8 @@ static DecodeStatus DecodeMemOperandSc(MCInst *Inst, unsigned Val,
 	else if((base >= TMS320C64X_REG_B0) && (base <= TMS320C64X_REG_B31))
 		base = (base - TMS320C64X_REG_B0 + TMS320C64X_REG_A0);
 	basereg = getReg(GPRegsDecoderTable, base);
+	if (basereg ==  ~0U)
+		return MCDisassembler_Fail;
 
 	switch(mode) {
 		case 0:
@@ -293,6 +295,8 @@ static DecodeStatus DecodeMemOperandSc(MCInst *Inst, unsigned Val,
 			else if((offset >= TMS320C64X_REG_B0) && (offset <= TMS320C64X_REG_B31))
 				offset = (offset - TMS320C64X_REG_B0 + TMS320C64X_REG_A0);
 			offsetreg = getReg(GPRegsDecoderTable, offset);
+			if (offsetreg ==  ~0U)
+				return MCDisassembler_Fail;
 			MCOperand_CreateImm0(Inst, (scaled << 19) | (basereg << 12) | (offsetreg << 5) | (mode << 1) | unit);
 			break;
 		default:

--- a/arch/TMS320C64x/TMS320C64xGenAsmWriter.inc
+++ b/arch/TMS320C64x/TMS320C64xGenAsmWriter.inc
@@ -677,9 +677,6 @@ static char *getRegisterName(unsigned RegNo) {
     209, 231, 20, 50, 60, 
   };
 
-  if (RegNo >= sizeof(RegAsmOffset) / sizeof(uint16_t))
-    return "invalid";
-
   return AsmStrs+RegAsmOffset[RegNo-1];
 #else
   return NULL;

--- a/arch/TMS320C64x/TMS320C64xGenAsmWriter.inc
+++ b/arch/TMS320C64x/TMS320C64xGenAsmWriter.inc
@@ -677,6 +677,9 @@ static char *getRegisterName(unsigned RegNo) {
     209, 231, 20, 50, 60, 
   };
 
+  if (RegNo >= sizeof(RegAsmOffset) / sizeof(uint16_t))
+    return "invalid";
+
   return AsmStrs+RegAsmOffset[RegNo-1];
 #else
   return NULL;


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=12957
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=12965

Maybe the best fix is to avoid calling `getRegisterName` with an invalid register as is done with the other architectures, using the result from `MCOperand_getReg` as an input to `getRegisterName`