### PR TITLE
MCInst: fix uninitialized value in operand value (next)

### DIFF
--- a/MCInst.c
+++ b/MCInst.c
@@ -21,6 +21,7 @@ void MCInst_Init(MCInst *inst)
 
 	for (i = 0; i < 48; i++) {
 		inst->Operands[i].Kind = kInvalid;
+		inst->Operands[i].ImmVal = 0;
 	}
 
 	inst->Opcode = 0;


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=14912

Same as https://github.com/aquynh/capstone/pull/1684 for next branch