### PR TITLE
M68k: Honour direction bit in fmove instruction

### DIFF
--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -2062,9 +2062,18 @@ static void d68020_cpgen(m68k_info *info)
 	ext->op_size.type = M68K_SIZE_TYPE_CPU;
 	ext->op_size.cpu_size = 0;
 
-	op0 = &ext->operands[0];
-	op1 = &ext->operands[1];
-
+	// Special case - adjust direction of fmove
+	if ((opmode == 0x00) && ((next >> 13) & 0x1) != 0)
+	{
+		op0 = &ext->operands[1];
+		op1 = &ext->operands[0];
+	}
+	else
+	{
+		op0 = &ext->operands[0];
+		op1 = &ext->operands[1];
+	}
+	
 	if (rm == 0 && supports_single_op && src == dst) {
 		ext->op_count = 1;
 		op0->reg = M68K_REG_FP0 + dst;


### PR DESCRIPTION
This commit fixes #1708 with fmove opcode.