### PR TITLE
update CI ubuntu version

### DIFF
--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -30,22 +30,6 @@ jobs:
       matrix:
         config:
           - {
-              name: 'ubuntu-18.04 x64 python2.7 cmake',
-              os: ubuntu-18.04,
-              arch: x64,
-              python-arch: x64,
-              python-version: '2.7',
-              build-system: 'cmake',
-            }
-          - {
-              name: 'ubuntu-18.04 x64 python3.6 cmake',
-              os: ubuntu-18.04,
-              arch: x64,
-              python-arch: x64,
-              python-version: '3.6',
-              build-system: 'cmake',
-            }
-          - {
               name: 'ubuntu-20.04 x64 python2.7 cmake',
               os: ubuntu-20.04,
               arch: x64,
@@ -54,16 +38,32 @@ jobs:
               build-system: 'cmake',
             }
           - {
-              name: 'ubuntu-20.04 x64 python3.9 make',
+              name: 'ubuntu-20.04 x64 python3.6 cmake',
               os: ubuntu-20.04,
+              arch: x64,
+              python-arch: x64,
+              python-version: '3.6',
+              build-system: 'cmake',
+            }
+          - {
+              name: 'ubuntu-22.04 x64 python2.7 cmake',
+              os: ubuntu-22.04,
+              arch: x64,
+              python-arch: x64,
+              python-version: '2.7',
+              build-system: 'cmake',
+            }
+          - {
+              name: 'ubuntu-22.04 x64 python3.9 make',
+              os: ubuntu-22.04,
               arch: x64,
               python-arch: x64,
               python-version: '3.9',
               build-system: 'make',
             }            
           - {
-              name: 'ubuntu-20.04 x64 python3.9 cmake',
-              os: ubuntu-20.04,
+              name: 'ubuntu-22.04 x64 python3.9 cmake',
+              os: ubuntu-22.04,
               arch: x64,
               python-arch: x64,
               python-version: '3.9',


### PR DESCRIPTION
According to [Github](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners), Ubuntu 18.04 has been *deprecated*.