### PR TITLE
wasm: fix misordering in cs.c

### DIFF
--- a/HACK.TXT
+++ b/HACK.TXT
@@ -86,6 +86,7 @@ Tests:
 - tests/test_iter.c
 - tests/test_newarch.c
 - suite/fuzz/fuzz_disasm.c: add the architecture and its modes to the list of fuzzed platforms
+- suite/capstone_get_setup.c
 
 Bindings:
 - bindings/Makefile

--- a/cs.c
+++ b/cs.c
@@ -209,13 +209,13 @@ static cs_err (*cs_arch_option[MAX_ARCH]) (cs_struct *, cs_opt_type, size_t valu
 #else
 	NULL,
 #endif
-#ifdef CAPSTONE_HAS_WASM
-	WASM_option,
+#ifdef CAPSTONE_HAS_MOS65XX
+	MOS65XX_option,
 #else
 	NULL,
 #endif
-#ifdef CAPSTONE_HAS_MOS65XX
-	MOS65XX_option,
+#ifdef CAPSTONE_HAS_WASM
+	WASM_option,
 #else
 	NULL,
 #endif
@@ -296,13 +296,13 @@ static cs_mode cs_arch_disallowed_mode_mask[MAX_ARCH] = {
 #else
 	0,
 #endif
-#ifdef CAPSTONE_HAS_WASM
-	0,
-#else
-    0,
-#endif
 #ifdef CAPSTONE_HAS_MOS65XX
 	~(CS_MODE_BIG_ENDIAN),
+#else
+	0,
+#endif
+#ifdef CAPSTONE_HAS_WASM
+	0,
 #else
 	0,
 #endif
@@ -352,14 +352,14 @@ static uint32_t all_arch = 0
 #ifdef CAPSTONE_HAS_EVM
 	| (1 << CS_ARCH_EVM)
 #endif
+#ifdef CAPSTONE_HAS_MOS65XX
+	| (1 << CS_ARCH_MOS65XX)
+#endif
 #ifdef CAPSTONE_HAS_WASM
 	| (1 << CS_ARCH_WASM)
 #endif
-#ifdef CAPSTONE_HAS_MOS65XX
-    | (1 << CS_ARCH_MOS65XX)
-#endif
 #ifdef CAPSTONE_HAS_BPF
-    | (1 << CS_ARCH_BPF)
+	| (1 << CS_ARCH_BPF)
 #endif
 ;
 

--- a/suite/capstone_get_setup.c
+++ b/suite/capstone_get_setup.c
@@ -8,7 +8,7 @@
  On default Capstone build, this code prints out the below output:
 
  $ capstone_get_setup
- x86=1 arm=1 arm64=1 mips=1 ppc=1 sparc=1 sysz=1 xcore=1 m68k=1 tms320c64x=1 m680x=1 evm=1 wasm=1
+ x86=1 arm=1 arm64=1 mips=1 ppc=1 sparc=1 sysz=1 xcore=1 m68k=1 tms320c64x=1 m680x=1 evm=1 wasm=1 mos65xx=1 bpf=1
 */
 
 #include <stdio.h>

--- a/tests/test_basic.c
+++ b/tests/test_basic.c
@@ -329,7 +329,7 @@ static void test()
 			(unsigned char*)WASM_CODE,
 			sizeof(WASM_CODE) - 1,
 			"WASM",
-        },
+		},
 #endif
 #ifdef CAPSTONE_HAS_MOS65XX
 		{


### PR DESCRIPTION
wasm should lay behind mos65xx (otherwise `cs_arch_disallowed_mode_mask` and `cs_arch_option` have wrong value)

also adds `suite/capstone_get_setup.c` to HACK.TXT