### PR TITLE
Fix pythonic bug

### DIFF
--- a/cs.c
+++ b/cs.c
@@ -707,10 +707,12 @@ cs_err CAPSTONE_API cs_option(csh ud, cs_opt_type type, size_t value)
 			return CS_ERR_OK;
 
 		case CS_OPT_SKIPDATA_SETUP:
-			if (value)
+			if (value) {
 				handle->skipdata_setup = *((cs_opt_skipdata *)value);
-				if (handle->skipdata_setup.mnemonic == NULL)
+				if (handle->skipdata_setup.mnemonic == NULL) {
 					handle->skipdata_setup.mnemonic = SKIPDATA_MNEM;
+				}
+			}
 			return CS_ERR_OK;
 
 		case CS_OPT_MNEMONIC:


### PR DESCRIPTION
This commit fixes these two warnings:

```
cs.c: In function ‘cs_option’:
393
cs.c:710:4: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
394
  710 |    if (value)
395
      |    ^~
396
cs.c:712:5: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
397
  712 |     if (handle->skipdata_setup.mnemonic == NULL)
398
      |     ^~
```