### PR TITLE
include: avoid UB with signed overflow/shift

### DIFF
--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -121,7 +121,7 @@ typedef enum cs_mode {
 	CS_MODE_M68K_030 = 1 << 4, ///< M68K 68030 mode
 	CS_MODE_M68K_040 = 1 << 5, ///< M68K 68040 mode
 	CS_MODE_M68K_060 = 1 << 6, ///< M68K 68060 mode
-	CS_MODE_BIG_ENDIAN = 1 << 31,	///< big-endian mode
+	CS_MODE_BIG_ENDIAN = 1U << 31,	///< big-endian mode
 	CS_MODE_MIPS32 = CS_MODE_32,	///< Mips32 ISA (Mips)
 	CS_MODE_MIPS64 = CS_MODE_64,	///< Mips64 ISA (Mips)
 	CS_MODE_M680X_6301 = 1 << 1, ///< M680X Hitachi 6301,6303 mode


### PR DESCRIPTION
if integer is 32-bit, and numeric literals default to int type,
the following applies (from The C Standard, 6.5.7, paragraph 4
[ISO/IEC 9899:2011]):

If E1 has a signed type and nonnegative value, and E1 × 2^E2 is
representable in the result type, then that is the resulting value;
otherwise, the behavior is undefined.

which means that the only way to safely shift is unsigned, so
use 1U to indicate the shifted bit is unsigned.