### PR TITLE
Two RISC-V fixes

### DIFF
--- a/arch/RISCV/RISCVDisassembler.c
+++ b/arch/RISCV/RISCVDisassembler.c
@@ -40,16 +40,15 @@
 */
 static uint64_t getFeatureBits(int mode) 
 {
-	if (mode == CS_MODE_RISCV32)
-		// return b11110
-		return RISCV_FeatureStdExtM | RISCV_FeatureStdExtA |
+	uint64_t ret = RISCV_FeatureStdExtM | RISCV_FeatureStdExtA |
 		       RISCV_FeatureStdExtF | RISCV_FeatureStdExtD ;
-	else
-		
-		// CS_MODE_RISCV64, return b11111
-		return RISCV_Feature64Bit   | RISCV_FeatureStdExtM | 
-		       RISCV_FeatureStdExtA | RISCV_FeatureStdExtF | 
-		       RISCV_FeatureStdExtD ;
+
+	if (mode & CS_MODE_RISCV64)
+		ret |= RISCV_Feature64Bit;
+	if (mode & CS_MODE_RISCVC)
+		ret |= RISCV_FeatureStdExtC;
+
+	return ret;
 }
 
 #define GET_REGINFO_ENUM

--- a/cs.c
+++ b/cs.c
@@ -655,7 +655,7 @@ static uint8_t skipdata_size(cs_struct *handle)
 		case CS_ARCH_RISCV:
 			// special compress mode
 			if (handle->mode & CS_MODE_RISCVC)
-				return 1;
+				return 2;
 			return 4;
 	}
 }


### PR DESCRIPTION
The first patch is a cleaner version of pulll #1594, which I discovered after writing the patch.
The second patch is a small fix for skipdata.