### PR TITLE
M680X - remove unused s_cpu_type

### DIFF
--- a/arch/M680X/M680XDisassembler.c
+++ b/arch/M680X/M680XDisassembler.c
@@ -2130,11 +2130,6 @@ static const cpu_tables g_cpu_tables[] = {
 	},
 };
 
-static const char * const s_cpu_type[] = {
-	"INVALID", "6301", "6309", "6800", "6801", "6805", "6808",
-	"6809", "6811", "CPU12", "HCS08",
-};
-
 static bool m680x_setup_internals(m680x_info *info, e_cpu_type cpu_type,
 	uint16_t address,
 	const uint8_t *code, uint16_t code_len)
@@ -2260,12 +2255,6 @@ cs_err M680X_disassembler_init(cs_struct *ud)
 
 	if (M680X_INS_ENDING != ARR_SIZE(g_insn_props)) {
 		CS_ASSERT(M680X_INS_ENDING == ARR_SIZE(g_insn_props));
-
-		return CS_ERR_MODE;
-	}
-
-	if (M680X_CPU_TYPE_ENDING != ARR_SIZE(s_cpu_type)) {
-		CS_ASSERT(M680X_CPU_TYPE_ENDING == ARR_SIZE(s_cpu_type));
 
 		return CS_ERR_MODE;
 	}


### PR DESCRIPTION
If you compile capstone with `-Werror` warning enabled it produces the following error:
```
  CC      arch/M680X/M680XDisassembler.o
arch/M680X/M680XDisassembler.c:2124:20: error: variable 's_cpu_type' is not needed and will not be emitted [-Werror,-Wunneeded-internal-declaration]
static const char *s_cpu_type[] = {
                   ^
1 error generated.
```
Since `s_cpu_type` is not used anywhere in the `next` branch, it's safe to just remove it completely. It was used in the `master` branch only, albeit also unnecessary.

cc @trufae @ret2libc 
