### PR TITLE
[broken, don't merge] correct register access attributes of Arm's LDM instruction

### DIFF
--- a/arch/ARM/ARMInstPrinter.c
+++ b/arch/ARM/ARMInstPrinter.c
@@ -753,13 +753,14 @@ void ARM_printInst(MCInst *MI, SStream *O, void *Info)
 				if (MI->csh->detail) {
 					MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].type = ARM_OP_REG;
 					MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].reg = BaseReg;
-					MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].access = CS_AC_READ | CS_AC_WRITE;
+					MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].access = CS_AC_READ;
 					MI->flat_insn->detail->arm.op_count++;
 				}
 
 				if (Writeback) {
 					MI->writeback = true;
 					SStream_concat0(O, "!");
+					MI->flat_insn->detail->arm.operands[MI->flat_insn->detail->arm.op_count].access |= CS_AC_WRITE;
 				}
 
 				SStream_concat0(O, ", ");


### PR DESCRIPTION
Arm's LDM first register is only written when writeback is true. Otherwise, it is read-only.