### PR TITLE
[SH] Fix build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 # For MSVC_RUNTIME_LIBRARY
 cmake_minimum_required(VERSION 3.15)
 
-add_compile_options(-Wunused-function -Warray-bounds -Wunused-variable -Wparentheses -Wint-in-bool-context)
+if (MSVC)
+    add_compile_options(/W1 /w14189 /w16268)
+else()
+    add_compile_options(-Wunused-function -Warray-bounds -Wunused-variable -Wparentheses -Wint-in-bool-context)
+endif()
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
     message(FATAL_ERROR "In-tree builds are not supported. Run CMake from a separate directory: cmake -B build")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # For MSVC_RUNTIME_LIBRARY
 cmake_minimum_required(VERSION 3.15)
 
-if (MSVC)
+if (CMAKE_C_COMPILER_ID MATCHES "MSVC")
     add_compile_options(/W1 /w14189 /w16268)
 else()
     add_compile_options(-Wunused-function -Warray-bounds -Wunused-variable -Wparentheses -Wint-in-bool-context)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # For MSVC_RUNTIME_LIBRARY
 cmake_minimum_required(VERSION 3.15)
 
+add_compile_options(-Wunused-function -Warray-bounds -Wunused-variable -Wparentheses -Wint-in-bool-context)
+
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
     message(FATAL_ERROR "In-tree builds are not supported. Run CMake from a separate directory: cmake -B build")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,6 @@
 # For MSVC_RUNTIME_LIBRARY
 cmake_minimum_required(VERSION 3.15)
 
-if (CMAKE_C_COMPILER_ID MATCHES "MSVC")
-    add_compile_options(/W1 /w14189 /w16268)
-else()
-    add_compile_options(-Wunused-function -Warray-bounds -Wunused-variable -Wparentheses -Wint-in-bool-context)
-endif()
-
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
     message(FATAL_ERROR "In-tree builds are not supported. Run CMake from a separate directory: cmake -B build")
 endif()
@@ -30,6 +24,13 @@ cmake_policy(SET CMP0091 NEW)
 project(capstone
     VERSION 5.0
 )
+
+if (MSVC)
+    add_compile_options(/W1 /w14189 /w16268)
+else()
+    add_compile_options(-Wunused-function -Warray-bounds -Wunused-variable -Wparentheses -Wint-in-bool-context)
+endif()
+
 
 # to configure the options specify them in in the command line or change them in the cmake UI.
 # Don't edit the makefile!

--- a/arch/SH/SHDisassembler.c
+++ b/arch/SH/SHDisassembler.c
@@ -374,7 +374,6 @@ static bool op0xx8(uint16_t code, uint64_t address, MCInst *MI, cs_mode mode,
 		{-1, SH_INS_INVALID, ISA_ALL, none},
 	};
 	
-	int lvl = isalevel(mode);
 	sh_insn insn = lookup_insn(list, insn_code, mode);
 	if (code & 0x0f00)
 		return MCDisassembler_Fail;
@@ -730,8 +729,6 @@ static bool op4xx5(uint16_t code, uint64_t address, MCInst *MI, cs_mode mode,
 		   sh_info *info, cs_detail *detail)
 {
 	int r = (code >> 8) & 0x0f;
-	uint16_t *regs;
-	uint8_t *count;
 	enum direction rw;
 	static const struct ri_list list[] = {
 		{0, SH_INS_ROTR, ISA_ALL, none},
@@ -1130,7 +1127,6 @@ opLDRSE(LDRE)
 static bool op##insn##_i(uint16_t code, uint64_t address, MCInst *MI, \
 			 cs_mode mode, sh_info *info, cs_detail *detail) \
 {									\
-	int dsp = code & 0x00ff;					\
 	MCInst_setOpcode(MI, SH_INS_##insn);				\
 	set_imm(info, 0, code & 0xff);					\
 	set_reg(info, SH_REG_R0, write, detail);			\
@@ -1146,7 +1142,6 @@ opImmR0(OR)
 static bool op##insn##_B(uint16_t code, uint64_t address, MCInst *MI, \
 			 cs_mode mode, sh_info *info, cs_detail *detail) \
 {									\
-	int dsp = code & 0x00ff;					\
 	MCInst_setOpcode(MI, SH_INS_##insn);				\
 	set_imm(info, 0, code & 0xff);					\
 	set_mem(info, SH_OP_MEM_GBR_R0, SH_REG_R0, 0, 8, detail);	\
@@ -1587,7 +1582,6 @@ static bool set_dsp_move_d(sh_info *info, int xy, uint16_t code, cs_mode mode, c
 	int a;
 	int d;
 	int dir;
-	int sz;
 	int op;
 	static const sh_reg base[] = {SH_REG_DSP_A0, SH_REG_DSP_X0};
 	switch (xy) {
@@ -1802,7 +1796,6 @@ static bool dsp_op_cc0_2opr(uint32_t code, sh_info *info, sh_insn insn,
 static bool decode_dsp_3op(const uint32_t code, sh_info *info,
 			   cs_detail *detail)
 {
-	int r;
 	int cc = (code >> 8) & 3;
 	int sx = (code >> 6) & 3;
 	int sy = (code >> 4) & 3;
@@ -2030,8 +2023,6 @@ static bool decode_dsp_3op(const uint32_t code, sh_info *info,
 static bool decode_dsp_p(const uint32_t code, MCInst *MI, cs_mode mode,
 			 sh_info *info, cs_detail *detail)
 {
-	bool ret;
-	
 	int dz = code & 0x0f;
 	MCInst_setOpcode(MI, SH_INS_DSP);
 	if (!decode_dsp_d(code >> 16, MI, mode, info, detail))

--- a/arch/SH/SHDisassembler.c
+++ b/arch/SH/SHDisassembler.c
@@ -564,13 +564,6 @@ static bool opMOV_rpd(uint16_t code, uint64_t address, MCInst *MI,
 	return MCDisassembler_Success;
 }
 
-static bool opDIV0U(uint16_t code, uint64_t address, MCInst *MI, cs_mode mode,
-		    sh_info *info, cs_detail *detail)
-{
-	MCInst_setOpcode(MI, SH_INS_DIV0U);
-	return MCDisassembler_Success;
-}
-
 opRR(ISA_ALL, TST, 0)
 opRR(ISA_ALL, AND, 0)
 opRR(ISA_ALL, XOR, 0)
@@ -1230,21 +1223,6 @@ static bool opMOVA(uint16_t code, uint64_t address, MCInst *MI, cs_mode mode,
 	set_mem(info, SH_OP_MEM_PCR, SH_REG_INVALID, (address & ~3) + 4 + dsp,
 		0, detail);
 	set_reg(info, SH_REG_R0, write, detail);
-	return MCDisassembler_Success;
-}
-
-static bool opc8xx(uint16_t code, uint64_t address, MCInst *MI, cs_mode mode,
-		   sh_info *info, cs_detail *detail)
-{
-	int imm = (code & 0x00ff);
-	sh_insn insn[] = {SH_INS_TST, SH_INS_AND, SH_INS_XOR, SH_INS_OR};
-	MCInst_setOpcode(MI, insn[(code >> 8) & 3]);
-	set_imm(info, 1, imm);
-	if (code & 0x0400) {
-		set_mem(info, SH_OP_MEM_GBR_R0, SH_REG_INVALID, 0, 8, detail);
-	} else {
-		set_reg(info, SH_REG_R0, write, detail);
-	}
 	return MCDisassembler_Success;
 }
 

--- a/arch/SH/SHInstPrinter.c
+++ b/arch/SH/SHInstPrinter.c
@@ -351,7 +351,6 @@ void SH_printInst(MCInst* MI, SStream* O, void* PrinterInfo)
 {
 #ifndef CAPSTONE_DIET
 	sh_info *info = (sh_info *)PrinterInfo;
-	cs_detail *detail = MI->flat_insn->detail;
 	int i;
 	int imm;
 

--- a/cs.c
+++ b/cs.c
@@ -369,8 +369,8 @@ bool CAPSTONE_API cs_support(int query)
 				    (1 << CS_ARCH_M68K)  | (1 << CS_ARCH_TMS320C64X) |
 				    (1 << CS_ARCH_M680X) | (1 << CS_ARCH_EVM)        |
 				    (1 << CS_ARCH_RISCV) | (1 << CS_ARCH_MOS65XX)    | 
-				    (1 << CS_ARCH_WASM)  | (1 << CS_ARCH_BPF))       |
-				    (1 << CS_ARCH_SH);
+				    (1 << CS_ARCH_WASM)  | (1 << CS_ARCH_BPF)       |
+				    (1 << CS_ARCH_SH));
 
 	if ((unsigned int)query < CS_ARCH_MAX)
 		return all_arch & (1 << query);

--- a/tests/test_sh.c
+++ b/tests/test_sh.c
@@ -37,10 +37,6 @@ static void print_string_hex_short(unsigned char *str, size_t len)
 		printf("%02x", *c & 0xff);
 }
 
-static const char *s_access[] = {
-	"UNCHANGED", "READ", "WRITE", "READ | WRITE",
-};
-
 static void print_read_write_regs(csh handle, cs_detail *detail)
 {
 	int i;
@@ -89,7 +85,6 @@ static void print_insn_detail(csh handle, cs_insn *insn)
 
 	for (i = 0; i < sh->op_count; i++) {
 		cs_sh_op *op = &(sh->operands[i]);
-		const char *comment;
 
 		switch ((int)op->type) {
 		default:


### PR DESCRIPTION
These commits add several build warning options to `CMakeList.txt` and fixes build warnings for the SH arch.
Two unused functions are removed and a `parantheses`/`int-in-bool-contexxt` warning is fixed.

@ysat0 Could you please take a look at it as well?