### PR TITLE
Add ARM64, System Z & PowerPC CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,33 @@ matrix:
             apt:
               packages:
                 - libcmocka-dev
+        - name: bionic gcc (ARM64)
+          arch: arm64
+          os: linux
+          dist: bionic
+          compiler: gcc
+          addons:
+            apt:
+              packages:
+                - libcmocka-dev
+        - name: bionic gcc (PowerPC)
+          arch: ppc64le
+          os: linux
+          dist: bionic
+          compiler: gcc
+          addons:
+            apt:
+              packages:
+                - libcmocka-dev
+        - name: bionic gcc (System Z)
+          arch: s390x
+          os: linux
+          dist: bionic
+          compiler: gcc
+          addons:
+            apt:
+              packages:
+                - libcmocka-dev
         - name: xenial clang
           os: linux
           dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ matrix:
             apt:
               packages:
                 - libcmocka-dev
+                - unzip
         - name: bionic gcc (PowerPC)
           arch: ppc64le
           os: linux


### PR DESCRIPTION
For more information see [Multiarchitecture support](https://blog.travis-ci.com/2019-10-07-multi-cpu-architecture-support) and [Build your open source projects on IBM Power and IBM Z CPU architecture](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) blog posts from Travis CI.

Checking on these architectures will help eliminate endianess/portability problems in the code.