### PR TITLE
Hotfix for `-DCAPSTONE_DIET` build.

### DIFF
--- a/arch/AArch64/AArch64GenAsmWriter.inc
+++ b/arch/AArch64/AArch64GenAsmWriter.inc
@@ -17,6 +17,7 @@ static uint64_t getMnemonic(MCInst *MI, SStream *O, unsigned int opcode) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverlength-strings"
 #endif
+
 #ifndef CAPSTONE_DIET
   static const char AsmStrs[] = {
   /* 0 */ "sha1su0\t\0"
@@ -1131,6 +1132,8 @@ static uint64_t getMnemonic(MCInst *MI, SStream *O, unsigned int opcode) {
   /* 8739 */ "ld1w\t{\0"
   /* 8746 */ "st1w\t{\0"
 };
+#endif
+
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
@@ -7480,7 +7483,6 @@ static uint64_t getMnemonic(MCInst *MI, SStream *O, unsigned int opcode) {
     138527510U,	// anonymous_5384
     138527511U,	// anonymous_5385
   };
-#endif
 
   static const uint32_t OpInfo1[] = {
     0U,	// PHI
@@ -13832,7 +13834,9 @@ static uint64_t getMnemonic(MCInst *MI, SStream *O, unsigned int opcode) {
   uint64_t Bits = 0;
   Bits |= (uint64_t)OpInfo0[opcode] << 0;
   Bits |= (uint64_t)OpInfo1[opcode] << 32;
+#ifndef CAPSTONE_DIET
 	SStream_concat0(O, AsmStrs+(Bits & 16383)-1);
+#endif
 	return Bits;
 
 }

--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -2481,6 +2481,7 @@ static void printMatrixTileVector(MCInst *MI, unsigned OpNum, SStream *O, bool I
 	MCOperand *RegOp = MCInst_getOperand(MI, OpNum);
   	// assert(MCOperand_isReg(RegOp) && "Unexpected operand type!");
 	unsigned Reg = MCOperand_getReg(RegOp);
+#ifndef CAPSTONE_DIET
 	const char *RegName = getRegisterName(Reg, AArch64_NoRegAltName);
 
 	const size_t strLn = strlen(RegName);
@@ -2499,6 +2500,7 @@ static void printMatrixTileVector(MCInst *MI, unsigned OpNum, SStream *O, bool I
 		}
 	}
 	SStream_concat0(O, RegNameNew);
+#endif
 
 	if (MI->csh->detail) {
 #ifndef CAPSTONE_DIET
@@ -2513,7 +2515,9 @@ static void printMatrixTileVector(MCInst *MI, unsigned OpNum, SStream *O, bool I
 		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].reg = Reg;
 		MI->flat_insn->detail->arm64.op_count++;
 	}
+#ifndef CAPSTONE_DIET
 	cs_mem_free(RegNameNew);
+#endif
 }
 
 static const unsigned MatrixZADRegisterTable[] = {

--- a/arch/PowerPC/PPCGenAsmWriter.inc
+++ b/arch/PowerPC/PPCGenAsmWriter.inc
@@ -6135,7 +6135,9 @@ static void printInstruction(MCInst *MI, SStream *O)
   uint64_t Bits = 0;
   Bits |= (uint64_t)OpInfo0[opcode] << 0;
   Bits |= (uint64_t)OpInfo1[opcode] << 32;
+#ifndef CAPSTONE_DIET
   SStream_concat0(O, AsmStrs+(Bits & 16383)-1);
+#endif
 
 
   // Fragment 0 encoded into 5 bits for 19 unique commands.


### PR DESCRIPTION
fixes https://github.com/capstone-engine/capstone/issues/2035

But I had to fix a segfault as well. So the `CAPSTONE_DIET` version seems to be broken for at least `AArch64` and `PPC`.

Guess it is better to address this with the `v6 release`.