### PR TITLE
Avoids type confusion in cpu12 for M680X

### DIFF
--- a/arch/M680X/M680XDisassembler.c
+++ b/arch/M680X/M680XDisassembler.c
@@ -1709,7 +1709,7 @@ static void ext_idx12_x_hdlr(MCInst *MI, m680x_info *info, uint16_t *address)
 	indexed12_hdlr(MI, info, address);
 	read_word(info, &imm16, *address);
 	op0->type = M680X_OP_EXTENDED;
-	op0->imm = (int16_t)imm16;
+	op0->ext.address = (int16_t)imm16;
 	set_operand_size(info, op0, 1);
 }
 


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=13487

Either the union is `int32_t imm` or it is `m680x_op_ext ext`
But it cannot be both at the same time