### PR TITLE
[M68K] store correct register value in op.reg_pair

### DIFF
--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -975,21 +975,21 @@ static void build_cas2(m68k_info *info, int size)
 
 	op0->address_mode = M68K_AM_NONE;
 	op0->type = M68K_OP_REG_PAIR;
-	op0->reg_pair.reg_0 = (extension >> 16) & 7;
-	op0->reg_pair.reg_1 = extension & 7;
+	op0->reg_pair.reg_0 = ((extension >> 16) & 7) + M68K_REG_D0;
+	op0->reg_pair.reg_1 = (extension & 7) + M68K_REG_D0;
 
 	op1->address_mode = M68K_AM_NONE;
 	op1->type = M68K_OP_REG_PAIR;
-	op1->reg_pair.reg_0 = (extension >> 22) & 7;
-	op1->reg_pair.reg_1 = (extension >> 6) & 7;
+	op1->reg_pair.reg_0 = ((extension >> 22) & 7) + M68K_REG_D0;
+	op1->reg_pair.reg_1 = ((extension >> 6) & 7) + M68K_REG_D0;
 
 	reg_0 = (extension >> 28) & 7;
 	reg_1 = (extension >> 12) & 7;
 
 	op2->address_mode = M68K_AM_NONE;
 	op2->type = M68K_OP_REG_PAIR;
-	op2->reg_pair.reg_0 = reg_0 + (BIT_1F(extension) ? 8 : 0);
-	op2->reg_pair.reg_1 = reg_1 + (BIT_F(extension) ? 8 : 0);
+	op2->reg_pair.reg_0 = reg_0 + (BIT_1F(extension) ? 8 : 0) + M68K_REG_D0;
+	op2->reg_pair.reg_1 = reg_1 + (BIT_F(extension) ? 8 : 0) + M68K_REG_D0;
 }
 
 static void build_chk2_cmp2(m68k_info *info, int size)
@@ -2233,8 +2233,8 @@ static void d68020_divl(m68k_info *info)
 
 	op1->address_mode = M68K_AM_NONE;
 	op1->type = M68K_OP_REG_PAIR;
-	op1->reg_pair.reg_0 = reg_0;
-	op1->reg_pair.reg_1 = reg_1;
+	op1->reg_pair.reg_0 = reg_0 + M68K_REG_D0;
+	op1->reg_pair.reg_1 = reg_1 + M68K_REG_D0;
 
 	if ((reg_0 == reg_1) || !BIT_A(extension)) {
 		op1->type = M68K_OP_REG;
@@ -2778,8 +2778,8 @@ static void d68020_mull(m68k_info *info)
 
 	op1->address_mode = M68K_AM_NONE;
 	op1->type = M68K_OP_REG_PAIR;
-	op1->reg_pair.reg_0 = reg_0;
-	op1->reg_pair.reg_1 = reg_1;
+	op1->reg_pair.reg_0 = reg_0 + M68K_REG_D0;
+	op1->reg_pair.reg_1 = reg_1 + M68K_REG_D0;
 
 	if (!BIT_A(extension)) {
 		op1->type = M68K_OP_REG;
@@ -3496,8 +3496,8 @@ static void update_op_reg_list(m68k_info *info, cs_m68k_op *op, int write)
 			break;
 
 		case M68K_OP_REG_PAIR:
-			add_reg_to_rw_list(info, M68K_REG_D0 + op->reg_pair.reg_0, write);
-			add_reg_to_rw_list(info, M68K_REG_D0 + op->reg_pair.reg_1, write);
+			add_reg_to_rw_list(info, op->reg_pair.reg_0, write);
+			add_reg_to_rw_list(info, op->reg_pair.reg_1, write);
 			break;
 	}
 }

--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -27,7 +27,7 @@
  * THE SOFTWARE.
  */
 
-/* The code bellow is based on MUSASHI but has been heavily modified for Capstone by
+/* The code below is based on MUSASHI but has been heavily modified for Capstone by
  * Daniel Collin <daniel@collin.com> 2015-2019 */
 
 /* ======================================================================== */

--- a/arch/M68K/M68KInstPrinter.c
+++ b/arch/M68K/M68KInstPrinter.c
@@ -124,8 +124,8 @@ static void registerBits(SStream* O, const cs_m68k_op* op)
 
 static void registerPair(SStream* O, const cs_m68k_op* op)
 {
-	SStream_concat(O, "%s:%s", s_reg_names[M68K_REG_D0 + op->reg_pair.reg_0],
-			s_reg_names[M68K_REG_D0 + op->reg_pair.reg_1]);
+	SStream_concat(O, "%s:%s", s_reg_names[op->reg_pair.reg_0],
+			s_reg_names[op->reg_pair.reg_1]);
 }
 
 static void printAddressingMode(SStream* O, unsigned int pc, const cs_m68k* inst, const cs_m68k_op* op)

--- a/tests/test_m68k.c
+++ b/tests/test_m68k.c
@@ -137,7 +137,12 @@ static void print_insn_detail(cs_insn *ins)
 				break;
 			case M68K_OP_REG_BITS:
 				printf("\t\toperands[%u].type: REG_BITS = $%x\n", i, op->register_bits);
-
+				break;
+			case M68K_OP_REG_PAIR:
+				printf("\t\toperands[%u].type: REG_PAIR = (%s, %s)\n", i,
+					cs_reg_name(handle, op->reg_pair.reg_0),
+					cs_reg_name(handle, op->reg_pair.reg_1));
+				break;
 		}
 	}
 


### PR DESCRIPTION
Fixes #1406 

Also fixes a small type in the licensing text.