### PR TITLE
Avoid overflow in SStream.c

### DIFF
--- a/SStream.c
+++ b/SStream.c
@@ -45,6 +45,9 @@ void SStream_concat(SStream *ss, const char *fmt, ...)
 	va_list ap;
 	int ret;
 
+	if (ss->index >= sizeof(ss->buffer)) {
+		return;
+	}
 	va_start(ap, fmt);
 	ret = cs_vsnprintf(ss->buffer + ss->index, sizeof(ss->buffer) - (ss->index + 1), fmt, ap);
 	va_end(ap);


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=12988

vsnprintf may return more characters than the buffer size
So we must check for overflow...
Finally WASM has made up a disassembly more than 512 characters long...