### PR TITLE
In x86: Fixed backward compatibility with C90

### DIFF
--- a/MCRegisterInfo.c
+++ b/MCRegisterInfo.c
@@ -133,13 +133,13 @@ const MCRegisterClass* MCRegisterInfo_getRegClass(const MCRegisterInfo *RI, unsi
 
 bool MCRegisterClass_contains(const MCRegisterClass *c, unsigned Reg)
 {
+	unsigned InByte = Reg % 8;
+	unsigned Byte = Reg / 8;
+
 	// Make sure that MCRegisterInfo_getRegClass didn't return 0
 	// (for calls to GETREGCLASS_CONTAIN0)
 	if(!c)
 		return false;
-
-	unsigned InByte = Reg % 8;
-	unsigned Byte = Reg / 8;
 
 	if (Byte >= c->RegSetSize)
 		return false;

--- a/MCRegisterInfo.c
+++ b/MCRegisterInfo.c
@@ -133,14 +133,17 @@ const MCRegisterClass* MCRegisterInfo_getRegClass(const MCRegisterInfo *RI, unsi
 
 bool MCRegisterClass_contains(const MCRegisterClass *c, unsigned Reg)
 {
-	unsigned InByte = Reg % 8;
-	unsigned Byte = Reg / 8;
+	unsigned InByte = 0;
+	unsigned Byte = 0;
 
 	// Make sure that MCRegisterInfo_getRegClass didn't return 0
 	// (for calls to GETREGCLASS_CONTAIN0)
 	if(!c)
 		return false;
-
+	
+	InByte = Reg % 8;
+	Byte = Reg / 8;
+	
 	if (Byte >= c->RegSetSize)
 		return false;
 

--- a/MCRegisterInfo.c
+++ b/MCRegisterInfo.c
@@ -140,10 +140,10 @@ bool MCRegisterClass_contains(const MCRegisterClass *c, unsigned Reg)
 	// (for calls to GETREGCLASS_CONTAIN0)
 	if(!c)
 		return false;
-	
+
 	InByte = Reg % 8;
 	Byte = Reg / 8;
-	
+
 	if (Byte >= c->RegSetSize)
 		return false;
 


### PR DESCRIPTION
In order to keep the backward compatibility, the function has to start from variable definitions.

Before the fix:

![before_fix](https://user-images.githubusercontent.com/3115348/223785941-f55a3d05-a0fc-4dc6-aa07-9842c13935cf.png)

After the fix:

![after_fix](https://user-images.githubusercontent.com/3115348/223785970-363e8544-b693-4242-b98f-323b5dc13961.png)

