### PR TITLE
Add missing arm64 to Darwin LIBARCHS and remove dependencies tracking…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ V ?= 0
 
 OS := $(shell uname)
 ifeq ($(OS),Darwin)
-LIBARCHS ?= x86_64
+LIBARCHS ?= x86_64 arm64
 PREFIX ?= /usr/local
 endif
 

--- a/functions.mk
+++ b/functions.mk
@@ -2,7 +2,9 @@
 # Common functions used by Makefile & tests/Makefile
 
 define compile
-        @$(CC) -MM -MP -MT $@ -MT $(@:.o=.d) $(CFLAGS) $< > $(@:.o=.d)
+	$(ifeq ($(MACOS_UNIVERSAL),no),
+	@$(CC) -MM -MP -MT $@ -MT $(@:.o=.d) $(CFLAGS) $< > $(@:.o=.d)
+	)
 	${CC} ${CFLAGS} -c $< -o $@
 endef
 

--- a/functions.mk
+++ b/functions.mk
@@ -3,7 +3,7 @@
 
 define compile
 	$(ifeq ($(MACOS_UNIVERSAL),no),
-	@$(CC) -MM -MP -MT $@ -MT $(@:.o=.d) $(CFLAGS) $< > $(@:.o=.d)
+		@$(CC) -MM -MP -MT $@ -MT $(@:.o=.d) $(CFLAGS) $< > $(@:.o=.d)
 	)
 	${CC} ${CFLAGS} -c $< -o $@
 endef


### PR DESCRIPTION
Add missing arm64 to Darwin LIBARCHS and remove dependencies tracking if building universal binary (dependencies not compatible with fat binaries)