### PR TITLE
fix SystemZRegDesc&SystemZMCRegisterClasses number of SystemZ InitMCR…

### DIFF
--- a/arch/SystemZ/SystemZDisassembler.c
+++ b/arch/SystemZ/SystemZDisassembler.c
@@ -471,9 +471,9 @@ void SystemZ_init(MCRegisterInfo *MRI)
 			SystemZRegEncodingTable);
 	*/
 
-	MCRegisterInfo_InitMCRegisterInfo(MRI, SystemZRegDesc, 98,
+	MCRegisterInfo_InitMCRegisterInfo(MRI, SystemZRegDesc, 194,
 			0, 0,
-			SystemZMCRegisterClasses, 12,
+			SystemZMCRegisterClasses, 21,
 			0, 0,
 			SystemZRegDiffLists,
 			0,


### PR DESCRIPTION
I read the LLVM source code and count the array number of /capstone/capstone/arch/SystemZ/SystemZGenRegisterInfo.inc in this branch.
It should be 194 & 21, not 98 & 12.