### PR TITLE
build: add xlc and AIX support

### DIFF
--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -30,14 +30,14 @@ extern "C" {
 #endif
 #else
 #define CAPSTONE_API
-#if defined(__GNUC__) && !defined(CAPSTONE_STATIC)
+#if (defined(__GNUC__) || defined(__IBMC__)) && !defined(CAPSTONE_STATIC)
 #define CAPSTONE_EXPORT __attribute__((visibility("default")))
 #else    // defined(CAPSTONE_STATIC)
 #define CAPSTONE_EXPORT
 #endif
 #endif
 
-#ifdef __GNUC__
+#if (defined(__GNUC__) || defined(__IBMC__))
 #define CAPSTONE_DEPRECATED __attribute__((deprecated))
 #elif defined(_MSC_VER)
 #define CAPSTONE_DEPRECATED __declspec(deprecated)

--- a/make.sh
+++ b/make.sh
@@ -145,6 +145,9 @@ case "$TARGET" in
       ${MAKE} "$@";;
   "mac-universal" ) MACOS_UNIVERSAL=yes ${MAKE} "$@";;
   "mac-universal-no" ) MACOS_UNIVERSAL=no ${MAKE} "$@";;
+  "xlc31" ) CC=xlc CFLAGS=-q31 LDFLAGS=-q31 ${MAKE} "$@";;
+  "xlc32" ) CC=xlc CFLAGS=-q32 LDFLAGS=-q32 ${MAKE} "$@";;
+  "xlc64" ) CC=xlc CFLAGS=-q64 LDFLAGS=-q64 ${MAKE} "$@";;
   * )
     echo "Usage: $0 ["$(grep '^  "' $0 | cut -d '"' -f 2 | tr "\\n" "|")"]"
     exit 1;;


### PR DESCRIPTION
These changes add support for IBM systems.
`xlc` is the compiler used, `ar` have different options on certain platforms and `ranlib` is unavailable on certain platforms