### PR TITLE
M680X: nit: Also use lowercase 'pcr'

### DIFF
--- a/arch/M680X/M680XInstPrinter.c
+++ b/arch/M680X/M680XInstPrinter.c
@@ -196,7 +196,7 @@ static void printOperand(MCInst *MI, SStream *O, m680x_info *info,
 
 		if (op->idx.base_reg == M680X_REG_PC &&
 			(op->idx.offset_bits > 0))
-			SStream_concat(O, "R");
+			SStream_concat(O, "r");
 
 		printIncDec(true, O, info, op);
 


### PR DESCRIPTION
- This occurs for M6809/HD6309/CPU12 PC relative indexed addressing.
  In this case the register is referenced as pcr (and not pc).
- This is a consequence of lowercase registers introduced in
  cc8da331d36ae6f6565057d467bc829bc3316317
- Example: lda   $FD00,pcr (instead of lda   $FD00,pcR)