### PR TITLE
Adds info for ARM brkdiv0

### DIFF
--- a/arch/ARM/ARMGenInstrInfo.inc
+++ b/arch/ARM/ARMGenInstrInfo.inc
@@ -2979,6 +2979,7 @@ enum {
 	ARM_tUDF	= 3213,
 	ARM_tUXTB	= 3214,
 	ARM_tUXTH	= 3215,
+	ARM_t__brkdiv0	= 3216,
 	ARM_INSTRUCTION_LIST_END = 3217
 };
 

--- a/arch/ARM/ARMMappingInsn.inc
+++ b/arch/ARM/ARMMappingInsn.inc
@@ -18769,3 +18769,10 @@
 	{ 0 }, { 0 }, { ARM_GRP_THUMB, ARM_GRP_THUMB1ONLY, ARM_GRP_V6, 0 }, 0, 0
 #endif
 },
+
+{
+	ARM_t__brkdiv0, ARM64_INS_BRK,
+#ifndef CAPSTONE_DIET
+	{ 0 }, { 0 }, { ARM_GRP_THUMB, ARM_GRP_THUMB1ONLY, ARM_GRP_V6, 0 }, 0, 0
+#endif
+},

--- a/arch/ARM/ARMMappingInsnOp.inc
+++ b/arch/ARM/ARMMappingInsnOp.inc
@@ -10726,3 +10726,7 @@
 {	/* ARM_tUXTH, ARM_INS_UXTH: uxth */
 	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
+
+{	/* ARM_t__brkdiv0, ARM_INS_BRK: brkdiv0 */
+	{ CS_AC_WRITE, CS_AC_READ, 0 }
+},


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=13768

I am not sure if I filled it correctly and completely but there is info missing for this new ARM instruction