### PR TITLE
fix for make.sh for android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ capstone_get_setup
 *.s
 
 cstool/cstool
+
+# android
+android-ndk-*

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ endif
 
 ifeq ($(CROSS),)
 RANLIB ?= ranlib
+else ifeq ($(ANDROID), 1)
+CC = $(CROSS)/../../bin/clang
+AR = $(CROSS)/ar
+RANLIB = $(CROSS)/ranlib
+STRIP = $(CROSS)/strip
 else
 CC = $(CROSS)gcc
 AR = $(CROSS)ar
@@ -437,6 +442,7 @@ clean:
 	rm -f $(LIBOBJ)
 	rm -f $(BLDIR)/lib$(LIBNAME).* $(BLDIR)/$(LIBNAME).pc
 	rm -f $(PKGCFGF)
+	[ ${ANDROID} -eq 1 ] && rm -rf android-ndk-*
 	$(MAKE) -C cstool clean
 
 ifeq (,$(findstring yes,$(CAPSTONE_BUILD_CORE_ONLY)))

--- a/make.sh
+++ b/make.sh
@@ -47,7 +47,6 @@ build_android() {
              --install-dir ${STANDALONE}
   }
 
-  #CC="${STANDALONE}/bin/clang" CFLAGS="--sysroot=${STANDALONE}/sysroot" ${MAKE} $*
   ANDROID=1 CROSS="${STANDALONE}/${CROSS}/bin" CFLAGS="--sysroot=${STANDALONE}/sysroot" ${MAKE} $*
 }
 

--- a/make.sh
+++ b/make.sh
@@ -15,6 +15,7 @@ build_android() {
     echo "ERROR! Please set \$NDK to point at your Android NDK directory."
     exit 1
   fi
+
   HOSTOS=$(uname -s | tr 'LD' 'ld')
   HOSTARCH=$(uname -m)
 
@@ -24,13 +25,11 @@ build_android() {
   case "$TARGARCH" in
     arm)
       [ -n "$APILEVEL" ] || APILEVEL="android-14"  # default to ICS
-      [ -n "$GCCVER" ] || GCCVER="4.8"
-      CROSS=arm-linux-androideabi-
+      CROSS=arm-linux-androideabi
       ;;
     arm64)
       [ -n "$APILEVEL" ] || APILEVEL="android-21"  # first with arm64
-      [ -n "$GCCVER" ] || GCCVER="4.9"
-      CROSS=aarch64-linux-android-
+      CROSS=aarch64-linux-android
       ;;
 
     *)
@@ -39,10 +38,17 @@ build_android() {
       ;;
   esac
 
-  TOOLCHAIN="$NDK/toolchains/$CROSS$GCCVER/prebuilt/$HOSTOS-$HOSTARCH"
-  PLATFORM="$NDK/platforms/$APILEVEL/arch-$TARGARCH"
+  STANDALONE=`realpath android-ndk-${TARGARCH}-${APILEVEL}`
 
-  CROSS="$TOOLCHAIN/bin/$CROSS" CFLAGS="--sysroot=$PLATFORM" LDFLAGS="--sysroot=$PLATFORM" ${MAKE} $*
+  [ -d $STANDALONE ] || {
+      python ${NDK}/build/tools/make_standalone_toolchain.py \
+             --arch ${TARGARCH} \
+             --api ${APILEVEL##*-} \
+             --install-dir ${STANDALONE}
+  }
+
+  #CC="${STANDALONE}/bin/clang" CFLAGS="--sysroot=${STANDALONE}/sysroot" ${MAKE} $*
+  ANDROID=1 CROSS="${STANDALONE}/${CROSS}/bin" CFLAGS="--sysroot=${STANDALONE}/sysroot" ${MAKE} $*
 }
 
 # build iOS lib for all iDevices, or only specific device


### PR DESCRIPTION
1. According to the issue #1518, I made a fix for the broken Android compilation script;
2. The fix is based on building standalone Android NDK env first, as I think this is the most general way for old & new version NDK, see this [link](https://developer.android.com/ndk/guides/other_build_systems?hl=zh-CN) for more details;
3. I replace the gcc to clang as Android has no support for gcc now;
4. You can try `NDK=/path/to/the/unzipped/ndk/dir ./make.sh cross-android arm64 [clean]` to test it. The build process is well but there is a problem for `make test`, the failure is because of the lack of `bingcc`:
```bash
make -C tests
make[1]: Entering directory '/root/workspace/capstone_make/capstone/tests'
/bin/sh: 1: /root/workspace/capstone_make/capstone/android-ndk-arm64-android-21/aarch64-linux-android/bingcc: not found
  CC      test_basic.o
  CC      test_detail.o
  CC      test_skipdata.o
make[1]: /root/workspace/capstone_make/capstone/android-ndk-arm64-android-21/aarch64-linux-android/bingcc: Command not found
make[1]: /root/workspace/capstone_make/capstone/android-ndk-arm64-android-21/aarch64-linux-android/bingcc: Command not found
Makefile:154: recipe for target 'test_basic.o' failed
make[1]: *** [test_basic.o] Error 127
make[1]: *** Waiting for unfinished jobs....
Makefile:154: recipe for target 'test_detail.o' failed
make[1]: *** [test_detail.o] Error 127
  CC      test_iter.o
make[1]: /root/workspace/capstone_make/capstone/android-ndk-arm64-android-21/aarch64-linux-android/bingcc: Command not found
make[1]: /root/workspace/capstone_make/capstone/android-ndk-arm64-android-21/aarch64-linux-android/bingcc: Command not found
Makefile:154: recipe for target 'test_skipdata.o' failed
make[1]: *** [test_skipdata.o] Error 127
Makefile:154: recipe for target 'test_iter.o' failed
make[1]: *** [test_iter.o] Error 127
make[1]: Leaving directory '/root/workspace/capstone_make/capstone/tests'
Makefile:366: recipe for target 'all' failed
make: *** [all] Error 2
r
```