### PR TITLE
ci: use proper job syntax for Windows

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,17 +31,20 @@ jobs:
       if: matrix.os == 'windows-latest' && matrix.platform == 'x64'
       uses: ilammy/msvc-dev-cmd@v1
 
-    - name: Install dependencies
+    - name: Install Python dependencies
+      if: matrix.os != 'ubuntu-latest'
+      run: pip install setuptools wheel
+
+    - name: Build distribution 📦 (Windows)
+      if: matrix.os == 'windows-latest'
+      shell: pwsh
       run: |
-        if [ ${{ matrix.os }} != 'ubuntu-latest' ]; then
-          pip install setuptools wheel
-        fi
+        cd bindings/python && python setup.py build -p win32 bdist_wheel -p win32
+
     - name: Build distribution 📦
       shell: bash 
       run: |
-        if [ ${{ matrix.platform }} == 'x32' ] && [ ${{ matrix.os }} == 'windows-latest' ]; then
-             cd bindings/python && python setup.py build -p win32 bdist_wheel -p win32
-        elif [ ${{ matrix.platform }} == 'x32' ] && [ ${{ matrix.os }} == 'ubuntu-latest' ]; then
+        if [ ${{ matrix.platform }} == 'x32' ] && [ ${{ matrix.os }} == 'ubuntu-latest' ]; then
              docker run --rm -v `pwd`/:/work dockcross/manylinux2014-x86 > ./dockcross
              chmod +x ./dockcross
              chmod +x bindings/python/build_wheel.sh


### PR DESCRIPTION
A blind fix, should fix this problem:
```
ParserError: D:\a\_temp\06b4544d-38a3-4a20-aba1-1a6522b4acd4.ps1:2
Line |
   2 |  if [ windows-latest != 'ubuntu-latest' ]; then
     |    ~
     | Missing '(' after 'if' in if statement.

Error: Process completed with exit code 1.
```
https://github.com/capstone-engine/capstone/actions/runs/5606238975/jobs/10256193870#step:6:58

cc @Rot127 @kabeor 

Ideally, thought, it's better to switch to [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/): https://github.com/capstone-engine/capstone/issues/2066#issuecomment-1610907218