### PR TITLE
Update Cython bindings

### DIFF
--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -1,4 +1,4 @@
-PYTHON2 ?= python
+PYTHON2 ?= python2
 PYTHON3 ?= python3
 
 .PHONY: gen_const install install3 install_cython sdist sdist3 bdist bdist3 clean check

--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -885,7 +885,7 @@ class Cs(object):
             raise CsError(status)
 
         try:
-            import ccapstone
+            from . import ccapstone
             # rewire disasm to use the faster version
             self.disasm = ccapstone.Cs(self).disasm
         except:

--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -144,6 +144,7 @@ __all__ = [
     'CS_GRP_INT',
     'CS_GRP_IRET',
     'CS_GRP_PRIVILEGE',
+    'CS_GRP_BRANCH_RELATIVE',
 
     'CS_AC_INVALID',
     'CS_AC_READ',
@@ -275,6 +276,7 @@ CS_GRP_RET     = 3  # all return instructions
 CS_GRP_INT     = 4  # all interrupt instructions (int+syscall)
 CS_GRP_IRET    = 5  # all interrupt return instructions
 CS_GRP_PRIVILEGE = 6  # all privileged instructions
+CS_GRP_BRANCH_RELATIVE = 7 # all relative branching instructions
 
 # Access types for instruction operands.
 CS_AC_INVALID  = 0        # Invalid/unitialized access type.

--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -342,10 +342,10 @@ def _load_lib(path):
     if os.path.exists(lib_file):
         return ctypes.cdll.LoadLibrary(lib_file)
     else:
-        # if we're on linux, try again with .so.4 extension
+        # if we're on linux, try again with .so.5 extension
         if lib_file.endswith('.so'):
-            if os.path.exists(lib_file + '.4'):
-                return ctypes.cdll.LoadLibrary(lib_file + '.4')
+            if os.path.exists(lib_file + '.{}'.format(CS_VERSION_MAJOR)):
+                return ctypes.cdll.LoadLibrary(lib_file + '.{}'.format(CS_VERSION_MAJOR))
     return None
 
 _cs = None

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -56,7 +56,7 @@ if 'PKG_MAJOR' not in VERSION_DATA or \
     raise Exception("Malformed pkgconfig.mk")
 
 if 'PKG_TAG' in VERSION_DATA:
-    VERSION = '{PKG_MAJOR}.{PKG_MINOR}.{PKG_EXTRA}.{PKG_TAG}'.format(**VERSION_DATA)
+    VERSION = '{PKG_MAJOR}.{PKG_MINOR}.{PKG_EXTRA}{PKG_TAG}'.format(**VERSION_DATA)
 else:
     VERSION = '{PKG_MAJOR}.{PKG_MINOR}.{PKG_EXTRA}'.format(**VERSION_DATA)
 

--- a/bindings/python/setup_cython.py
+++ b/bindings/python/setup_cython.py
@@ -41,7 +41,7 @@ else:
 compile_args = ['-O3', '-fomit-frame-pointer', '-I' + HEADERS_DIR]
 link_args = ['-L' + LIBS_DIR]
 
-ext_module_names = ['arm', 'arm_const', 'arm64', 'arm64_const', 'm68k', 'm68k_const', 'm680x', 'm680x_const', 'mips', 'mips_const', 'ppc', 'ppc_const', 'x86', 'x86_const', 'sparc', 'sparc_const', 'systemz', 'sysz_const', 'xcore', 'xcore_const', 'tms320c64x', 'tms320c64x_const', 'evm', 'evm_const' ]
+ext_module_names = ['arm', 'arm_const', 'arm64', 'arm64_const', 'm68k', 'm68k_const', 'm680x', 'm680x_const', 'mips', 'mips_const', 'ppc', 'ppc_const', 'x86', 'x86_const', 'sparc', 'sparc_const', 'systemz', 'sysz_const', 'xcore', 'xcore_const', 'tms320c64x', 'tms320c64x_const', 'evm', 'evm_const', 'mos65xx', 'mos65xx_const', 'bpf', 'bpf_const', 'riscv', 'riscv_const', 'tricore', 'tricore_const' ]
 
 ext_modules = [Extension("capstone.ccapstone",
                          ["pyx/ccapstone.pyx"],
@@ -53,6 +53,10 @@ ext_modules += [Extension("capstone.%s" % name,
                           extra_compile_args=compile_args,
                           extra_link_args=link_args)
                 for name in ext_module_names]
+
+for e in ext_modules:
+    e.cython_directives = {"language_level": str(sys.version_info[0])}
+
 
 def clean_bins():
     shutil.rmtree(LIBS_DIR, ignore_errors=True)
@@ -137,6 +141,8 @@ setup(
     classifiers  = [
                 'License :: OSI Approved :: BSD License',
                 'Programming Language :: Python :: 2',
+                'Programming Language :: Python :: 2.7',
+                'Programming Language :: Python :: 3',
                 ],
     include_package_data=True,
     package_data={

--- a/bindings/python/setup_cython.py
+++ b/bindings/python/setup_cython.py
@@ -10,6 +10,7 @@ from Cython.Distutils import build_ext
 
 SYSTEM = sys.platform
 VERSION = '5.0.0'
+VERSION_PARTS = VERSION.split(".")
 
 # adapted from commit e504b81 of Nguyen Tan Cong
 # Reference: https://docs.python.org/2/library/platform.html#cross-platform
@@ -25,7 +26,7 @@ PYPACKAGE_DIR = os.path.join(ROOT_DIR, 'capstone')
 CYPACKAGE_DIR = os.path.join(ROOT_DIR, 'pyx')
 
 if SYSTEM == 'darwin':
-    VERSIONED_LIBRARY_FILE = "libcapstone.4.dylib"
+    VERSIONED_LIBRARY_FILE = "libcapstone.{}.dylib".format(VERSION_PARTS[0])
     LIBRARY_FILE = "libcapstone.dylib"
     STATIC_LIBRARY_FILE = 'libcapstone.a'
 elif SYSTEM in ('win32', 'cygwin'):
@@ -33,7 +34,7 @@ elif SYSTEM in ('win32', 'cygwin'):
     LIBRARY_FILE = "capstone.dll"
     STATIC_LIBRARY_FILE = None
 else:
-    VERSIONED_LIBRARY_FILE = "libcapstone.so.4"
+    VERSIONED_LIBRARY_FILE = "libcapstone.so.{}".format(VERSION_PARTS[0])
     LIBRARY_FILE = "libcapstone.so"
     STATIC_LIBRARY_FILE = 'libcapstone.a'
 


### PR DESCRIPTION
Bring all new architectures to the cython binding and fix build warnings.

Loading the cython bindings was broken even when they were installed correctly. I've switched it to how the `debug()` function imports ccapstone.

```diff
diff --git a/bindings/python/capstone/__init__.py b/bindings/python/capstone/__init__.py
index 9098b3ed48..4ec23458d1 100755
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -885,7 +885,7 @@ def __init__(self, arch, mode):
             raise CsError(status)
 
         try:
-            import ccapstone
+            from . import ccapstone
             # rewire disasm to use the faster version
             self.disasm = ccapstone.Cs(self).disasm
         except:
```