### PR TITLE
Fixes MOS groups count

### DIFF
--- a/arch/MOS65XX/MOS65XXDisassembler.c
+++ b/arch/MOS65XX/MOS65XXDisassembler.c
@@ -65,12 +65,12 @@ static void fillDetails(MCInst *MI, struct OpInfo opinfo, int cpu_type)
 	detail->mos65xx.op_count = 0;
 
 	if (insinfo.group_type != MOS65XX_GRP_INVALID) {
-		detail->groups[0] = insinfo.group_type;
+		detail->groups[detail->groups_count] = insinfo.group_type;
 		detail->groups_count++;
 	}
 
 	if (opinfo.am == MOS65XX_AM_REL || opinfo.am == MOS65XX_AM_ZP_REL) {
-		detail->groups[0] = MOS65XX_GRP_BRANCH_RELATIVE;
+		detail->groups[detail->groups_count] = MOS65XX_GRP_BRANCH_RELATIVE;
 		detail->groups_count++;	
 	}
 


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15112

Test example is
`cstool -d 6502 "30 20"`

Expected output is 
```
	Groups: jump branch_relative 
```
instead of
```
	Groups: branch_relative (null)
```