### PR TITLE
Corpus generation is more robust

### DIFF
--- a/suite/test_corpus.py
+++ b/suite/test_corpus.py
@@ -115,7 +115,10 @@ def test_file(fname):
             continue
         hex_code = code.replace('0x', '')
         hex_code = hex_code.replace(',', '')
-        hex_data = hex_code.decode('hex')
+        try:
+            hex_data = hex_code.strip().decode('hex')
+        except:
+            print "skipping", hex_code
         fout = open("fuzz/corpus/%s_%s" % (os.path.basename(fname), hex_code), 'w')
         if (arch, mode) not in mc_modes:
             print "fail", arch, mode


### PR DESCRIPTION
This should fix oss-fuzz build

(Line `// issues` in suite/MC/RISCV/insn-riscv32.s.cs was interpreted as sample hex data)