### PR TITLE
Always return the same type from regs_read

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -830,12 +830,12 @@ class CsInsn(object):
         if regs_read_count.value > 0:
             regs_read = regs_read[:regs_read_count.value]
         else:
-            regs_read = ()
+            regs_read = []
 
         if regs_write_count.value > 0:
             regs_write = regs_write[:regs_write_count.value]
         else:
-            regs_write = ()
+            regs_write = []
 
         return (regs_read, regs_write)
 


### PR DESCRIPTION
When there are regs returned they are in a list, so the function returns a tuple of 2 lists.
When there are no regs, a tuple is returned instead, so it will be a tuple of tuples (or a tuple of one tuple + one list).