### PR TITLE
Bug solved: #1538

### DIFF
--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -1622,7 +1622,6 @@ static bool valid_repne(cs_struct *h, unsigned int opcode)
 			case X86_INS_MOVSB:
 			case X86_INS_MOVSS:
 			case X86_INS_MOVSW:
-			case X86_INS_MOVSD:
 			case X86_INS_MOVSQ:
 
 			case X86_INS_LODSB:
@@ -1644,6 +1643,11 @@ static bool valid_repne(cs_struct *h, unsigned int opcode)
 			case X86_INS_OUTSD:
 
 				return true;
+
+			case X86_INS_MOVSD:
+				if (opcode == X86_MOVSW) // REP MOVSB
+					return true;
+				return false;
 
 			case X86_INS_CMPSD:
 				if (opcode == X86_CMPSL) // REP CMPSD


### PR DESCRIPTION
Solve the issue #1538 (SSE variant of MOVSD is incorrectly decoded as REPNE MOVSD)