### PR TITLE
x86: fix call/jmp access mode of mem operand

### DIFF
--- a/arch/X86/X86MappingInsnOp.inc
+++ b/arch/X86/X86MappingInsnOp.inc
@@ -1179,7 +1179,7 @@
 },
 {	/* X86_CALL16m, X86_INS_CALL: call{w}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_CALL16r, X86_INS_CALL: call{w}	{*}$dst */
 	0,
@@ -1187,7 +1187,7 @@
 },
 {	/* X86_CALL32m, X86_INS_CALL: call{l}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_CALL32r, X86_INS_CALL: call{l}	{*}$dst */
 	0,
@@ -1195,7 +1195,7 @@
 },
 {	/* X86_CALL64m, X86_INS_CALL: call{q}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_CALL64pcrel32, X86_INS_CALL: call{q}	$dst */
 	0,
@@ -2459,7 +2459,7 @@
 },
 {	/* X86_FARCALL16m, X86_INS_LCALL: lcall{w}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_FARCALL32i, X86_INS_LCALL: lcall{l}	$seg : $off */
 	0,
@@ -2467,7 +2467,7 @@
 },
 {	/* X86_FARCALL32m, X86_INS_LCALL: lcall{l}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_FARCALL64, X86_INS_LCALL: lcall{q}	{*}$dst */
 	0,
@@ -2479,7 +2479,7 @@
 },
 {	/* X86_FARJMP16m, X86_INS_LJMP: ljmp{w}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_FARJMP32i, X86_INS_LJMP: ljmp{l}	$seg : $off */
 	0,
@@ -2487,7 +2487,7 @@
 },
 {	/* X86_FARJMP32m, X86_INS_LJMP: ljmp{l}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_FARJMP64, X86_INS_LJMP: ljmp{q}	{*}$dst */
 	0,
@@ -3743,7 +3743,7 @@
 },
 {	/* X86_JMP16m, X86_INS_JMP: jmp{w}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_JMP16r, X86_INS_JMP: jmp{w}	{*}$dst */
 	0,
@@ -3751,7 +3751,7 @@
 },
 {	/* X86_JMP32m, X86_INS_JMP: jmp{l}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_JMP32r, X86_INS_JMP: jmp{l}	{*}$dst */
 	0,
@@ -3759,7 +3759,7 @@
 },
 {	/* X86_JMP64m, X86_INS_JMP: jmp{q}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_JMP64r, X86_INS_JMP: jmp{q}	{*}$dst */
 	0,

--- a/arch/X86/X86MappingInsnOp_reduce.inc
+++ b/arch/X86/X86MappingInsnOp_reduce.inc
@@ -971,7 +971,7 @@
 },
 {	/* X86_CALL16m, X86_INS_CALL: call{w}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_CALL16r, X86_INS_CALL: call{w}	{*}$dst */
 	0,
@@ -979,7 +979,7 @@
 },
 {	/* X86_CALL32m, X86_INS_CALL: call{l}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_CALL32r, X86_INS_CALL: call{l}	{*}$dst */
 	0,
@@ -987,7 +987,7 @@
 },
 {	/* X86_CALL64m, X86_INS_CALL: call{q}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_CALL64pcrel32, X86_INS_CALL: call{q}	$dst */
 	0,
@@ -1747,7 +1747,7 @@
 },
 {	/* X86_FARCALL16m, X86_INS_LCALL: lcall{w}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_FARCALL32i, X86_INS_LCALL: lcall{l}	$seg : $off */
 	0,
@@ -1755,7 +1755,7 @@
 },
 {	/* X86_FARCALL32m, X86_INS_LCALL: lcall{l}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_FARCALL64, X86_INS_LCALL: lcall{q}	{*}$dst */
 	0,
@@ -1767,7 +1767,7 @@
 },
 {	/* X86_FARJMP16m, X86_INS_LJMP: ljmp{w}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_FARJMP32i, X86_INS_LJMP: ljmp{l}	$seg : $off */
 	0,
@@ -1775,7 +1775,7 @@
 },
 {	/* X86_FARJMP32m, X86_INS_LJMP: ljmp{l}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_FARJMP64, X86_INS_LJMP: ljmp{q}	{*}$dst */
 	0,
@@ -2191,7 +2191,7 @@
 },
 {	/* X86_JMP16m, X86_INS_JMP: jmp{w}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_JMP16r, X86_INS_JMP: jmp{w}	{*}$dst */
 	0,
@@ -2199,7 +2199,7 @@
 },
 {	/* X86_JMP32m, X86_INS_JMP: jmp{l}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_JMP32r, X86_INS_JMP: jmp{l}	{*}$dst */
 	0,
@@ -2207,7 +2207,7 @@
 },
 {	/* X86_JMP64m, X86_INS_JMP: jmp{q}	{*}$dst */
 	0,
-	{ CS_AC_IGNORE, 0 }
+	{ CS_AC_READ, 0 }
 },
 {	/* X86_JMP64r, X86_INS_JMP: jmp{q}	{*}$dst */
 	0,


### PR DESCRIPTION
This PR fixes the access mode of the memory operand for variants of `call` and `jmp` instructions. Currently, this access mode is set to `CS_AC_IGNORE`. The fixed mode is `CS_AC_READ`

In order to check the fix, I provide sample hex code of instructions `jmp	qword ptr [rax*8 + 0x4edbe0]` and `call	qword ptr [rax*8 + 0x4edbe0]` respectively. 

```
cstool -d x64 "ff 24 c5 e0 db 4e 00"
```
```
cstool -d x64 "ff 14 c5 e0 db 4e 00"
```

