### PR TITLE
Fix Python bindings after changes to cs_detail

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -728,7 +728,7 @@ class CsInsn(object):
         elif arch == CS_ARCH_RISCV:
             (self.operands) = riscv.get_arch_info(self._raw.detail.contents.arch.riscv)
         elif arch == CS_ARCH_TRICORE:
-            (self.operands) = riscv.get_arch_info(self._raw.detail.contents.arch.tricore)
+            (self.update_flags, self.operands) = tricore.get_arch_info(self._raw.detail.contents.arch.tricore)
 
 
     def __getattr__(self, name):

--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -407,12 +407,13 @@ class _cs_arch(ctypes.Union):
 
 class _cs_detail(ctypes.Structure):
     _fields_ = (
-        ('regs_read', ctypes.c_uint16 * 16),
+        ('regs_read', ctypes.c_uint16 * 20),
         ('regs_read_count', ctypes.c_ubyte),
         ('regs_write', ctypes.c_uint16 * 20),
         ('regs_write_count', ctypes.c_ubyte),
         ('groups', ctypes.c_ubyte * 8),
         ('groups_count', ctypes.c_ubyte),
+        ('writeback', ctypes.c_bool),
         ('arch', _cs_arch),
     )
 

--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -726,7 +726,7 @@ class CsInsn(object):
         elif arch == CS_ARCH_BPF:
             (self.operands) = bpf.get_arch_info(self._raw.detail.contents.arch.bpf)
         elif arch == CS_ARCH_RISCV:
-            (self.operands) = riscv.get_arch_info(self._raw.detail.contents.arch.riscv)
+            (self.need_effective_addr, self.operands) = riscv.get_arch_info(self._raw.detail.contents.arch.riscv)
         elif arch == CS_ARCH_TRICORE:
             (self.update_flags, self.operands) = tricore.get_arch_info(self._raw.detail.contents.arch.tricore)
 

--- a/bindings/python/capstone/riscv.py
+++ b/bindings/python/capstone/riscv.py
@@ -7,7 +7,7 @@ from .riscv_const import *
 # define the API
 class RISCVOpMem(ctypes.Structure):
     _fields_ = (
-        ('base', ctypes.c_uint8),
+        ('base', ctypes.c_uint),
         ('disp', ctypes.c_int64),
     )
 
@@ -39,11 +39,11 @@ class RISCVOp(ctypes.Structure):
 
 class CsRISCV(ctypes.Structure):
     _fields_ = (
-	('need_effective_addr', ctypes.c_bool),
+        ('need_effective_addr', ctypes.c_bool),
         ('op_count',            ctypes.c_uint8),
         ('operands',            RISCVOp * 8),
     )
 
 def get_arch_info(a):
-    return (copy_ctypes_list(a.operands[:a.op_count]))
+    return (a.need_effective_addr, copy_ctypes_list(a.operands[:a.op_count]))
 

--- a/bindings/python/capstone/tricore.py
+++ b/bindings/python/capstone/tricore.py
@@ -1,6 +1,7 @@
 # Capstone Python bindings, by billow <billow.fun@gmail.com>
 
-import ctypes, copy
+import ctypes
+from . import copy_ctypes_list
 from .tricore_const import *
 
 class TriCoreOpMem(ctypes.Structure):
@@ -22,6 +23,7 @@ class TriCoreOp(ctypes.Structure):
     _fields_ = (
         ('type', ctypes.c_uint),
         ('value', TriCoreOpValue),
+        ('access', ctypes.c_uint8)
     )
 
     @property
@@ -42,4 +44,8 @@ class CsTriCore(ctypes.Structure):
     _fields_ = (
         ('op_count', ctypes.c_uint8),
         ('operands', TriCoreOp * 8),
+        ('update_flags', ctypes.c_bool),
     )
+
+def get_arch_info(a):
+    return (a.update_flags, copy_ctypes_list(a.operands[:a.op_count]))


### PR DESCRIPTION
https://github.com/capstone-engine/capstone/pull/2034 changed the `regs_read` array size and added a new `writeback`
element to the `cs_detail` struct.

Those changes weren't reflected in the Python bindings causing details to be missing.

I've included fixes for the RISCV and TriCore bindings as well, since they were related or popped up during testing of this change. I originally looked into the problems while testing the changes to the RISCV instruction groups #2007 in Python.