### PR TITLE
[SuperH]: fix IMM format specifier in test

### DIFF
--- a/tests/test_sh.c
+++ b/tests/test_sh.c
@@ -96,7 +96,7 @@ static void print_insn_detail(csh handle, cs_insn *insn)
 			break;
 
 		case SH_OP_IMM:
-			printf("\t\toperands[%u].type: IMMEDIATE = #%lu\n", i,
+			printf("\t\toperands[%u].type: IMMEDIATE = #%llu\n", i,
 			       op->imm);
 			break;
 


### PR DESCRIPTION
Fixes the following warning on macOS ARM64 (M1):
```
/Users/user/capstone/tests/test_sh.c:100:11: warning: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
                               op->imm);
                               ^~~~~~~
```