### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/COMPILE_MSVC.TXT
+++ b/COMPILE_MSVC.TXT
@@ -106,3 +106,17 @@ versions, and Windows Driver Kit 8.1 Update 1 or newer versions are required.
 
       >sc delete test_winkernel
       >bcdedit /deletevalue testsigning
+      
+      
+      
+(3) Installing and building capstone via vcpkg
+  
+  You can download and install capstone using the vcpkg(https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install capstone
+
+  The capstone port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request on the vcpkg repository(https://github.com/Microsoft/vcpkg). 


### PR DESCRIPTION
`capstone`  is available as a port in [vcpkg](https://github.com/microsoft/vcpkg/tree/master), a C++ library manager that simplifies installation for `capstone`  and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `capstone` , ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/capstone/portfile.cmake). We try to keep the library maintained as close as possible to the original library.