### PR TITLE
sh: add missing include for CMake install step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ set(HEADERS_COMMON
     include/capstone/mos65xx.h
     include/capstone/bpf.h
     include/capstone/riscv.h
+    include/capstone/sh.h
     include/capstone/platform.h
 )
 


### PR DESCRIPTION
This PR adds missing sh.h header in capstone installation.

Closes #1963