### PR TITLE
Add Coverity Scan Action

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,0 +1,41 @@
+name: coverity-scan
+on:
+  schedule:
+    - cron: '0 18 * * 1,4' # Bi-weekly at 18:00 UTC on Monday and Thursday
+
+jobs:
+  latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Download Coverity Build Tool
+        run: |
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=$TOKEN&project=capstone-next" -O cov-analysis-linux64.tar.gz
+          mkdir cov-analysis-linux64
+          tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+
+      - name: Fixed world writable dirs
+        run: |
+          chmod go-w $HOME
+          sudo chmod -R go-w /usr/share
+          
+      - name: Build with cov-build
+        run: |
+          export PATH=`pwd`/cov-analysis-linux64/bin:$PATH
+          cov-build --dir cov-int make
+
+      - name: Submit the result to Coverity Scan
+        run: |
+          tar czvf capstone.tgz cov-int
+          curl \
+            --form project=capstone-next \
+            --form token=$TOKEN \
+            --form email=noreply@capstone-engine.org \
+            --form file=@capstone.tgz \
+            --form version=trunk \
+            --form description="capstone" \
+            https://scan.coverity.com/builds?project=capstone-next
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}


### PR DESCRIPTION
Since we migrated our CI, and Capstone used our CI, setting GitHub Action would help automate sending builds without our help.

You only need to add the token (you can see it at https://scan.coverity.com/projects/capstone-next/builds/new page) in the Github repo Settings -> Secrets -> Add

There you should add a token with a name `COVERITY_SCAN_TOKEN`

Feel free to reach me if you have questions.

