### PR TITLE
capstone.pc.in: use CMAKE_INSTALL_LIBDIR for libdir

### DIFF
--- a/capstone.pc.in
+++ b/capstone.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/lib@LIBSUFFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include/capstone
 
 Name: capstone


### PR DESCRIPTION
On x86_64-linux gentoo system capstone was installing
it's files to 'lib64' libdir, but was referring 'lib' libdir:

```
$ cat /usr/lib64/pkgconfig/capstone.pc
...
libdir=${prefix}/lib
...
```

On radare2 built it means injecting -L/usr/lib into a 64-build
and pulling in 32-bit libraries. 'ld.lld' is not able to resolve
the ambiguity.

It happens because @LIBSUFFIX@ is not present in cmake-3.17.3.

Let's fix the paths by using @CMAKE_INSTALL_LIBDIR@.
This variable is already used in capstone's build system,
thus should be safe to rely on.

Reported-by: Agostino Sarubbo
Bug: https://bugs.gentoo.org/730722