### PR TITLE
Python binding handling of bytearrays

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -1053,11 +1053,11 @@ class Cs(object):
             print(code)
             code = code.encode()
             print(code)'''
-        # Hi, Hacker! Unicorn's memory accessors give you back bytearrays, but they
-        # cause TypeErrors when you hand them into Capstone.
+        # Pass a bytearray by reference
+        size = len(code)
         if isinstance(code, bytearray):
-            code = bytes(code)
-        res = _cs.cs_disasm(self.csh, code, len(code), offset, count, ctypes.byref(all_insn))
+            code = ctypes.byref(ctypes.c_char.from_buffer(code))
+        res = _cs.cs_disasm(self.csh, code, size, offset, count, ctypes.byref(all_insn))
         if res > 0:
             try:
                 for i in range(res):
@@ -1081,11 +1081,11 @@ class Cs(object):
             raise CsError(CS_ERR_DIET)
 
         all_insn = ctypes.POINTER(_cs_insn)()
-        # Hi, Hacker! Unicorn's memory accessors give you back bytearrays, but they
-        # cause TypeErrors when you hand them into Capstone.
+        size = len(code)
+        # Pass a bytearray by reference
         if isinstance(code, bytearray):
-            code = bytes(code)
-        res = _cs.cs_disasm(self.csh, code, len(code), offset, count, ctypes.byref(all_insn))
+            code = ctypes.byref(ctypes.c_char.from_buffer(code))
+        res = _cs.cs_disasm(self.csh, code, size, offset, count, ctypes.byref(all_insn))
         if res > 0:
             try:
                 for i in range(res):


### PR DESCRIPTION
I'm not very familiar with the capstone code but surely it would be better to pass bytearrays by reference instead of making a copy using `bytes`? This can be done by passing the bytearray to  `from_buffer` on the relevant ctype.