### PR TITLE
Fix for incorrect register usages in ARM64 MOV/MOVN instructions.

### DIFF
--- a/arch/AArch64/AArch64MappingInsnOp.inc
+++ b/arch/AArch64/AArch64MappingInsnOp.inc
@@ -13620,12 +13620,12 @@
 
 {	/* AArch64_MOVNWi, AArch64_INS_MOV: mov */
 	0,
-	{ CS_AC_WRITE | CS_AC_READ, CS_AC_READ, CS_AC_READ, 0 }
+	{ CS_AC_WRITE, CS_AC_READ, CS_AC_READ, 0 }
 },
 
 {	/* AArch64_MOVNXi, AArch64_INS_MOV: mov */
 	0,
-	{ CS_AC_WRITE | CS_AC_READ, CS_AC_READ, CS_AC_READ, 0 }
+	{ CS_AC_WRITE, CS_AC_READ, CS_AC_READ, 0 }
 },
 
 {	/* AArch64_MOVPRFX_ZPmZ_B, AArch64_INS_MOVPRFX: movprfx */
@@ -13675,12 +13675,12 @@
 
 {	/* AArch64_MOVZWi, AArch64_INS_MOV: mov */
 	0,
-	{ CS_AC_WRITE | CS_AC_READ, CS_AC_READ, CS_AC_READ, 0 }
+	{ CS_AC_WRITE, CS_AC_READ, CS_AC_READ, 0 }
 },
 
 {	/* AArch64_MOVZXi, AArch64_INS_MOV: mov */
 	0,
-	{ CS_AC_WRITE | CS_AC_READ, CS_AC_READ, CS_AC_READ, 0 }
+	{ CS_AC_WRITE, CS_AC_READ, CS_AC_READ, 0 }
 },
 
 {	/* AArch64_MRS, AArch64_INS_MRS: mrs */

--- a/suite/regress/test_arm64_mov_imm.py
+++ b/suite/regress/test_arm64_mov_imm.py
@@ -1,0 +1,54 @@
+import unittest
+from capstone import *
+from capstone.arm64 import *
+
+class ARM64MovImmRegAccessTest(unittest.TestCase):
+
+    # These instructions should all have their 1st operand register being WRITTEN and not READ.
+    PATTERNS = [
+        ("00 00 80 D2", "mov x0, #0"),
+        ("E2 66 82 52", "movz w2, #0x1337"),
+        ("A3 D5 9B 92", "movn x3, #0xdead"),
+        ("E4 DD 97 12", "movn w4, #0xbeef"),
+        ]
+
+    def setUp(self):
+        self.insts = []
+        self.cs = Cs(CS_ARCH_ARM64, CS_MODE_LITTLE_ENDIAN)
+        self.cs.detail = True
+
+        for pattern, asm in self.PATTERNS:
+            l = list(self.cs.disasm(bytes.fromhex(pattern), 0))
+            self.assertTrue(len(l) == 1)
+
+            _, expected_reg_written, _ = asm.split()
+            # strip comma and []
+            expected_reg_written = [expected_reg_written[:-1]]
+            expected_reg_read = [] # nothing should be read
+            expected_regs = [expected_reg_read, expected_reg_written]
+
+            self.insts.append((l[0], asm, expected_regs))
+
+
+    def test_regs_access(self):
+        """Check that the `regs_access` API provides correct data"""
+        
+        for inst, asm, expected_regs in self.insts:
+
+            # Check that the instruction writes the first register operand and reads the second
+            for i, decoded_regs in enumerate(map(lambda l: list(map(self.cs.reg_name, l)), inst.regs_access())):
+                self.assertEqual(decoded_regs, expected_regs[i], "%s has %r %s registers instead of %r" % (asm, decoded_regs, ["read", "written"][i], expected_regs[i]))
+
+
+    def test_operands(self):
+        """Check that the `operands` API provides correct data"""
+        for inst, asm, expected_regs in self.insts:
+            ops = inst.operands
+            self.assertEqual(len(ops), 2)
+            
+            self.assertEqual(ops[0].type, CS_OP_REG, "%s has operand 0 with invalid type" % asm)
+            self.assertEqual(ops[0].access, CS_AC_WRITE, "%s has operand 0 with invalid access" % asm)
+            self.assertEqual(ops[1].type, CS_OP_IMM, "%s has operand 0 with invalid type" % asm)
+            
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As reported by issues #1652  and #1591 there were issues in register usages reported by `cstool` (and associated APIs):

```
./cstool -d arm64 '00 00 80 D2'
 0  00 00 80 d2  mov	x0, #0
	ID: 488 (mov)
	op_count: 2
		operands[0].type: REG = x0
		operands[0].access: READ | WRITE  // should be WRITE only
		operands[1].type: IMM = 0x0
	Registers read: x0
	Registers modified: x0
```

This PR fixes the issue and adds a unit test.
Like most other register usage issues, the problem was `arch/AArch64/AArch64MappingInsnOp.inc` and it would be better to fix the script that was used to generate it, but it's sadly not committed as part of Capstone.
