### PR TITLE
Updates test_corpus to support new examples

### DIFF
--- a/suite/test_corpus.py
+++ b/suite/test_corpus.py
@@ -96,11 +96,14 @@ def test_file(fname):
         # ignore all the input lines having # in front.
         if line.startswith('#'):
             continue
+        if line.startswith('// '):
+            line=line[3:]
         #print("Check %s" %line)
         code = line.split(' = ')[0]
         if len(code) < 2:
             continue
-        asm  = ''.join(line.split(' = ')[1:])
+        if code.find('//') >= 0:
+            continue
         hex_code = code.replace('0x', '')
         hex_code = hex_code.replace(',', '')
         hex_data = hex_code.decode('hex')


### PR DESCRIPTION
Oss-fuzz could not build the latest capstone because it could not build the corpus with new examples in cs test files such as `// 0xd2,0xfa,0x13,0xf1 = qsub16 r1, r2, r3`

