### PR TITLE
Fixed 47 missing dependencies and 51 excessive dependencies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ else
 endif
 endif
 
-$(LIBOBJ): config.mk *.h include/capstone/*.h
+$(LIBOBJ): config.mk
 
 $(LIBOBJ_ARM): $(DEP_ARM)
 $(LIBOBJ_ARM64): $(DEP_ARM64)
@@ -444,6 +444,18 @@ else
 	$(generate-pkgcfg)
 endif
 
+# destination path macro we'll use below
+df = $(*F)
+
+# create a list of auto dependencies
+AUTODEPS:= $(patsubst %.o,%.d, $(LIBOBJ))
+
+
+# include by auto dependencies
+-include $(AUTODEPS)
+
+
+
 install: $(PKGCFGF) $(ARCHIVE) $(LIBRARY)
 	mkdir -p $(LIBDIR)
 	$(call install-library,$(LIBDIR))
@@ -467,6 +479,7 @@ clean:
 	rm -f $(LIBOBJ)
 	rm -f $(BLDIR)/lib$(LIBNAME).* $(BLDIR)/$(LIBNAME).pc
 	rm -f $(PKGCFGF)
+	rm -f $(AUTODEPS)
 	$(MAKE) -C cstool clean
 
 ifeq (,$(findstring yes,$(CAPSTONE_BUILD_CORE_ONLY)))
@@ -566,3 +579,5 @@ define generate-pkgcfg
 	echo 'Libs: -L$${libdir} -lcapstone' >> $(PKGCFGF)
 	echo 'Cflags: -I$${includedir}' >> $(PKGCFGF)
 endef
+
+

--- a/Makefile
+++ b/Makefile
@@ -579,5 +579,3 @@ define generate-pkgcfg
 	echo 'Libs: -L$${libdir} -lcapstone' >> $(PKGCFGF)
 	echo 'Cflags: -I$${includedir}' >> $(PKGCFGF)
 endef
-
-

--- a/Makefile
+++ b/Makefile
@@ -444,17 +444,12 @@ else
 	$(generate-pkgcfg)
 endif
 
-# destination path macro we'll use below
-df = $(*F)
-
 # create a list of auto dependencies
 AUTODEPS:= $(patsubst %.o,%.d, $(LIBOBJ))
 
 
 # include by auto dependencies
 -include $(AUTODEPS)
-
-
 
 install: $(PKGCFGF) $(ARCHIVE) $(LIBRARY)
 	mkdir -p $(LIBDIR)

--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,6 @@ endif
 # create a list of auto dependencies
 AUTODEPS:= $(patsubst %.o,%.d, $(LIBOBJ))
 
-
 # include by auto dependencies
 -include $(AUTODEPS)
 

--- a/cstool/Makefile
+++ b/cstool/Makefile
@@ -37,7 +37,7 @@ endif
 
 clean:
 	${RM} -rf *.o $(TARGET)
-	${RM} -rf *.d
+	${RM} -f *.d
 
 %.o: %.c
 ifeq ($(V), 0)

--- a/cstool/Makefile
+++ b/cstool/Makefile
@@ -37,6 +37,7 @@ endif
 
 clean:
 	${RM} -rf *.o $(TARGET)
+	${RM} -rf *.d
 
 %.o: %.c
 ifeq ($(V), 0)

--- a/functions.mk
+++ b/functions.mk
@@ -2,6 +2,7 @@
 # Common functions used by Makefile & tests/Makefile
 
 define compile
+        @$(CC) -MM -MP -MT $@ -MT $(@:.o=.d) $(CFLAGS) $< > $(@:.o=.d)
 	${CC} ${CFLAGS} -c $< -o $@
 endef
 

--- a/suite/fuzz/Makefile
+++ b/suite/fuzz/Makefile
@@ -53,6 +53,7 @@ all: $(REPRODUCERMC) $(REPRODUCERBIN) $(FUZZERBIN) $(PLATFORMDECODE)
 
 clean:
 	rm -rf fuzz_harness $(OBJS) $(PLATFORMDECODE) $(REPRODUCERMC) $(REPRODUCERBIN) $(FUZZERBIN) $(OBJDIR)/lib$(LIBNAME).* $(OBJDIR)/$(LIBNAME).*
+	rm -rf *.d $(OBJDIR)/*.d
 
 $(REPRODUCERMC): fuzz_disasm.o drivermc.o platform.o
 	@mkdir -p $(@D)

--- a/suite/fuzz/Makefile
+++ b/suite/fuzz/Makefile
@@ -53,7 +53,7 @@ all: $(REPRODUCERMC) $(REPRODUCERBIN) $(FUZZERBIN) $(PLATFORMDECODE)
 
 clean:
 	rm -rf fuzz_harness $(OBJS) $(PLATFORMDECODE) $(REPRODUCERMC) $(REPRODUCERBIN) $(FUZZERBIN) $(OBJDIR)/lib$(LIBNAME).* $(OBJDIR)/$(LIBNAME).*
-	rm -rf *.d $(OBJDIR)/*.d
+	rm -f *.d $(OBJDIR)/*.d
 
 $(REPRODUCERMC): fuzz_disasm.o drivermc.o platform.o
 	@mkdir -p $(@D)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -137,6 +137,7 @@ all: $(BINARY)
 
 clean:
 	rm -rf $(OBJS) $(BINARY) $(TESTDIR)/*.exe $(TESTDIR)/*.static $(OBJDIR)/lib$(LIBNAME).* $(OBJDIR)/$(LIBNAME).*
+	rm -rf *.d $(TESTDIR)/*.d $(OBJDIR)/*.d
 	# remove orphan files due to renaming from test.c to test_basic.c
 	rm -rf $(TESTDIR)/test.o $(TESTDIR)/test.exe $(TESTDIR)/test.static $(TESTDIR)/test
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -137,7 +137,7 @@ all: $(BINARY)
 
 clean:
 	rm -rf $(OBJS) $(BINARY) $(TESTDIR)/*.exe $(TESTDIR)/*.static $(OBJDIR)/lib$(LIBNAME).* $(OBJDIR)/$(LIBNAME).*
-	rm -rf *.d $(TESTDIR)/*.d $(OBJDIR)/*.d
+	rm -f *.d $(TESTDIR)/*.d $(OBJDIR)/*.d
 	# remove orphan files due to renaming from test.c to test_basic.c
 	rm -rf $(TESTDIR)/test.o $(TESTDIR)/test.exe $(TESTDIR)/test.static $(TESTDIR)/test
 


### PR DESCRIPTION
Hi, I've fixed 47 missing dependencies and 51 excessive dependencies reported.
Those issues can cause incorrect results or unnecessary rebuilds when capstone is incrementally built.

For example, any changes in "arch/AArch64/AArch64BaseInfo.h" will not cause "arch/AArch64/AArch64BaseInfo.o" to be rebuilt, which is incorrect.

"MCInstrDesc.h" is specified as the prerequisite of "arch/Mips/MipsDisassembler.o". However, this header file is not read by the process when "arch/Mips/MipsDisassembler.o" is built. Hence, the changes in "MCInstrDesc.h" can cause an unnecessary rebuild of "arch/Mips/MipsDisassembler.o", which slow down the build of the whole project.  

A useful tool is the -M class of flags that we can pass to clang/gcc to generate "dependency files". Even if we don't use the flag directly in the Makefile, a script that we use could take advantage of the feature.
I modify the Makefile to read dependencies from compiler-generated files. I've checked. The dependences generate from the new Makefile are correct.
Looking forward to your confirmation.

Thanks
Vemake