### PR TITLE
systemz: pad instruction width up to 6 bytes

### DIFF
--- a/cstool/cstool.c
+++ b/cstool/cstool.c
@@ -455,10 +455,14 @@ int main(int argc, char **argv)
 					putchar(' ');
 				printf("%02x", insn[i].bytes[j]);
 			}
-			// X86 instruction size is variable.
+			// X86 and s390 instruction sizes are variable.
 			// align assembly instruction after the opcode
 			if (arch == CS_ARCH_X86) {
 				for (; j < 16; j++) {
+					printf("   ");
+				}
+			} else if (arch == CS_ARCH_SYSZ) {
+				for (; j < 6; j++) {
 					printf("   ");
 				}
 			}


### PR DESCRIPTION
instructions could be 2, 4 or 6 bytes so pad accordingly as it
was done on the other CISC architecture.