### PR TITLE
python: only use ascii character

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -219,7 +219,7 @@ Capstone offers some unparalleled features:
 
 - Having clean/simple/lightweight/intuitive architecture-neutral API.
 
-- Provide details on disassembled instruction (called “decomposer” by others).
+- Provide details on disassembled instruction (called "decomposer" by others).
 
 - Provide semantics of the disassembled instruction, such as list of implicit
   registers read & written.


### PR DESCRIPTION
Otherwise python setup.py install from bindings/python
will fail with
SyntaxError: Non-ASCII character '\xe2' in file setup.py on line 223,
but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

Should fix oss-fuzz build
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=27542