### PR TITLE
Fix missing `NOTRACK` prefix

### DIFF
--- a/suite/cstest/issues.cs
+++ b/suite/cstest/issues.cs
@@ -1,3 +1,11 @@
+!# issue 1997 notrack jmp
+!# CS_ARCH_X86, CS_MODE_64, None
+0x3e,0xff,0xe0 == notrack jmp rax
+
+!# issue 1997 notrack call
+!# CS_ARCH_X86, CS_MODE_64, None
+0x3e,0xff,0xd0 == notrack call rax
+
 !# issue 1924 SME Index instruction alias printing is not always valid
 !# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
 0x02,0x00,0x9f,0xe0 == ld1w	{za0h.s[w12, 2]}, p0/z, [x0] ; operands[0].type: REG = zas0 ; operands[0].index.base: REG = w12 ; operands[0].index.disp: 0x2 ; operands[1].type: REG = p0 ; operands[2].type: MEM ; operands[2].mem.base: REG = x0


### PR DESCRIPTION
Fixes https://github.com/capstone-engine/capstone/issues/1997