### PR TITLE
Fix for x86_op record for ocaml bindings

### DIFF
--- a/bindings/ocaml/ocaml.c
+++ b/bindings/ocaml/ocaml.c
@@ -369,15 +369,15 @@ CAMLprim value _cs_disasm(cs_arch arch, csh handle, const uint8_t * code, size_t
 							for (i = 0; i < lcount; i++) {
 								switch(insn[j-1].detail->x86.operands[i].type) {
 									case X86_OP_REG:
-										tmp = caml_alloc(5, 1);
+										tmp = caml_alloc(1, 1);
 										Store_field(tmp, 0, Val_int(insn[j-1].detail->x86.operands[i].reg));
 										break;
 									case X86_OP_IMM:
-										tmp = caml_alloc(5, 2);
+										tmp = caml_alloc(1, 2);
 										Store_field(tmp, 0, Val_int(insn[j-1].detail->x86.operands[i].imm));
 										break;
 									case X86_OP_MEM:
-										tmp = caml_alloc(5, 3);
+										tmp = caml_alloc(1, 3);
 										tmp2 = caml_alloc(5, 0);
 										Store_field(tmp2, 0, Val_int(insn[j-1].detail->x86.operands[i].mem.segment));
 										Store_field(tmp2, 1, Val_int(insn[j-1].detail->x86.operands[i].mem.base));
@@ -388,14 +388,16 @@ CAMLprim value _cs_disasm(cs_arch arch, csh handle, const uint8_t * code, size_t
 										Store_field(tmp, 0, tmp2);
 										break;
 									default:
+										tmp = caml_alloc(1, 0); // X86_OP_INVALID
 										break;
 								}
-								Store_field(tmp, 1, Val_int(insn[j-1].detail->x86.operands[i].size));
-								Store_field(tmp, 2, Val_int(insn[j-1].detail->x86.operands[i].access));
-								Store_field(tmp, 3, Val_int(insn[j-1].detail->x86.operands[i].avx_bcast));
-								Store_field(tmp, 4, Val_int(insn[j-1].detail->x86.operands[i].avx_zero_opmask));
-								tmp2 = caml_alloc(1, 0);
+
+								tmp2 = caml_alloc(5, 0);
 								Store_field(tmp2, 0, tmp);
+								Store_field(tmp2, 1, Val_int(insn[j-1].detail->x86.operands[i].size));
+								Store_field(tmp2, 2, Val_int(insn[j-1].detail->x86.operands[i].access));
+								Store_field(tmp2, 3, Val_int(insn[j-1].detail->x86.operands[i].avx_bcast));
+								Store_field(tmp2, 4, Val_int(insn[j-1].detail->x86.operands[i].avx_zero_opmask));
 								Store_field(array, i, tmp2);
 							}
 						} else	// empty array

--- a/bindings/ocaml/test_x86.ml
+++ b/bindings/ocaml/test_x86.ml
@@ -30,9 +30,9 @@ let all_tests = [
 let print_op handle i op =
 	( match op.value with
 	| X86_OP_INVALID _ -> ();	(* this would never happens *)
-	| X86_OP_REG reg -> printf "\t\top[%d]: REG = %s\n" i (cs_reg_name handle reg);
-	| X86_OP_IMM imm -> printf "\t\top[%d]: IMM = 0x%x\n" i imm;
-	| X86_OP_MEM mem -> ( printf "\t\top[%d]: MEM\n" i;
+	| X86_OP_REG reg -> printf "\t\top[%d]: REG = %s  [sz=%d]\n" i (cs_reg_name handle reg) op.size;
+	| X86_OP_IMM imm -> printf "\t\top[%d]: IMM = 0x%x  [sz=%d]\n" i imm op.size;
+	| X86_OP_MEM mem -> ( printf "\t\top[%d]: MEM  [sz=%d]\n" i op.size;
 		if mem.base != 0 then
 			printf "\t\t\toperands[%u].mem.base: REG = %s\n" i (cs_reg_name handle  mem.base);
 		if mem.index != 0 then


### PR DESCRIPTION
This PR fixes a bug with the `x86_op` record in the ocaml bindings. 

Before the change fields such as `size` where returned with bad values, for example:
```
Platform: X86 64 (Intel syntax)
0x1000	push	rbp
	Prefix:
	Opcode: 0x55
	addr_size: 8
	modrm: 0x0
	sib: 0x0
	op_count: 1
		op[0]: REG = rbp  [sz=2944]
```
After the change the fields are correctly returned to ocaml:
```
Platform: X86 64 (Intel syntax)
0x1000	push	rbp
	Prefix:
	Opcode: 0x55
	addr_size: 8
	modrm: 0x0
	sib: 0x0
	op_count: 1
		op[0]: REG = rbp  [sz=8]
```
