### PR TITLE
PyPI workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,80 @@
+name: PyPI 📦 Distribution
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        platform: [x32, x64]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Set up MSVC x86
+      if: matrix.os == 'windows-latest' && matrix.platform == 'x32'
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x86
+
+    - name: Set up MSVC x64
+      if: matrix.os == 'windows-latest' && matrix.platform == 'x64'
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Install dependencies
+      run: |
+        pip install setuptools wheel
+
+    - name: Build distribution 📦
+      shell: bash 
+      run: |
+        if [ ${{ matrix.platform }} == 'x32' ] && [ ${{ matrix.os }} == 'windows-latest' ]; then
+             cd bindings/python && python setup.py build -p win32 bdist_wheel -p win32
+        elif [ ${{ matrix.platform }} == 'x32' ] && [ ${{ matrix.os }} == 'ubuntu-latest' ]; then
+             docker run --rm -v `pwd`/:/work dockcross/manylinux1-x86 > ./dockcross
+             chmod +x ./dockcross
+             ./dockcross bindings/python/build_wheel.sh
+        elif [ ${{ matrix.platform }} == 'x64' ] && [ ${{ matrix.os }} == 'ubuntu-latest' ]; then
+             docker run --rm -v `pwd`/:/work dockcross/manylinux1-x64 > ./dockcross
+             chmod +x ./dockcross
+             ./dockcross bindings/python/build_wheel.sh
+        elif [ ${{ matrix.platform }} == 'x32' ] && [ ${{ matrix.os }} == 'macos-latest' ]; then
+             cd bindings/python && python setup.py sdist
+        else
+             cd bindings/python && python setup.py bdist_wheel
+        fi
+
+    - uses: actions/upload-artifact@v2
+      with:
+         path: ${{ github.workspace }}/bindings/python/dist/*
+
+  publish:
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - name: Publish distribution 📦 to test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.testpypi_pass }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Publish distribution 📦 to PyPI
+        if: ${{ success() }}
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_pass }}

--- a/CREDITS.TXT
+++ b/CREDITS.TXT
@@ -80,3 +80,4 @@ Stephen Eckels (stevemk14ebr): x86 encoding features
 Sebastian Macke: MOS65XX architecture
 Ilya Leoshkevich: SystemZ architecture improvements.
 Do Minh Tuan: Regression testing tool (cstest)
+Kevin Foo (chfl4gs): PyPI github actions workflow.

--- a/bindings/python/build_wheel.sh
+++ b/bindings/python/build_wheel.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e -x
+
+cd bindings/python
+sudo rm /usr/bin/python && sudo ln -s /opt/python/cp27-cp27m/bin/python /usr/bin/python; python -V
+
+# Compile wheels
+if [ -f /opt/python/cp36-cp36m/bin/python ];then
+  /opt/python/cp36-cp36m/bin/python setup.py bdist_wheel
+else
+  python3 setup.py bdist_wheel
+fi
+cd dist
+auditwheel repair *.whl
+mv -f wheelhouse/*.whl .

--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -207,6 +207,48 @@ if 'bdist_wheel' in sys.argv and '--plat-name' not in sys.argv:
         # https://www.python.org/dev/peps/pep-0425/
         sys.argv.insert(idx + 1, name.replace('.', '_').replace('-', '_'))
 
+long_desc = '''
+Capstone is a disassembly framework with the target of becoming the ultimate
+disasm engine for binary analysis and reversing in the security community.
+
+Created by Nguyen Anh Quynh, then developed and maintained by a small community,
+Capstone offers some unparalleled features:
+
+- Support multiple hardware architectures: ARM, ARM64 (ARMv8), Mips, PPC, Sparc,
+  SystemZ, XCore and X86 (including X86_64).
+
+- Having clean/simple/lightweight/intuitive architecture-neutral API.
+
+- Provide details on disassembled instruction (called “decomposer” by others).
+
+- Provide semantics of the disassembled instruction, such as list of implicit
+  registers read & written.
+
+- Implemented in pure C language, with lightweight wrappers for C++, C#, Go,
+  Java, NodeJS, Ocaml, Python, Ruby & Vala ready (available in main code,
+  or provided externally by the community).
+
+- Native support for all popular platforms: Windows, Mac OSX, iOS, Android,
+  Linux, *BSD, Solaris, etc.
+
+- Thread-safe by design.
+
+- Special support for embedding into firmware or OS kernel.
+
+- High performance & suitable for malware analysis (capable of handling various
+  X86 malware tricks).
+
+- Distributed under the open source BSD license.
+
+Further information is available at http://www.capstone-engine.org
+
+
+[License]
+
+This project is released under the BSD license. If you redistribute the binary
+or source code of Capstone, please attach file LICENSE.TXT with your products.
+'''
+
 setup(
     provides=['capstone'],
     packages=['capstone'],
@@ -215,9 +257,14 @@ setup(
     author='Nguyen Anh Quynh',
     author_email='aquynh@gmail.com',
     description='Capstone disassembly engine',
-    url='http://www.capstone-engine.org',
+    long_description=long_desc,
+    long_description_content_type="text/markdown",
+    url='https://www.capstone-engine.org',
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
@@ -227,6 +274,7 @@ setup(
     cmdclass=cmdclass,
     zip_safe=True,
     include_package_data=True,
+    is_pure=False,
     package_data={
         "capstone": ["lib/*", "include/capstone/*"],
     }


### PR DESCRIPTION
**Purpose:**
- Utilizing github action to build and publish python distribution packages including source package to pypi.org on repo [tag]. Build will still be triggered on [push].
- Speed up project release process.

**Binary distribution packages:**
sdist, win32, win-amd64, manylinux1_x86_64, manylinux1_i686, macos_10.14_x86_64

**Preparation:**
- Go to https://pypi.org/manage/account/#api-tokens and create a new API token for the Capstone-engine project on PyPI, limit the token scope to just this project. You can call it something like GitHub Actions CI/CD or anything that can be easily distinguishable in the token list. Don’t close the page just yet — you won’t see that token again.

- In a separate browser tab or window, go to the Github Settings tab of capstone-engine/capstone repository and then click on Secrets in the left sidebar.
 
- Create a new secret called pypi_pass and copy-paste the token generated from the first step. 

- Repeat the steps for test.pypi.org and create a secret named testpypi_pass with the testpypi token.

**Build tools/Dockers**
Using dockcross's manylinux1 images for Linux builds. Comply with PEP 513 requirements.

**Artifacts**
Workflow will produce zipped a artifact containing all the files for download/inspection/testing.

**Workflows**
- Update VERSION according to PEP 440 and tag and release (manual)
- Update setup.py for dev status classifiers. (manual)
- Build wheel for respective OSes on push. (automated)
- If tagged and builds completed, download artifacts and upload to Test PyPI. (automated)
- If Test PyPi upload completed without any error, upload files to real PyPI site. (automated)