### PR TITLE
Fixes the (pip) Python Module build on FreeBSD.

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -140,6 +140,13 @@ def build_libraries():
         # Do not build tests & static library
         os.system('cmake -DCMAKE_BUILD_TYPE=RELEASE -DCAPSTONE_BUILD_TESTS=0 -DCAPSTONE_BUILD_STATIC=0 -G "NMake Makefiles" ..')
         os.system("nmake")
+    elif "freebsd" in SYSTEM:
+        # FreeBSD distinguishes make (BSD) vs gmake (GNU). Use cmake + bsd make :-)
+        if not os.path.exists("build"): os.mkdir("build")
+        os.chdir("build")
+        # Do not build tests & static library
+        os.system('cmake -DCMAKE_BUILD_TYPE=RELEASE -DCAPSTONE_BUILD_TESTS=0 -DCAPSTONE_BUILD_STATIC=0 ..')
+        os.system("make")
     else:   # Unix incl. cygwin
         os.system("CAPSTONE_BUILD_CORE_ONLY=yes bash ./make.sh")
 


### PR DESCRIPTION
This fixes the manual and `pip` Python Module build on FreeBSD.

FreeBSD distinguishes make (BSD) vs gmake (GNU) so cmake + bsd make needs to be used.

Although FreeBSD provides capstone system packages, this module will build and install its own C extensions.

[capstone-build-fixed.txt](https://github.com/aquynh/capstone/files/6456198/capstone-build-fixed.txt)
[capstone-build-fixed-tests.txt](https://github.com/aquynh/capstone/files/6456199/capstone-build-fixed-tests.txt)

Signed-off-by: Tomasz 'CeDeROM' CEDRO <tomek@cedro.info>