### PR TITLE
Re-fix pkgconfig includedir/Cflags

### DIFF
--- a/capstone.pc.in
+++ b/capstone.pc.in
@@ -6,7 +6,7 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 Name: capstone
 Description: Capstone disassembly engine
 Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
-URL: http://www.capstone-engine.org
+URL: https://www.capstone-engine.org/
 archive=${libdir}/libcapstone.a
 Libs: -L${libdir} -lcapstone
 Cflags: -I${includedir}/capstone

--- a/capstone.pc.in
+++ b/capstone.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: capstone
 Description: Capstone disassembly engine
@@ -9,5 +9,5 @@ Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
 URL: http://www.capstone-engine.org
 archive=${libdir}/libcapstone.a
 Libs: -L${libdir} -lcapstone
-Cflags: -I${includedir}
+Cflags: -I${includedir}/capstone
 archs=@CAPSTONE_ARCHITECTURES@


### PR DESCRIPTION
In capstone-5.x, the combination of includedir and Cflags once again requires consumers to

```C
#include <capstone/capstone.h>
```

rather than

```C
#include <capstone.h>
```

This is a breaking change even though it was essentially an aesthetic choice when originally made. To avoid annoying other projects, we add the `/capstone` suffix back into `Cflags`.