### PR TITLE
[ARM] Fix VFP feature check

### DIFF
--- a/arch/ARM/ARMDisassembler.c
+++ b/arch/ARM/ARMDisassembler.c
@@ -392,10 +392,9 @@ bool ARM_getFeatureBits(unsigned int mode, unsigned int feature)
 			feature == ARM_HasV8_4aOps || feature == ARM_HasV8_3aOps)
 			// HasV8MBaselineOps
 			return false;
-	} else {
-		if (feature == ARM_FeatureVFPOnlySP)
-			return false;
 	}
+	if (feature == ARM_FeatureVFPOnlySP)
+		return false;
 
 	if ((mode & CS_MODE_MCLASS) == 0) {
 		if (feature == ARM_FeatureMClass)


### PR DESCRIPTION
ARM VFP instructions could not be disassembled if `arch != armv8`. This happens because of a faulty feature check. The check assumes VFP is `v8` only.

This is not the case as can be checked with LLVM:

```
echo "0x04,0x0b,0xb7,0xee,0x10,0xfa,0xf1,0xee,0x02,0x0b,0x31,0xee,0x42,0x0b,0x31,0xee,0xc8,0x1b,0xb0,0xee" | llvm-mc-16 --triple=armv7 --mattr=+vfp3 --disassemble
	.text
	vmov.f64	d0, #1.250000e+00
	vmrs	APSR_nzcv, fpscr
	vadd.f64	d0, d1, d2
	vsub.f64	d0, d1, d2
	vabs.f64	d1, d8
```