### PR TITLE
fix cstest `Makefile`

### DIFF
--- a/suite/cstest/Makefile
+++ b/suite/cstest/Makefile
@@ -1,12 +1,12 @@
 SOURCE = src
-INCLUDE = include
+INCLUDE = include ../../include
 BUILD = build
 LIBRARY = -lcmocka -lcapstone -L../..
 
 all:
 	rm -rf $(BUILD)
 	mkdir $(BUILD)
-	$(CC) $(SOURCE)/*.c -I$(INCLUDE) -o $(BUILD)/cstest $(LIBRARY)
+	$(CC) $(SOURCE)/*.c $(INCLUDE:%=-I %) -o $(BUILD)/cstest $(LIBRARY)
 cstest:
 	$(BUILD)/cstest -d ../MC	
 clean:


### PR DESCRIPTION
fix

```
cc src/*.c -Iinclude -o build/cstest -lcmocka -lcapstone -L../..
In file included from src/arm64_detail.c:5:
include/factory.h:8:10: fatal error: capstone/capstone.h: No such file or directory
    8 | #include <capstone/capstone.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from src/arm_detail.c:5:
include/factory.h:8:10: fatal error: capstone/capstone.h: No such file or directory
    8 | #include <capstone/capstone.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```