### PR TITLE
Update Makefile

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,6 +22,7 @@ ifeq ($(CROSS),)
 CC ?= cc
 else ifeq ($(ANDROID), 1)
 CC = $(CROSS)/../../bin/clang
+LDFLAGS += -pie -fPIE
 else
 CC = $(CROSS)gcc
 endif


### PR DESCRIPTION
fix error: Android 5.0 and later only support position-independent executables (-fPIE).