### PR TITLE
Multiply signed integer instead of left shift

### DIFF
--- a/arch/TMS320C64x/TMS320C64xDisassembler.c
+++ b/arch/TMS320C64x/TMS320C64xDisassembler.c
@@ -244,7 +244,7 @@ static DecodeStatus DecodePCRelScst21(MCInst *Inst, unsigned Val,
 		imm |= ~((1 << 21) - 1);
 
 	/* Address is relative to the address of the first instruction in the fetch packet */
-	MCOperand_CreateImm0(Inst, (Address & ~31) + (imm << 2));
+	MCOperand_CreateImm0(Inst, (Address & ~31) + (imm * 4));
 
 	return MCDisassembler_Success;
 }


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=12962

Left shift of a signed value is undefined behavior.
Other solution would be casting to a `uint32_t`