### PR TITLE
Fix bug introduced in commit 0932f167fd5620bba1619fc3fae90924292ebb2e

### DIFF
--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -3122,7 +3122,7 @@ static bool valid_repne(cs_struct *h, unsigned int opcode)
 				return true;
 
 			case X86_INS_MOVSD:
-				if (opcode == X86_MOVSW) // REP MOVSB
+				if (opcode == X86_MOVSL) // REP MOVSD
 					return true;
 				return false;
 


### PR DESCRIPTION
In https://github.com/aquynh/capstone/commit/0932f167fd5620bba1619fc3fae90924292ebb2e a fix was submitted to remove the repne/repnz prefix from movs instructions with SSE registers. However, the change checks for X86_MOVSW rather than X86_MOVSL (movsd).
This breaks a simple repne movsd instruction:
want:
0:  f2 a5                   repnz movs DWORD PTR es:[edi],DWORD PTR ds:[esi]
got:
0:  f2 a5                   movs DWORD PTR es:[edi],DWORD PTR ds:[esi]

Clearly, the f2 prefix is dropped, even though it should be present.