### PR TITLE
msvc: Bugfix for compile errors.

### DIFF
--- a/msvc/capstone_dll/capstone_dll.vcxproj
+++ b/msvc/capstone_dll/capstone_dll.vcxproj
@@ -84,7 +84,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;_DEBUG;_WINDOWS;_USRDLL;CAPSTONE_SHARED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_EVM;CAPSTONE_HAS_M680X;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_WASM;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;_DEBUG;_WINDOWS;_USRDLL;CAPSTONE_SHARED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -102,7 +102,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;_DEBUG;_WINDOWS;_USRDLL;CAPSTONE_SHARED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_EVM;CAPSTONE_HAS_M680X;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_WASM;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;_DEBUG;_WINDOWS;_USRDLL;CAPSTONE_SHARED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -122,7 +122,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;NDEBUG;_WINDOWS;_USRDLL;CAPSTONE_SHARED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_EVM;CAPSTONE_HAS_M680X;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_WASM;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;NDEBUG;_WINDOWS;_USRDLL;CAPSTONE_SHARED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -144,7 +144,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;NDEBUG;_WINDOWS;_USRDLL;CAPSTONE_SHARED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_EVM;CAPSTONE_HAS_M680X;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_WASM;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;NDEBUG;_WINDOWS;_USRDLL;CAPSTONE_SHARED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -168,6 +168,17 @@
     <ClCompile Include="..\..\arch\ARM\ARMInstPrinter.c" />
     <ClCompile Include="..\..\arch\ARM\ARMMapping.c" />
     <ClCompile Include="..\..\arch\ARM\ARMModule.c" />
+    <ClCompile Include="..\..\arch\BPF\BPFDisassembler.c" />
+    <ClCompile Include="..\..\arch\BPF\BPFInstPrinter.c" />
+    <ClCompile Include="..\..\arch\BPF\BPFMapping.c" />
+    <ClCompile Include="..\..\arch\BPF\BPFModule.c" />
+    <ClCompile Include="..\..\arch\EVM\EVMDisassembler.c" />
+    <ClCompile Include="..\..\arch\EVM\EVMInstPrinter.c" />
+    <ClCompile Include="..\..\arch\EVM\EVMMapping.c" />
+    <ClCompile Include="..\..\arch\EVM\EVMModule.c" />
+    <ClCompile Include="..\..\arch\M680X\M680XDisassembler.c" />
+    <ClCompile Include="..\..\arch\M680X\M680XInstPrinter.c" />
+    <ClCompile Include="..\..\arch\M680X\M680XModule.c" />
     <ClCompile Include="..\..\arch\M68K\M68KDisassembler.c" />
     <ClCompile Include="..\..\arch\M68K\M68KInstPrinter.c" />
     <ClCompile Include="..\..\arch\M68K\M68KModule.c" />
@@ -179,6 +190,10 @@
     <ClCompile Include="..\..\arch\PowerPC\PPCInstPrinter.c" />
     <ClCompile Include="..\..\arch\PowerPC\PPCMapping.c" />
     <ClCompile Include="..\..\arch\PowerPC\PPCModule.c" />
+    <ClCompile Include="..\..\arch\RISCV\RISCVDisassembler.c" />
+    <ClCompile Include="..\..\arch\RISCV\RISCVInstPrinter.c" />
+    <ClCompile Include="..\..\arch\RISCV\RISCVMapping.c" />
+    <ClCompile Include="..\..\arch\RISCV\RISCVModule.c" />
     <ClCompile Include="..\..\arch\Sparc\SparcDisassembler.c" />
     <ClCompile Include="..\..\arch\Sparc\SparcInstPrinter.c" />
     <ClCompile Include="..\..\arch\Sparc\SparcMapping.c" />
@@ -188,9 +203,14 @@
     <ClCompile Include="..\..\arch\SystemZ\SystemZMapping.c" />
     <ClCompile Include="..\..\arch\SystemZ\SystemZMCTargetDesc.c" />
     <ClCompile Include="..\..\arch\SystemZ\SystemZModule.c" />
+    <ClCompile Include="..\..\arch\WASM\WASMDisassembler.c" />
+    <ClCompile Include="..\..\arch\WASM\WASMInstPrinter.c" />
+    <ClCompile Include="..\..\arch\WASM\WASMMapping.c" />
+    <ClCompile Include="..\..\arch\WASM\WASMModule.c" />
     <ClCompile Include="..\..\arch\X86\X86ATTInstPrinter.c" />
     <ClCompile Include="..\..\arch\X86\X86Disassembler.c" />
     <ClCompile Include="..\..\arch\X86\X86DisassemblerDecoder.c" />
+    <ClCompile Include="..\..\arch\X86\X86InstPrinterCommon.c" />
     <ClCompile Include="..\..\arch\X86\X86IntelInstPrinter.c" />
     <ClCompile Include="..\..\arch\X86\X86Mapping.c" />
     <ClCompile Include="..\..\arch\X86\X86Module.c" />

--- a/msvc/capstone_static/capstone_static.vcxproj
+++ b/msvc/capstone_static/capstone_static.vcxproj
@@ -28,6 +28,17 @@
     <ClCompile Include="..\..\arch\ARM\ARMInstPrinter.c" />
     <ClCompile Include="..\..\arch\ARM\ARMMapping.c" />
     <ClCompile Include="..\..\arch\ARM\ARMModule.c" />
+    <ClCompile Include="..\..\arch\BPF\BPFDisassembler.c" />
+    <ClCompile Include="..\..\arch\BPF\BPFInstPrinter.c" />
+    <ClCompile Include="..\..\arch\BPF\BPFMapping.c" />
+    <ClCompile Include="..\..\arch\BPF\BPFModule.c" />
+    <ClCompile Include="..\..\arch\EVM\EVMDisassembler.c" />
+    <ClCompile Include="..\..\arch\EVM\EVMInstPrinter.c" />
+    <ClCompile Include="..\..\arch\EVM\EVMMapping.c" />
+    <ClCompile Include="..\..\arch\EVM\EVMModule.c" />
+    <ClCompile Include="..\..\arch\M680X\M680XDisassembler.c" />
+    <ClCompile Include="..\..\arch\M680X\M680XInstPrinter.c" />
+    <ClCompile Include="..\..\arch\M680X\M680XModule.c" />
     <ClCompile Include="..\..\arch\M68K\M68KDisassembler.c" />
     <ClCompile Include="..\..\arch\M68K\M68KInstPrinter.c" />
     <ClCompile Include="..\..\arch\M68K\M68KModule.c" />
@@ -39,6 +50,10 @@
     <ClCompile Include="..\..\arch\PowerPC\PPCInstPrinter.c" />
     <ClCompile Include="..\..\arch\PowerPC\PPCMapping.c" />
     <ClCompile Include="..\..\arch\PowerPC\PPCModule.c" />
+    <ClCompile Include="..\..\arch\RISCV\RISCVDisassembler.c" />
+    <ClCompile Include="..\..\arch\RISCV\RISCVInstPrinter.c" />
+    <ClCompile Include="..\..\arch\RISCV\RISCVMapping.c" />
+    <ClCompile Include="..\..\arch\RISCV\RISCVModule.c" />
     <ClCompile Include="..\..\arch\Sparc\SparcDisassembler.c" />
     <ClCompile Include="..\..\arch\Sparc\SparcInstPrinter.c" />
     <ClCompile Include="..\..\arch\Sparc\SparcMapping.c" />
@@ -48,9 +63,14 @@
     <ClCompile Include="..\..\arch\SystemZ\SystemZMapping.c" />
     <ClCompile Include="..\..\arch\SystemZ\SystemZMCTargetDesc.c" />
     <ClCompile Include="..\..\arch\SystemZ\SystemZModule.c" />
+    <ClCompile Include="..\..\arch\WASM\WASMDisassembler.c" />
+    <ClCompile Include="..\..\arch\WASM\WASMInstPrinter.c" />
+    <ClCompile Include="..\..\arch\WASM\WASMMapping.c" />
+    <ClCompile Include="..\..\arch\WASM\WASMModule.c" />
     <ClCompile Include="..\..\arch\X86\X86ATTInstPrinter.c" />
     <ClCompile Include="..\..\arch\X86\X86Disassembler.c" />
     <ClCompile Include="..\..\arch\X86\X86DisassemblerDecoder.c" />
+    <ClCompile Include="..\..\arch\X86\X86InstPrinterCommon.c" />
     <ClCompile Include="..\..\arch\X86\X86IntelInstPrinter.c" />
     <ClCompile Include="..\..\arch\X86\X86Mapping.c" />
     <ClCompile Include="..\..\arch\X86\X86Module.c" />
@@ -128,7 +148,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_EVM;CAPSTONE_HAS_M680X;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_WASM;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -144,7 +164,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_EVM;CAPSTONE_HAS_M680X;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_WASM;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -162,7 +182,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_EVM;CAPSTONE_HAS_M680X;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_WASM;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -182,7 +202,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CAPSTONE_X86_ATT_DISABLE_NO;CAPSTONE_DIET_NO;CAPSTONE_X86_REDUCE_NO;CAPSTONE_HAS_ARM;CAPSTONE_HAS_ARM64;CAPSTONE_HAS_EVM;CAPSTONE_HAS_M680X;CAPSTONE_HAS_M68K;CAPSTONE_HAS_MIPS;CAPSTONE_HAS_POWERPC;CAPSTONE_HAS_SPARC;CAPSTONE_HAS_SYSZ;CAPSTONE_HAS_WASM;CAPSTONE_HAS_X86;CAPSTONE_HAS_XCORE;CAPSTONE_USE_SYS_DYN_MEM;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\include;..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/msvc/cstool/cstool.vcxproj
+++ b/msvc/cstool/cstool.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{A5AB9988-6B03-4F0D-8D40-9440BBC8B03D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>cstool</RootNamespace>
-	<ProjectName>cstool</ProjectName>
+    <ProjectName>cstool</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -157,15 +157,21 @@
     <ClCompile Include="..\..\cstool\cstool.c" />
     <ClCompile Include="..\..\cstool\cstool_arm.c" />
     <ClCompile Include="..\..\cstool\cstool_arm64.c" />
+    <ClCompile Include="..\..\cstool\cstool_bpf.c" />
+    <ClCompile Include="..\..\cstool\cstool_evm.c" />
     <ClCompile Include="..\..\cstool\cstool_m680x.c" />
     <ClCompile Include="..\..\cstool\cstool_m68k.c" />
     <ClCompile Include="..\..\cstool\cstool_mips.c" />
+    <ClCompile Include="..\..\cstool\cstool_mos65xx.c" />
     <ClCompile Include="..\..\cstool\cstool_ppc.c" />
+    <ClCompile Include="..\..\cstool\cstool_riscv.c" />
     <ClCompile Include="..\..\cstool\cstool_sparc.c" />
     <ClCompile Include="..\..\cstool\cstool_systemz.c" />
     <ClCompile Include="..\..\cstool\cstool_tms320c64x.c" />
+    <ClCompile Include="..\..\cstool\cstool_wasm.c" />
     <ClCompile Include="..\..\cstool\cstool_x86.c" />
     <ClCompile Include="..\..\cstool\cstool_xcore.c" />
+    <ClCompile Include="..\..\cstool\getopt.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
- Add archs BPF, EVM, M680X, RISCV and WASM to
  capstone_dll, capstone_static and cstool projects.
- Add getopt.c to cstool project.
- Add X86InstPrinterCommon.c to capstone_dll
  and capstone_static project.