### PR TITLE
Add __repr__ for capstone.CsInsn

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -539,6 +539,10 @@ class CsInsn(object):
             self._raw.detail = ctypes.pointer(all_info.detail._type_())
             ctypes.memmove(ctypes.byref(self._raw.detail[0]), ctypes.byref(all_info.detail[0]), ctypes.sizeof(type(all_info.detail[0])))
 
+    def __repr__(self):
+            def __repr__(self):
+        return '<cs.CsInsn: address=0x%x, size=%d, mnemonic=%s, op_str=%s>' % (self.address, self.size, self.mnemonic, self.op_str)
+            
     # return instruction's ID.
     @property
     def id(self):


### PR DESCRIPTION
Currently, a `print(instruction)` displays a not very useful string like `<capstone.CsInsn object at 0x7f3759d88128>`.

This PR enhances adds a `__repr__` magic method to the `capstone.CsInsn` class so it displays as follows:
```
<cs.CsInsn: address=0x5555555545fa, size=1, mnemonic=push, op_str=rbp>
```