### PR TITLE
Allow to override PYTHON[23] in Makefiles

### DIFF
--- a/bindings/Makefile
+++ b/bindings/Makefile
@@ -14,7 +14,7 @@ TEST_SYSZ = $(TMPDIR)/test_systemz
 TEST_X86 = $(TMPDIR)/test_x86
 TEST_XCORE = $(TMPDIR)/test_xcore
 
-PYTHON2 = python
+PYTHON2 ?= python
 
 .PHONY: all expected python java ocaml
 

--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -20,7 +20,7 @@ else
   endif
 endif
 
-PYTHON2 = python
+PYTHON2 ?= python
 
 CAPSTONE_JAVA = Capstone.java Arm_const.java Arm64_const.java Mips_const.java \
 				X86_const.java Xcore_const.java Ppc_const.java Sparc_const.java\

--- a/bindings/ocaml/Makefile
+++ b/bindings/ocaml/Makefile
@@ -3,7 +3,7 @@
 
 LIB = capstone
 FLAGS = '-Wall -Wextra -Wwrite-strings'
-PYTHON2 = python
+PYTHON2 ?= python
 
 all: arm_const.cmxa arm64_const.cmxa m680x_const.cmxa mips_const.cmxa ppc_const.cmxa sparc_const.cmxa sysz_const.cmxa x86_const.cmxa xcore_const.cmxa arm.cmxa arm64.cmxa m680x.cmxa mips.cmxa ppc.cmxa x86.cmxa sparc.cmxa systemz.cmxa xcore.cmxa capstone.cmxa test_basic.cmx test_detail.cmx test_x86.cmx test_arm.cmx test_arm64.cmx test_mips.cmx test_ppc.cmx test_sparc.cmx test_systemz.cmx test_xcore.cmx test_m680x.cmx ocaml.o
 	ocamlopt -o test_basic -ccopt $(FLAGS) ocaml.o capstone.cmx test_basic.cmx -cclib -l$(LIB)

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -1,5 +1,5 @@
-PYTHON2 = python
-PYTHON3 = python3
+PYTHON2 ?= python
+PYTHON3 ?= python3
 
 .PHONY: gen_const install install3 install_cython sdist sdist3 bdist bdist3 clean check
 


### PR DESCRIPTION
`$(PYTHON2)` and/or `$(PYTHON3)` might differ from `python` and/or `python3`,
accordingly. Allow to override these variables by user choice.