### PR TITLE
Avoid overflow in SStream.c (#1381)

### DIFF
--- a/SStream.c
+++ b/SStream.c
@@ -45,6 +45,9 @@ void SStream_concat(SStream *ss, const char *fmt, ...)
 	va_list ap;
 	int ret;
 
+	if (ss->index >= sizeof(ss->buffer)) {
+		return;
+	}
 	va_start(ap, fmt);
 	ret = cs_vsnprintf(ss->buffer + ss->index, sizeof(ss->buffer) - (ss->index + 1), fmt, ap);
 	va_end(ap);


### PR DESCRIPTION
I think that this was wrongfully removed by commit 5a99624074d56f8eea26699496f0e8dc41cbf3fb

`cs_vsnprintf` returns the number of bytes that could have been written, ie that can exceed the specified size of the buffer