### PR TITLE
fix crash when using skipdata with NULL mnemonic

### DIFF
--- a/cs.c
+++ b/cs.c
@@ -709,6 +709,8 @@ cs_err CAPSTONE_API cs_option(csh ud, cs_opt_type type, size_t value)
 		case CS_OPT_SKIPDATA_SETUP:
 			if (value)
 				handle->skipdata_setup = *((cs_opt_skipdata *)value);
+				if (handle->skipdata_setup.mnemonic == NULL)
+					handle->skipdata_setup.mnemonic = SKIPDATA_MNEM;
 			return CS_ERR_OK;
 
 		case CS_OPT_MNEMONIC:


### PR DESCRIPTION
When setting up skipdata with the mnemonic as `NULL`, capstone will crash during disassembly here when trying to strcpy a null pointer:
https://github.com/aquynh/capstone/blob/c93fa3a79614a0de48dcb0b9dd98156bd6326bee/cs.c#L945-L946

This can be verified by changing `cs_opt_skipdata` in `test_skipdata.c`.

This fix will use the `SKIPDATA_MNEM ` constant when `NULL` is passed, so it will work according to the documentation:
https://github.com/aquynh/capstone/blob/c93fa3a79614a0de48dcb0b9dd98156bd6326bee/include/capstone/capstone.h#L255-L260