### PR TITLE
tms320c64x: remove extra indent

### DIFF
--- a/arch/TMS320C64x/TMS320C64xInstPrinter.c
+++ b/arch/TMS320C64x/TMS320C64xInstPrinter.c
@@ -70,8 +70,6 @@ void TMS320C64x_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci)
 		SStream_Init(&ss);
 		if (tms320c64x->condition.reg != TMS320C64X_REG_INVALID)
 			SStream_concat(&ss, "[%c%s]|", (tms320c64x->condition.zero == 1) ? '!' : '|', cs_reg_name(ud, tms320c64x->condition.reg));
-		else
-			SStream_concat0(&ss, "||||||");
 
 		p = strchr(insn_asm, '\t');
 		if (p != NULL)


### PR DESCRIPTION
Fixes #1418

`TMS320C64x_post_printer()` added `"|||||"` to the beginning of the mnemonic.
`fill_insn()` replaced `'|'` with `' '`, which caused the extra whitespace.

Someone more familiar with tms320c64x should make sure this makes sense.