### PR TITLE
Change include path to fix error with embedded cmake builds

### DIFF
--- a/include/capstone/riscv.h
+++ b/include/capstone/riscv.h
@@ -13,7 +13,7 @@ extern "C" {
 #include <stdint.h>
 #endif
 
-#include "capstone/platform.h"
+#include "platform.h"
 
 // GCC MIPS toolchain has a default macro called "mips" which breaks
 // compilation


### PR DESCRIPTION
Fixed a build issue. I integrate the capstone directory into a larger project and use the cmakefile. It was an easy fix, but not sure how I can show how to reproduce in your git repo.
 
```
In file included from /home/mjm/sim/src/capstone/include/capstone/capstone.h:302,
                 from /home/mjm/sim/src/ampere/event_stream/event_stream.cc:22:
/home/mjm/sim/src/capstone/include/capstone/riscv.h:16:10: fatal error: capstone/platform.h: No such file or directory
#include "capstone/platform.h"
          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.

```