### PR TITLE
fix bug in displacement offset

### DIFF
--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -1418,7 +1418,6 @@ static int readDisplacement(struct InternalInstruction* insn)
 			break;
 	}
 
-	insn->consumedDisplacement = true;
 
 	return 0;
 }


### PR DESCRIPTION
This solves https://github.com/aquynh/capstone/issues/1560

The removed line was making Line 1402 effectively dead code.