### PR TITLE
Sync Python bindings for x86, m68k, and mos65xx

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -703,7 +703,7 @@ class CsInsn(object):
             (self.prefix, self.opcode, self.rex, self.addr_size, \
                 self.modrm, self.sib, self.disp, \
                 self.sib_index, self.sib_scale, self.sib_base, self.xop_cc, self.sse_cc, \
-                self.avx_cc, self.avx_sae, self.avx_rm, self.eflags, \
+                self.avx_cc, self.avx_sae, self.avx_rm, self.eflags, self.fpu_flags, \
                 self.encoding, self.modrm_offset, self.disp_offset, self.disp_size, self.imm_offset, self.imm_size, \
                 self.operands) = x86.get_arch_info(self._raw.detail.contents.arch.x86)
         elif arch == CS_ARCH_M68K:

--- a/bindings/python/capstone/m68k.py
+++ b/bindings/python/capstone/m68k.py
@@ -66,6 +66,10 @@ class M68KOp(ctypes.Structure):
     @property
     def reg(self):
         return self.value.reg
+    
+    @property
+    def reg_pair(self):
+        return self.value.reg_pair
 
     @property
     def mem(self):

--- a/bindings/python/capstone/mos65xx.py
+++ b/bindings/python/capstone/mos65xx.py
@@ -8,8 +8,8 @@ from .mos65xx_const import *
 class MOS65xxOpValue(ctypes.Union):
     _fields_ = (
         ('reg', ctypes.c_uint),
-        ('imm', ctypes.c_uint8),
-        ('mem', ctypes.c_uint16),
+        ('imm', ctypes.c_uint16),
+        ('mem', ctypes.c_uint32),
     )
 
 class MOS65xxOp(ctypes.Structure):

--- a/bindings/python/capstone/x86.py
+++ b/bindings/python/capstone/x86.py
@@ -43,6 +43,11 @@ class X86Op(ctypes.Structure):
     def mem(self):
         return self.value.mem
 
+class X86Flags(ctypes.Union):
+    _fields_ = (
+        ('eflags', ctypes.c_uint64),
+        ('fpu_flags', ctypes.c_uint64),
+    )
 
 class CsX86Encoding(ctypes.Structure):
     _fields_ = (
@@ -70,16 +75,24 @@ class CsX86(ctypes.Structure):
         ('avx_cc', ctypes.c_uint),
         ('avx_sae', ctypes.c_bool),
         ('avx_rm', ctypes.c_uint),
-        ('eflags', ctypes.c_uint64),
+        ('flags', X86Flags),
         ('op_count', ctypes.c_uint8),
         ('operands', X86Op * 8),
         ('encoding', CsX86Encoding),
     )
 
+    @property
+    def eflags(self):
+        return self.flags.eflags
+    
+    @property
+    def fpu_flags(self):
+        return self.flags.fpu_flags
+
 def get_arch_info(a):
     return (a.prefix[:], a.opcode[:], a.rex, a.addr_size, \
             a.modrm, a.sib, a.disp, a.sib_index, a.sib_scale, \
-            a.sib_base, a.xop_cc, a.sse_cc, a.avx_cc, a.avx_sae, a.avx_rm, a.eflags, \
+            a.sib_base, a.xop_cc, a.sse_cc, a.avx_cc, a.avx_sae, a.avx_rm, a.eflags, a.fpu_flags, \
             a.encoding, a.encoding.modrm_offset, a.encoding.disp_offset, a.encoding.disp_size, a.encoding.imm_offset, a.encoding.imm_size, \
             copy_ctypes_list(a.operands[:a.op_count]))
 

--- a/bindings/python/pyx/ccapstone.pyx
+++ b/bindings/python/pyx/ccapstone.pyx
@@ -34,7 +34,7 @@ class CsDetail(object):
                 self.modrm, self.sib, self.disp, \
                 self.sib_index, self.sib_scale, self.sib_base, \
                 self.xop_cc, self.sse_cc, self.avx_cc, self.avx_sae, self.avx_rm, \
-                self.eflags, self.encoding, self.modrm_offset, self.disp_offset, \
+                self.eflags, self.fpu_flags, self.encoding, self.modrm_offset, self.disp_offset, \
                 self.disp_size, self.imm_offset, self.imm_size, self.operands) = x86.get_arch_info(detail.arch.x86)
         elif arch == capstone.CS_ARCH_M68K:
             (self.operands, self.op_size) = m68k.get_arch_info(detail.arch.m68k)


### PR DESCRIPTION
There were some inconsistencies that popped up while fixing the tests for #2086

- [x86 eflags/fpu_flags union](https://github.com/capstone-engine/capstone/blob/2bd076d31932da619b96608b5372fc4faeaac8d4/include/capstone/x86.h#L366-L373) was not represented in the bindings
- [m68k reg_pair operand value](https://github.com/capstone-engine/capstone/blob/2bd076d31932da619b96608b5372fc4faeaac8d4/include/capstone/m68k.h#L166) was not exposed like the other M68kOpValue fields.
- [mos65xx struct field sizes changed](https://github.com/capstone-engine/capstone/blob/2bd076d31932da619b96608b5372fc4faeaac8d4/include/capstone/mos65xx.h#L184-L185)