### PR TITLE
m680x: remove calls to fprintf, abort

### DIFF
--- a/arch/M680X/M680XDisassembler.c
+++ b/arch/M680X/M680XDisassembler.c
@@ -932,8 +932,6 @@ static bool is_sufficient_code_size(const m680x_info *info, uint16_t address,
 			break;
 
 		default:
-			fprintf(stderr, "Internal error: Unexpected instruction "
-				"handler id %d\n", insn_description->hid[i]);
 			retval = false;
 			break;
 		}
@@ -1114,9 +1112,8 @@ static void reg_bits_hdlr(MCInst *MI, m680x_info *info, uint16_t *address)
 		break;
 
 	default:
-		fprintf(stderr, "Internal error: Unexpected operand0 register "
-			"%d\n", op0->reg);
-		abort();
+		// Should never happen
+		return;
 	}
 
 	if ((info->insn == M680X_INS_PULU ||
@@ -1560,8 +1557,6 @@ static void immediate_hdlr(MCInst *MI, m680x_info *info, uint16_t *address)
 
 	default:
 		op->imm = 0;
-		fprintf(stderr, "Internal error: Unexpected immediate byte "
-			"size %d.\n", op->size);
 	}
 
 	*address += op->size;
@@ -1766,8 +1761,6 @@ static void loop_hdlr(MCInst *MI, m680x_info *info, uint16_t *address)
 	info->insn = index_to_insn_id[(post_byte >> 5) & 0x07];
 
 	if (info->insn == M680X_INS_ILLGL) {
-		fprintf(stderr, "Internal error: Unexpected post byte "
-			"in loop instruction %02x.\n", post_byte);
 		illegal_hdlr(MI, info, address);
 	};
 
@@ -2145,8 +2138,6 @@ static bool m680x_setup_internals(m680x_info *info, e_cpu_type cpu_type,
 	const uint8_t *code, uint16_t code_len)
 {
 	if (cpu_type == M680X_CPU_TYPE_INVALID) {
-		fprintf(stderr, "M680X_CPU_TYPE_%s is not suppported\n",
-			s_cpu_type[cpu_type]);
 		return false;
 	}
 
@@ -2224,86 +2215,50 @@ bool M680X_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 cs_err M680X_disassembler_init(cs_struct *ud)
 {
 	if (M680X_REG_ENDING != ARR_SIZE(g_m6800_reg_byte_size)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"m680x_reg and g_m6800_reg_byte_size\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (M680X_REG_ENDING != ARR_SIZE(g_m6801_reg_byte_size)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"m680x_reg and g_m6801_reg_byte_size\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (M680X_REG_ENDING != ARR_SIZE(g_m6805_reg_byte_size)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"m680x_reg and g_m6805_reg_byte_size\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (M680X_REG_ENDING != ARR_SIZE(g_m6808_reg_byte_size)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"m680x_reg and g_m6808_reg_byte_size\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (M680X_REG_ENDING != ARR_SIZE(g_m6811_reg_byte_size)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"m680x_reg and g_m6811_reg_byte_size\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (M680X_REG_ENDING != ARR_SIZE(g_cpu12_reg_byte_size)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"m680x_reg and g_cpu12_reg_byte_size\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (M680X_REG_ENDING != ARR_SIZE(g_m6809_reg_byte_size)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"m680x_reg and g_m6809_reg_byte_size\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (M680X_INS_ENDING != ARR_SIZE(g_insn_props)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"m680x_insn and g_insn_props\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (M680X_CPU_TYPE_ENDING != ARR_SIZE(s_cpu_type)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"e_cpu_type and s_cpu_type\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (M680X_CPU_TYPE_ENDING != ARR_SIZE(g_cpu_tables)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"e_cpu_type and g_cpu_tables\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (HANDLER_ID_ENDING != ARR_SIZE(g_insn_handler)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"insn_hdlr_id and g_insn_handler\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (ACCESS_MODE_ENDING !=  MATRIX_SIZE(g_access_mode_to_access)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"e_access_mode and g_access_mode_to_access\n");
-
 		return CS_ERR_MODE;
 	}
 

--- a/arch/M680X/M680XInstPrinter.c
+++ b/arch/M680X/M680XInstPrinter.c
@@ -336,23 +336,14 @@ cs_err M680X_instprinter_init(cs_struct *ud)
 #ifndef CAPSTONE_DIET
 
 	if (M680X_REG_ENDING != ARR_SIZE(s_reg_names)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"m680x_reg and s_reg_names\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (M680X_INS_ENDING != ARR_SIZE(s_instruction_names)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"m680x_insn and s_instruction_names\n");
-
 		return CS_ERR_MODE;
 	}
 
 	if (M680X_GRP_ENDING != ARR_SIZE(s_group_names)) {
-		fprintf(stderr, "Internal error: Size mismatch in enum "
-			"m680x_group_type and s_group_names\n");
-
 		return CS_ERR_MODE;
 	}
 


### PR DESCRIPTION
Addresses #1483

fprintf is not suitable for kernel code other other environments.

Libraries should not exit with abort.