### PR TITLE
[PPC] Fix random branch hint and `update_cr0` set up.

### DIFF
--- a/arch/PowerPC/PPCInstPrinter.c
+++ b/arch/PowerPC/PPCInstPrinter.c
@@ -410,6 +410,7 @@ void PPC_printInst(MCInst *MI, SStream *O, void *Info)
 {
 	char *mnem;
 	unsigned int opcode = MCInst_getOpcode(MI);
+	memset(O->buffer, 0, sizeof(O->buffer));
 
 	// printf("opcode = %u\n", opcode);
 
@@ -635,6 +636,16 @@ void PPC_printInst(MCInst *MI, SStream *O, void *Info)
 		cs_mem_free(mnem);
 	} else
 		printInstruction(MI, O);
+
+	const char *mnem_end = strchr(O->buffer, ' ');
+	unsigned mnem_len = 0;
+	if (mnem_end)
+		mnem_len = mnem_end - O->buffer;
+	if (!mnem_end || mnem_len >= sizeof(MI->flat_insn->mnemonic))
+		mnem_len = sizeof(MI->flat_insn->mnemonic) - 1;
+
+	memset(MI->flat_insn->mnemonic, 0, sizeof(MI->flat_insn->mnemonic));
+	strncpy(MI->flat_insn->mnemonic, O->buffer, mnem_len);
 }
 
 // FIXME


### PR DESCRIPTION
The branch hint and the `update_cr0` flag can be set to true at random.

Those flags are set here:

https://github.com/capstone-engine/capstone/blob/dc69f000d2b7f8025056017425a3b68dac8e2e2c/arch/PowerPC/PPCInstPrinter.c#L77-L92

Because the `cs_insn->mnemonic` gets filled *after* the `PPC_post_printer()` is called and `cs_insn->mnemonic` is not memset to 0 before, `PPC_post_printer()` tests `cs_insn->mnemonic` with random data.

This in turn leads randomly to incorrect setting of the branch hints and the `update_cr0` flag. 

The branch hints and `update_cr0` flag will no longer set by checking the mnemonic once the `auto-sync` update is done. So this is really just a hotfix until https://github.com/capstone-engine/capstone/pull/2013 is merged.
