### PR TITLE
Fixes uninitialized memory for X86 BND instructions

### DIFF
--- a/arch/X86/X86ATTInstPrinter.c
+++ b/arch/X86/X86ATTInstPrinter.c
@@ -788,9 +788,17 @@ static void printanymem(MCInst *MI, unsigned OpNo, SStream *O)
 				 break;
 		case X86_LEA32r:
 		case X86_LEA64_32r:
+		case X86_BNDCL32rm:
+		case X86_BNDCN32rm:
+		case X86_BNDCU32rm:
+		case X86_BNDSTXmr:
+		case X86_BNDLDXrm:
 				 MI->x86opsize = 4;
 				 break;
 		case X86_LEA64r:
+		case X86_BNDCL64rm:
+		case X86_BNDCN64rm:
+		case X86_BNDCU64rm:
 				 MI->x86opsize = 8;
 				 break;
 	}

--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -1006,8 +1006,16 @@ static void printanymem(MCInst *MI, unsigned OpNo, SStream *O)
 				 break;
 		case X86_LEA32r:
 		case X86_LEA64_32r:
+		case X86_BNDCL32rm:
+		case X86_BNDCN32rm:
+		case X86_BNDCU32rm:
+		case X86_BNDSTXmr:
+		case X86_BNDLDXrm:
 				 MI->x86opsize = 4;
 				 break;
+		case X86_BNDCL64rm:
+		case X86_BNDCN64rm:
+		case X86_BNDCU64rm:
 		case X86_LEA64r:
 				 MI->x86opsize = 8;
 				 break;


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=13466

What about `X86_BNDCL32rr` and such ? Should they be added too ?
Or is the fix for 13467 supposed to work for this one too ?

