### PR TITLE
Fixed 47 missing dependencies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ else
 endif
 endif
 
-$(LIBOBJ): config.mk *.h include/capstone/*.h
+$(LIBOBJ): config.mk
 
 $(LIBOBJ_ARM): $(DEP_ARM)
 $(LIBOBJ_ARM64): $(DEP_ARM64)
@@ -414,6 +414,18 @@ else
 	$(generate-pkgcfg)
 endif
 
+# destination path macro we'll use below
+df = $(*F)
+
+# create a list of auto dependencies
+AUTODEPS:= $(patsubst %.o,%.d, $(LIBOBJ))
+
+
+# include by auto dependencies
+-include $(AUTODEPS)
+
+
+
 install: $(PKGCFGF) $(ARCHIVE) $(LIBRARY)
 	mkdir -p $(LIBDIR)
 	$(call install-library,$(LIBDIR))
@@ -437,6 +449,7 @@ clean:
 	rm -f $(LIBOBJ)
 	rm -f $(BLDIR)/lib$(LIBNAME).* $(BLDIR)/$(LIBNAME).pc
 	rm -f $(PKGCFGF)
+	rm -f $(AUTODEPS)
 	$(MAKE) -C cstool clean
 
 ifeq (,$(findstring yes,$(CAPSTONE_BUILD_CORE_ONLY)))
@@ -537,3 +550,5 @@ define generate-pkgcfg
 	echo 'Libs: -L$${libdir} -lcapstone' >> $(PKGCFGF)
 	echo 'Cflags: -I$${includedir}' >> $(PKGCFGF)
 endef
+
+

--- a/functions.mk
+++ b/functions.mk
@@ -2,6 +2,7 @@
 # Common functions used by Makefile & tests/Makefile
 
 define compile
+        @$(CC) -MM -MP -MT $@ -MT $(@:.o=.d) $(CFLAGS) $< > $(@:.o=.d)
 	${CC} ${CFLAGS} -c $< -o $@
 endef
 


### PR DESCRIPTION
Hi, I've fixed 47 dependencies missing reported.
Those issues can cause incorrect results when capstone is incrementally built.
For example, any changes in "arch/AArch64/AArch64BaseInfo.h" will not cause "arch/AArch64/AArch64BaseInfo.o" to be rebuilt, which is incorrect. 
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

Thanks
Vemake