### PR TITLE
Fix CITest && python binding issues

### DIFF
--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -93,7 +93,6 @@ jobs:
       run: |
         ./make.sh;
         make check;
-        mkdir build && mv libcapstone.* build/ && cd build;
         # sudo make install
 
     - name: cmake
@@ -103,14 +102,15 @@ jobs:
         mkdir build && cd build;
         cmake -DCAPSTONE_INSTALL=1 -DBUILD_SHARED_LIBS=1 ..;
         cmake --build . --config Release;
+        cp libcapstone.* ../;
         # sudo make install;
 
     - name: build python binding
       shell: 'script -q -e -c "bash {0}"'
       run: |
         pwd && ls;
-        mkdir -p ../bindings/python/capstone/lib && cp libcapstone.so.5.* ../bindings/python/capstone/lib/libcapstone.so;
-        cd ../bindings/python;
+        mkdir -p bindings/python/capstone/lib && cp libcapstone.so.5.* bindings/python/capstone/lib/libcapstone.so;
+        cd bindings/python;
         make && make check ; 
         cd ../..;
 

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -30,28 +30,28 @@ jobs:
       matrix:
         config:
           - {
-              name: 'ubuntu-18.04 x64 python2.7 make',
+              name: 'ubuntu-18.04 x64 python2.7 cmake',
               os: ubuntu-18.04,
               arch: x64,
               python-arch: x64,
               python-version: '2.7',
-              build-system: 'make',
+              build-system: 'cmake',
             }
           - {
-              name: 'ubuntu-18.04 x64 python3.6 make',
+              name: 'ubuntu-18.04 x64 python3.6 cmake',
               os: ubuntu-18.04,
               arch: x64,
               python-arch: x64,
               python-version: '3.6',
-              build-system: 'make',
+              build-system: 'cmake',
             }
           - {
-              name: 'ubuntu-20.04 x64 python2.7 make',
+              name: 'ubuntu-20.04 x64 python2.7 cmake',
               os: ubuntu-20.04,
               arch: x64,
               python-arch: x64,
               python-version: '2.7',
-              build-system: 'make',
+              build-system: 'cmake',
             }
           - {
               name: 'ubuntu-20.04 x64 python3.9 make',

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -93,7 +93,7 @@ jobs:
       run: |
         ./make.sh
         make check
-        sudo make install
+        # sudo make install
 
     - name: cmake
       if: startsWith(matrix.config.build-system, 'cmake')
@@ -102,13 +102,16 @@ jobs:
         mkdir build && cd build;
         cmake -DCAPSTONE_INSTALL=1 -DBUILD_SHARED_LIBS=1 ..;
         cmake --build . --config Release;
-        sudo make install;
+        # sudo make install;
 
     - name: build python binding
       shell: 'script -q -e -c "bash {0}"'
       run: |
+        pwd;
+        ls;
         mkdir -p ~/capstone/bindings/python/capstone/lib && cp libcapstone.so.5.* ~/capstone/bindings/python/capstone/lib/libcapstone.so;
         cd ~/capstone/bindings/python;
+        pwd;
         make check; cd ../..;
 
     - name: cstest

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -93,6 +93,7 @@ jobs:
       run: |
         ./make.sh;
         make check;
+        cp libcapstone.so.5 libcapstone.so.5.0
         # sudo make install
 
     - name: cmake
@@ -108,7 +109,6 @@ jobs:
     - name: build python binding
       shell: 'script -q -e -c "bash {0}"'
       run: |
-        pwd && ls;
         mkdir -p bindings/python/capstone/lib && cp libcapstone.so.5.* bindings/python/capstone/lib/libcapstone.so;
         cd bindings/python;
         make && make check ; 

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -108,6 +108,7 @@ jobs:
     - name: build python binding
       shell: 'script -q -e -c "bash {0}"'
       run: |
+        pwd && ls;
         mkdir -p ../bindings/python/capstone/lib && cp libcapstone.so.5.* ../bindings/python/capstone/lib/libcapstone.so;
         cd ../bindings/python;
         make && make check ; 

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -91,8 +91,9 @@ jobs:
       if: startsWith(matrix.config.build-system, 'make')
       shell: 'script -q -e -c "bash {0}"'
       run: |
-        ./make.sh
-        make check
+        ./make.sh;
+        make check;
+        mkdir build && mv libcapstone.* build/ && cd build;
         # sudo make install
 
     - name: cmake
@@ -107,12 +108,10 @@ jobs:
     - name: build python binding
       shell: 'script -q -e -c "bash {0}"'
       run: |
-        pwd;
-        ls;
-        mkdir -p ~/capstone/bindings/python/capstone/lib && cp libcapstone.so.5.* ~/capstone/bindings/python/capstone/lib/libcapstone.so;
-        cd ~/capstone/bindings/python;
-        pwd;
-        make check; cd ../..;
+        mkdir -p ../bindings/python/capstone/lib && cp libcapstone.so.5.* ../bindings/python/capstone/lib/libcapstone.so;
+        cd ../bindings/python;
+        make && make check ; 
+        cd ../..;
 
     - name: cstest
       shell: 'script -q -e -c "bash {0}"'

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -99,17 +99,17 @@ jobs:
       if: startsWith(matrix.config.build-system, 'cmake')
       shell: 'script -q -e -c "bash {0}"'
       run: |
-        mkdir build
-        cd build
-        cmake -DCAPSTONE_INSTALL=1 ..
-        cmake --build . --config Release
-        sudo make install
+        mkdir build && cd build;
+        cmake -DCAPSTONE_INSTALL=1 -DBUILD_SHARED_LIBS=1 ..;
+        cmake --build . --config Release;
+        sudo make install;
 
     - name: build python binding
       shell: 'script -q -e -c "bash {0}"'
       run: |
-        cp libcapstone.so.* bindings/python/libcapstone.so
-        cd bindings/python && make check; cd ../..;
+        mkdir -p ~/capstone/bindings/python/capstone/lib && cp libcapstone.so.5.* ~/capstone/bindings/python/capstone/lib/libcapstone.so;
+        cd ~/capstone/bindings/python;
+        make check; cd ../..;
 
     - name: cstest
       shell: 'script -q -e -c "bash {0}"'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ cmake_policy(SET CMP0042 NEW)
 cmake_policy(SET CMP0091 NEW)
 
 project(capstone
-    VERSION 5.0.0
+    VERSION 5.0
 )
 
 # to configure the options specify them in in the command line or change them in the cmake UI.

--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,7 @@ endif
 endif
 
 API_MAJOR=$(shell echo `grep -e CS_API_MAJOR include/capstone/capstone.h | grep -v = | awk '{print $$3}'` | awk '{print $$1}')
+API_MINOR=$(shell echo `grep -e CS_API_MINOR include/capstone/capstone.h | grep -v = | awk '{print $$3}'` | awk '{print $$1}')
 VERSION_EXT =
 
 IS_APPLE := $(shell $(CC) -dM -E - < /dev/null 2> /dev/null | grep __apple_build_version__ | wc -l | tr -d " ")
@@ -374,7 +375,7 @@ CFLAGS := $(CFLAGS:-fPIC=)
 else
 # Linux, *BSD
 EXT = so
-VERSION_EXT = $(EXT).$(API_MAJOR)
+VERSION_EXT = $(EXT).$(API_MAJOR).$(API_MINOR)
 AR_EXT = a
 $(LIBNAME)_LDFLAGS += -Wl,-soname,lib$(LIBNAME).$(VERSION_EXT)
 endif

--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,6 @@ endif
 endif
 
 API_MAJOR=$(shell echo `grep -e CS_API_MAJOR include/capstone/capstone.h | grep -v = | awk '{print $$3}'` | awk '{print $$1}')
-API_MINOR=$(shell echo `grep -e CS_API_MINOR include/capstone/capstone.h | grep -v = | awk '{print $$3}'` | awk '{print $$1}')
 VERSION_EXT =
 
 IS_APPLE := $(shell $(CC) -dM -E - < /dev/null 2> /dev/null | grep __apple_build_version__ | wc -l | tr -d " ")
@@ -375,7 +374,7 @@ CFLAGS := $(CFLAGS:-fPIC=)
 else
 # Linux, *BSD
 EXT = so
-VERSION_EXT = $(EXT).$(API_MAJOR).$(API_MINOR)
+VERSION_EXT = $(EXT).$(API_MAJOR)
 AR_EXT = a
 $(LIBNAME)_LDFLAGS += -Wl,-soname,lib$(LIBNAME).$(VERSION_EXT)
 endif

--- a/bindings/python/setup_cython.py
+++ b/bindings/python/setup_cython.py
@@ -9,7 +9,7 @@ from distutils.command.build import build
 from Cython.Distutils import build_ext
 
 SYSTEM = sys.platform
-VERSION = '4.0.0'
+VERSION = '5.0.0'
 
 # adapted from commit e504b81 of Nguyen Tan Cong
 # Reference: https://docs.python.org/2/library/platform.html#cross-platform

--- a/bindings/python/test_basic.py
+++ b/bindings/python/test_basic.py
@@ -82,7 +82,10 @@ def test_cs_disasm_quick():
 
 
 def test_different_data_formats():
-    data = bytes.fromhex('4831C948F7E1043B48BB0A2F62696E2F2F736852530A545F5257545E0F05')
+    if _python3:
+        data = bytes.fromhex('4831C948F7E1043B48BB0A2F62696E2F2F736852530A545F5257545E0F05')
+    else:
+        data = bytes(bytearray.fromhex('4831C948F7E1043B48BB0A2F62696E2F2F736852530A545F5257545E0F05'))
     mnemonics = ['xor', 'mul', 'add', 'movabs', 'push', 'pop', 'push', 'push', 'push', 'pop', 'syscall']
     disassembler = Cs(CS_ARCH_X86, CS_MODE_64)
     for name, code in (

--- a/cs.c
+++ b/cs.c
@@ -369,8 +369,8 @@ bool CAPSTONE_API cs_support(int query)
 				    (1 << CS_ARCH_M68K)  | (1 << CS_ARCH_TMS320C64X) |
 				    (1 << CS_ARCH_M680X) | (1 << CS_ARCH_EVM)        |
 				    (1 << CS_ARCH_RISCV) | (1 << CS_ARCH_MOS65XX)    | 
-				    (1 << CS_ARCH_WASM)  | (1 << CS_ARCH_BPF))       |
-				    (1 << CS_ARCH_SH);
+				    (1 << CS_ARCH_WASM)  | (1 << CS_ARCH_BPF)        |
+				    (1 << CS_ARCH_SH));
 
 	if ((unsigned int)query < CS_ARCH_MAX)
 		return all_arch & (1 << query);

--- a/suite/regress/test_arm64_ldr_registers.py
+++ b/suite/regress/test_arm64_ldr_registers.py
@@ -2,6 +2,9 @@ import unittest
 from capstone import *
 from capstone.arm64 import *
 
+_python3 = sys.version_info.major == 3
+
+
 class SubRegTest(unittest.TestCase):
 
     PATTERNS = [
@@ -18,7 +21,10 @@ class SubRegTest(unittest.TestCase):
         self.cs.detail = True
 
         for pattern, asm in self.PATTERNS:
-            l = list(self.cs.disasm(bytes.fromhex(pattern), 0))
+            if _python3:
+                l = list(self.cs.disasm(bytes.fromhex(pattern), 0))
+            else:
+                l = list(self.cs.disasm(bytearray.fromhex(pattern), 0))
             self.assertTrue(len(l) == 1)
 
             _, expected_reg_written, expected_reg_read = asm.split()


### PR DESCRIPTION
- Add more `cmake` tests while reducing `make` tests(cmake will be mainly supported in the future).
- Fix python binding test for **Python3+**.
- Consider not supporting Python2 anymore in the future.