### PR TITLE
Fix TriCore test

### DIFF
--- a/tests/test_iter.c
+++ b/tests/test_iter.c
@@ -256,7 +256,7 @@ struct platform platforms[] = {
 #ifdef CAPSTONE_HAS_TRICORE
 	    {
 		CS_ARCH_TRICORE,
-		CS_MODE_BIG_ENDIAN | CS_MODE_TRICORE_162,
+		CS_MODE_TRICORE_162,
 		(unsigned char*)TRICORE_CODE,
 		sizeof(TRICORE_CODE) - 1,
 		"TriCore"


### PR DESCRIPTION
In capstone 5.0_rc3 the test `test_iter` fails when performing checks for the TriCore architecture. `cs_open()` returns `CS_ERR_MODE` (5):

```
$ ./test_iter 
[...]
****************
Platform: TriCore
Failed on cs_open() with error returned: 5
```

The test requests mode `CS_MODE_BIG_ENDIAN | CS_MODE_TRICORE_162`, but TriCore is a little endian architecture. See section 1.1.1 in https://www.infineon.com/dgdl/Infineon-AURIX_TC3xx_Architecture_vol1-UserManual-v01_00-EN.pdf?fileId=5546d46276fb756a01771bc4c2e33bdd. Dropping `CS_MODE_BIG_ENDIAN` fixes the error.

It seems this kind of error was fixed in d9f13fe77218de2e6d3bd8d6aea5146a3de5da4e, but the test was missed there.