### PR TITLE
Use GNUInstallDirs for the headers too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,7 +597,7 @@ source_group("Include\\MOS65XX" FILES ${HEADERS_MOS65XX})
 include("GNUInstallDirs")
 
 ## installation
-install(FILES ${HEADERS_COMMON} DESTINATION include/capstone)
+install(FILES ${HEADERS_COMMON} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/capstone)
 configure_file(capstone.pc.in ${CMAKE_BINARY_DIR}/capstone.pc @ONLY)
 
 if (CAPSTONE_BUILD_STATIC)


### PR DESCRIPTION
Have been looking into getting the latest release build on Haiku with some changes in CMakeList.txt, however the master branch here is ahead of the release (as it should) so I checked some changes.
You already switched to CMAKE_INSTALL_LIBDIR, switching to CMAKE_INSTALL_INCLUDEDIR should fix the buid on Haiku and shouldn't harm any other OS.