### PR TITLE
Set sysop members by their C++ type name.

### DIFF
--- a/arch/ARM/ARMGenSystemRegister.inc
+++ b/arch/ARM/ARMGenSystemRegister.inc
@@ -1,4 +1,4 @@
-/* Capstone Disassembly Engine, http://www.capstone-engine.org */
+/* Capstone Disassembly Engine, https://www.capstone-engine.org */
 /* By Nguyen Anh Quynh <aquynh@gmail.com>, 2013-2022, */
 /*    Rot127 <unisono@quyllur.org> 2022-2023 */
 /* Automatically generated file by Capstone's LLVM TableGen Disassembler Backend. */
@@ -37,39 +37,39 @@ ARMSysReg_lookupMClassSysRegByEncoding(uint16_t Encoding);
 
 #ifdef GET_BANKEDREG_IMPL
 static const ARMBankedReg_BankedReg BankedRegsList[] = {
-	{ "elr_hyp", { ARM_BANKEDREG_ELR_HYP }, 0x1E },	  // 0
-	{ "lr_abt", { ARM_BANKEDREG_LR_ABT }, 0x14 },	  // 1
-	{ "lr_fiq", { ARM_BANKEDREG_LR_FIQ }, 0xE },	  // 2
-	{ "lr_irq", { ARM_BANKEDREG_LR_IRQ }, 0x10 },	  // 3
-	{ "lr_mon", { ARM_BANKEDREG_LR_MON }, 0x1C },	  // 4
-	{ "lr_svc", { ARM_BANKEDREG_LR_SVC }, 0x12 },	  // 5
-	{ "lr_und", { ARM_BANKEDREG_LR_UND }, 0x16 },	  // 6
-	{ "lr_usr", { ARM_BANKEDREG_LR_USR }, 0x6 },	  // 7
-	{ "r10_fiq", { ARM_BANKEDREG_R10_FIQ }, 0xA },	  // 8
-	{ "r10_usr", { ARM_BANKEDREG_R10_USR }, 0x2 },	  // 9
-	{ "r11_fiq", { ARM_BANKEDREG_R11_FIQ }, 0xB },	  // 10
-	{ "r11_usr", { ARM_BANKEDREG_R11_USR }, 0x3 },	  // 11
-	{ "r12_fiq", { ARM_BANKEDREG_R12_FIQ }, 0xC },	  // 12
-	{ "r12_usr", { ARM_BANKEDREG_R12_USR }, 0x4 },	  // 13
-	{ "r8_fiq", { ARM_BANKEDREG_R8_FIQ }, 0x8 },	  // 14
-	{ "r8_usr", { ARM_BANKEDREG_R8_USR }, 0x0 },	  // 15
-	{ "r9_fiq", { ARM_BANKEDREG_R9_FIQ }, 0x9 },	  // 16
-	{ "r9_usr", { ARM_BANKEDREG_R9_USR }, 0x1 },	  // 17
-	{ "spsr_abt", { ARM_BANKEDREG_SPSR_ABT }, 0x34 }, // 18
-	{ "spsr_fiq", { ARM_BANKEDREG_SPSR_FIQ }, 0x2E }, // 19
-	{ "spsr_hyp", { ARM_BANKEDREG_SPSR_HYP }, 0x3E }, // 20
-	{ "spsr_irq", { ARM_BANKEDREG_SPSR_IRQ }, 0x30 }, // 21
-	{ "spsr_mon", { ARM_BANKEDREG_SPSR_MON }, 0x3C }, // 22
-	{ "spsr_svc", { ARM_BANKEDREG_SPSR_SVC }, 0x32 }, // 23
-	{ "spsr_und", { ARM_BANKEDREG_SPSR_UND }, 0x36 }, // 24
-	{ "sp_abt", { ARM_BANKEDREG_SP_ABT }, 0x15 },	  // 25
-	{ "sp_fiq", { ARM_BANKEDREG_SP_FIQ }, 0xD },	  // 26
-	{ "sp_hyp", { ARM_BANKEDREG_SP_HYP }, 0x1F },	  // 27
-	{ "sp_irq", { ARM_BANKEDREG_SP_IRQ }, 0x11 },	  // 28
-	{ "sp_mon", { ARM_BANKEDREG_SP_MON }, 0x1D },	  // 29
-	{ "sp_svc", { ARM_BANKEDREG_SP_SVC }, 0x13 },	  // 30
-	{ "sp_und", { ARM_BANKEDREG_SP_UND }, 0x17 },	  // 31
-	{ "sp_usr", { ARM_BANKEDREG_SP_USR }, 0x5 },	  // 32
+	{ "elr_hyp", { .bankedreg = ARM_BANKEDREG_ELR_HYP }, 0x1E },   // 0
+	{ "lr_abt", { .bankedreg = ARM_BANKEDREG_LR_ABT }, 0x14 },     // 1
+	{ "lr_fiq", { .bankedreg = ARM_BANKEDREG_LR_FIQ }, 0xE },      // 2
+	{ "lr_irq", { .bankedreg = ARM_BANKEDREG_LR_IRQ }, 0x10 },     // 3
+	{ "lr_mon", { .bankedreg = ARM_BANKEDREG_LR_MON }, 0x1C },     // 4
+	{ "lr_svc", { .bankedreg = ARM_BANKEDREG_LR_SVC }, 0x12 },     // 5
+	{ "lr_und", { .bankedreg = ARM_BANKEDREG_LR_UND }, 0x16 },     // 6
+	{ "lr_usr", { .bankedreg = ARM_BANKEDREG_LR_USR }, 0x6 },      // 7
+	{ "r10_fiq", { .bankedreg = ARM_BANKEDREG_R10_FIQ }, 0xA },    // 8
+	{ "r10_usr", { .bankedreg = ARM_BANKEDREG_R10_USR }, 0x2 },    // 9
+	{ "r11_fiq", { .bankedreg = ARM_BANKEDREG_R11_FIQ }, 0xB },    // 10
+	{ "r11_usr", { .bankedreg = ARM_BANKEDREG_R11_USR }, 0x3 },    // 11
+	{ "r12_fiq", { .bankedreg = ARM_BANKEDREG_R12_FIQ }, 0xC },    // 12
+	{ "r12_usr", { .bankedreg = ARM_BANKEDREG_R12_USR }, 0x4 },    // 13
+	{ "r8_fiq", { .bankedreg = ARM_BANKEDREG_R8_FIQ }, 0x8 },      // 14
+	{ "r8_usr", { .bankedreg = ARM_BANKEDREG_R8_USR }, 0x0 },      // 15
+	{ "r9_fiq", { .bankedreg = ARM_BANKEDREG_R9_FIQ }, 0x9 },      // 16
+	{ "r9_usr", { .bankedreg = ARM_BANKEDREG_R9_USR }, 0x1 },      // 17
+	{ "spsr_abt", { .bankedreg = ARM_BANKEDREG_SPSR_ABT }, 0x34 }, // 18
+	{ "spsr_fiq", { .bankedreg = ARM_BANKEDREG_SPSR_FIQ }, 0x2E }, // 19
+	{ "spsr_hyp", { .bankedreg = ARM_BANKEDREG_SPSR_HYP }, 0x3E }, // 20
+	{ "spsr_irq", { .bankedreg = ARM_BANKEDREG_SPSR_IRQ }, 0x30 }, // 21
+	{ "spsr_mon", { .bankedreg = ARM_BANKEDREG_SPSR_MON }, 0x3C }, // 22
+	{ "spsr_svc", { .bankedreg = ARM_BANKEDREG_SPSR_SVC }, 0x32 }, // 23
+	{ "spsr_und", { .bankedreg = ARM_BANKEDREG_SPSR_UND }, 0x36 }, // 24
+	{ "sp_abt", { .bankedreg = ARM_BANKEDREG_SP_ABT }, 0x15 },     // 25
+	{ "sp_fiq", { .bankedreg = ARM_BANKEDREG_SP_FIQ }, 0xD },      // 26
+	{ "sp_hyp", { .bankedreg = ARM_BANKEDREG_SP_HYP }, 0x1F },     // 27
+	{ "sp_irq", { .bankedreg = ARM_BANKEDREG_SP_IRQ }, 0x11 },     // 28
+	{ "sp_mon", { .bankedreg = ARM_BANKEDREG_SP_MON }, 0x1D },     // 29
+	{ "sp_svc", { .bankedreg = ARM_BANKEDREG_SP_SVC }, 0x13 },     // 30
+	{ "sp_und", { .bankedreg = ARM_BANKEDREG_SP_UND }, 0x17 },     // 31
+	{ "sp_usr", { .bankedreg = ARM_BANKEDREG_SP_USR }, 0x5 },      // 32
 };
 
 const ARMBankedReg_BankedReg *
@@ -124,275 +124,320 @@ ARMBankedReg_lookupBankedRegByEncoding(uint8_t Encoding)
 
 #ifdef GET_MCLASSSYSREG_IMPL
 static const ARMSysReg_MClassSysReg MClassSysRegsList[] = {
-	{ "apsr", { ARM_MCLASSSYSREG_APSR }, 0x800, 0x100, 0x800, { 0 } }, // 0
+	{ "apsr",
+	  { .mclasssysreg = ARM_MCLASSSYSREG_APSR },
+	  0x800,
+	  0x100,
+	  0x800,
+	  { 0 } }, // 0
 	{ "apsr_g",
-	  { ARM_MCLASSSYSREG_APSR_G },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_APSR_G },
 	  0x400,
 	  0x0,
 	  0x400,
 	  { ARM_FeatureDSP } }, // 1
 	{ "apsr_nzcvq",
-	  { ARM_MCLASSSYSREG_APSR_NZCVQ },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_APSR_NZCVQ },
 	  0x1800,
 	  0x200,
 	  0x800,
 	  { 0 } }, // 2
 	{ "apsr_nzcvqg",
-	  { ARM_MCLASSSYSREG_APSR_NZCVQG },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_APSR_NZCVQG },
 	  0xC00,
 	  0x300,
 	  0xC00,
 	  { ARM_FeatureDSP } }, // 3
 	{ "basepri",
-	  { ARM_MCLASSSYSREG_BASEPRI },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_BASEPRI },
 	  0x811,
 	  0x111,
 	  0x811,
 	  { ARM_HasV7Ops } }, // 4
 	{ "basepri_max",
-	  { ARM_MCLASSSYSREG_BASEPRI_MAX },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_BASEPRI_MAX },
 	  0x812,
 	  0x112,
 	  0x812,
 	  { ARM_HasV7Ops } }, // 5
 	{ "basepri_ns",
-	  { ARM_MCLASSSYSREG_BASEPRI_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_BASEPRI_NS },
 	  0x891,
 	  0x191,
 	  0x891,
 	  { ARM_Feature8MSecExt, ARM_HasV7Ops } }, // 6
 	{ "control",
-	  { ARM_MCLASSSYSREG_CONTROL },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_CONTROL },
 	  0x814,
 	  0x114,
 	  0x814,
 	  { 0 } }, // 7
 	{ "control_ns",
-	  { ARM_MCLASSSYSREG_CONTROL_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_CONTROL_NS },
 	  0x894,
 	  0x194,
 	  0x894,
 	  { ARM_Feature8MSecExt } }, // 8
-	{ "eapsr", { ARM_MCLASSSYSREG_EAPSR }, 0x802, 0x102, 0x802, { 0 } }, // 9
+	{ "eapsr",
+	  { .mclasssysreg = ARM_MCLASSSYSREG_EAPSR },
+	  0x802,
+	  0x102,
+	  0x802,
+	  { 0 } }, // 9
 	{ "eapsr_g",
-	  { ARM_MCLASSSYSREG_EAPSR_G },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_EAPSR_G },
 	  0x402,
 	  0x2,
 	  0x402,
 	  { ARM_FeatureDSP } }, // 10
 	{ "eapsr_nzcvq",
-	  { ARM_MCLASSSYSREG_EAPSR_NZCVQ },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_EAPSR_NZCVQ },
 	  0x1802,
 	  0x202,
 	  0x802,
 	  { 0 } }, // 11
 	{ "eapsr_nzcvqg",
-	  { ARM_MCLASSSYSREG_EAPSR_NZCVQG },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_EAPSR_NZCVQG },
 	  0xC02,
 	  0x302,
 	  0xC02,
-	  { ARM_FeatureDSP } },						   // 12
-	{ "epsr", { ARM_MCLASSSYSREG_EPSR }, 0x806, 0x106, 0x806, { 0 } }, // 13
+	  { ARM_FeatureDSP } }, // 12
+	{ "epsr",
+	  { .mclasssysreg = ARM_MCLASSSYSREG_EPSR },
+	  0x806,
+	  0x106,
+	  0x806,
+	  { 0 } }, // 13
 	{ "faultmask",
-	  { ARM_MCLASSSYSREG_FAULTMASK },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_FAULTMASK },
 	  0x813,
 	  0x113,
 	  0x813,
 	  { ARM_HasV7Ops } }, // 14
 	{ "faultmask_ns",
-	  { ARM_MCLASSSYSREG_FAULTMASK_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_FAULTMASK_NS },
 	  0x893,
 	  0x193,
 	  0x893,
 	  { ARM_Feature8MSecExt, ARM_HasV7Ops } }, // 15
-	{ "iapsr", { ARM_MCLASSSYSREG_IAPSR }, 0x801, 0x101, 0x801, { 0 } }, // 16
+	{ "iapsr",
+	  { .mclasssysreg = ARM_MCLASSSYSREG_IAPSR },
+	  0x801,
+	  0x101,
+	  0x801,
+	  { 0 } }, // 16
 	{ "iapsr_g",
-	  { ARM_MCLASSSYSREG_IAPSR_G },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_IAPSR_G },
 	  0x401,
 	  0x1,
 	  0x401,
 	  { ARM_FeatureDSP } }, // 17
 	{ "iapsr_nzcvq",
-	  { ARM_MCLASSSYSREG_IAPSR_NZCVQ },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_IAPSR_NZCVQ },
 	  0x1801,
 	  0x201,
 	  0x801,
 	  { 0 } }, // 18
 	{ "iapsr_nzcvqg",
-	  { ARM_MCLASSSYSREG_IAPSR_NZCVQG },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_IAPSR_NZCVQG },
 	  0xC01,
 	  0x301,
 	  0xC01,
 	  { ARM_FeatureDSP } }, // 19
-	{ "iepsr", { ARM_MCLASSSYSREG_IEPSR }, 0x807, 0x107, 0x807, { 0 } }, // 20
-	{ "ipsr", { ARM_MCLASSSYSREG_IPSR }, 0x805, 0x105, 0x805, { 0 } }, // 21
-	{ "msp", { ARM_MCLASSSYSREG_MSP }, 0x808, 0x108, 0x808, { 0 } },   // 22
+	{ "iepsr",
+	  { .mclasssysreg = ARM_MCLASSSYSREG_IEPSR },
+	  0x807,
+	  0x107,
+	  0x807,
+	  { 0 } }, // 20
+	{ "ipsr",
+	  { .mclasssysreg = ARM_MCLASSSYSREG_IPSR },
+	  0x805,
+	  0x105,
+	  0x805,
+	  { 0 } }, // 21
+	{ "msp",
+	  { .mclasssysreg = ARM_MCLASSSYSREG_MSP },
+	  0x808,
+	  0x108,
+	  0x808,
+	  { 0 } }, // 22
 	{ "msplim",
-	  { ARM_MCLASSSYSREG_MSPLIM },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_MSPLIM },
 	  0x80A,
 	  0x10A,
 	  0x80A,
 	  { ARM_HasV8MBaselineOps } }, // 23
 	{ "msplim_ns",
-	  { ARM_MCLASSSYSREG_MSPLIM_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_MSPLIM_NS },
 	  0x88A,
 	  0x18A,
 	  0x88A,
 	  { ARM_Feature8MSecExt, ARM_HasV8MBaselineOps } }, // 24
 	{ "msp_ns",
-	  { ARM_MCLASSSYSREG_MSP_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_MSP_NS },
 	  0x888,
 	  0x188,
 	  0x888,
 	  { ARM_Feature8MSecExt } }, // 25
 	{ "pac_key_p_0",
-	  { ARM_MCLASSSYSREG_PAC_KEY_P_0 },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_P_0 },
 	  0x820,
 	  0x120,
 	  0x820,
 	  { ARM_FeaturePACBTI } }, // 26
 	{ "pac_key_p_0_ns",
-	  { ARM_MCLASSSYSREG_PAC_KEY_P_0_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_P_0_NS },
 	  0x8A0,
 	  0x1A0,
 	  0x8A0,
 	  { ARM_FeaturePACBTI } }, // 27
 	{ "pac_key_p_1",
-	  { ARM_MCLASSSYSREG_PAC_KEY_P_1 },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_P_1 },
 	  0x821,
 	  0x121,
 	  0x821,
 	  { ARM_FeaturePACBTI } }, // 28
 	{ "pac_key_p_1_ns",
-	  { ARM_MCLASSSYSREG_PAC_KEY_P_1_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_P_1_NS },
 	  0x8A1,
 	  0x1A1,
 	  0x8A1,
 	  { ARM_FeaturePACBTI } }, // 29
 	{ "pac_key_p_2",
-	  { ARM_MCLASSSYSREG_PAC_KEY_P_2 },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_P_2 },
 	  0x822,
 	  0x122,
 	  0x822,
 	  { ARM_FeaturePACBTI } }, // 30
 	{ "pac_key_p_2_ns",
-	  { ARM_MCLASSSYSREG_PAC_KEY_P_2_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_P_2_NS },
 	  0x8A2,
 	  0x1A2,
 	  0x8A2,
 	  { ARM_FeaturePACBTI } }, // 31
 	{ "pac_key_p_3",
-	  { ARM_MCLASSSYSREG_PAC_KEY_P_3 },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_P_3 },
 	  0x823,
 	  0x123,
 	  0x823,
 	  { ARM_FeaturePACBTI } }, // 32
 	{ "pac_key_p_3_ns",
-	  { ARM_MCLASSSYSREG_PAC_KEY_P_3_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_P_3_NS },
 	  0x8A3,
 	  0x1A3,
 	  0x8A3,
 	  { ARM_FeaturePACBTI } }, // 33
 	{ "pac_key_u_0",
-	  { ARM_MCLASSSYSREG_PAC_KEY_U_0 },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_U_0 },
 	  0x824,
 	  0x124,
 	  0x824,
 	  { ARM_FeaturePACBTI } }, // 34
 	{ "pac_key_u_0_ns",
-	  { ARM_MCLASSSYSREG_PAC_KEY_U_0_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_U_0_NS },
 	  0x8A4,
 	  0x1A4,
 	  0x8A4,
 	  { ARM_FeaturePACBTI } }, // 35
 	{ "pac_key_u_1",
-	  { ARM_MCLASSSYSREG_PAC_KEY_U_1 },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_U_1 },
 	  0x825,
 	  0x125,
 	  0x825,
 	  { ARM_FeaturePACBTI } }, // 36
 	{ "pac_key_u_1_ns",
-	  { ARM_MCLASSSYSREG_PAC_KEY_U_1_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_U_1_NS },
 	  0x8A5,
 	  0x1A5,
 	  0x8A5,
 	  { ARM_FeaturePACBTI } }, // 37
 	{ "pac_key_u_2",
-	  { ARM_MCLASSSYSREG_PAC_KEY_U_2 },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_U_2 },
 	  0x826,
 	  0x126,
 	  0x826,
 	  { ARM_FeaturePACBTI } }, // 38
 	{ "pac_key_u_2_ns",
-	  { ARM_MCLASSSYSREG_PAC_KEY_U_2_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_U_2_NS },
 	  0x8A6,
 	  0x1A6,
 	  0x8A6,
 	  { ARM_FeaturePACBTI } }, // 39
 	{ "pac_key_u_3",
-	  { ARM_MCLASSSYSREG_PAC_KEY_U_3 },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_U_3 },
 	  0x827,
 	  0x127,
 	  0x827,
 	  { ARM_FeaturePACBTI } }, // 40
 	{ "pac_key_u_3_ns",
-	  { ARM_MCLASSSYSREG_PAC_KEY_U_3_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PAC_KEY_U_3_NS },
 	  0x8A7,
 	  0x1A7,
 	  0x8A7,
 	  { ARM_FeaturePACBTI } }, // 41
 	{ "primask",
-	  { ARM_MCLASSSYSREG_PRIMASK },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PRIMASK },
 	  0x810,
 	  0x110,
 	  0x810,
 	  { 0 } }, // 42
 	{ "primask_ns",
-	  { ARM_MCLASSSYSREG_PRIMASK_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PRIMASK_NS },
 	  0x890,
 	  0x190,
 	  0x890,
-	  { 0 } },							 // 43
-	{ "psp", { ARM_MCLASSSYSREG_PSP }, 0x809, 0x109, 0x809, { 0 } }, // 44
+	  { 0 } }, // 43
+	{ "psp",
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PSP },
+	  0x809,
+	  0x109,
+	  0x809,
+	  { 0 } }, // 44
 	{ "psplim",
-	  { ARM_MCLASSSYSREG_PSPLIM },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PSPLIM },
 	  0x80B,
 	  0x10B,
 	  0x80B,
 	  { ARM_HasV8MBaselineOps } }, // 45
 	{ "psplim_ns",
-	  { ARM_MCLASSSYSREG_PSPLIM_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PSPLIM_NS },
 	  0x88B,
 	  0x18B,
 	  0x88B,
 	  { ARM_Feature8MSecExt, ARM_HasV8MBaselineOps } }, // 46
 	{ "psp_ns",
-	  { ARM_MCLASSSYSREG_PSP_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_PSP_NS },
 	  0x889,
 	  0x189,
 	  0x889,
 	  { ARM_Feature8MSecExt } }, // 47
 	{ "sp_ns",
-	  { ARM_MCLASSSYSREG_SP_NS },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_SP_NS },
 	  0x898,
 	  0x198,
 	  0x898,
-	  { ARM_Feature8MSecExt } },					   // 48
-	{ "xpsr", { ARM_MCLASSSYSREG_XPSR }, 0x803, 0x103, 0x803, { 0 } }, // 49
+	  { ARM_Feature8MSecExt } }, // 48
+	{ "xpsr",
+	  { .mclasssysreg = ARM_MCLASSSYSREG_XPSR },
+	  0x803,
+	  0x103,
+	  0x803,
+	  { 0 } }, // 49
 	{ "xpsr_g",
-	  { ARM_MCLASSSYSREG_XPSR_G },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_XPSR_G },
 	  0x403,
 	  0x3,
 	  0x403,
 	  { ARM_FeatureDSP } }, // 50
 	{ "xpsr_nzcvq",
-	  { ARM_MCLASSSYSREG_XPSR_NZCVQ },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_XPSR_NZCVQ },
 	  0x1803,
 	  0x203,
 	  0x803,
 	  { 0 } }, // 51
 	{ "xpsr_nzcvqg",
-	  { ARM_MCLASSSYSREG_XPSR_NZCVQG },
+	  { .mclasssysreg = ARM_MCLASSSYSREG_XPSR_NZCVQG },
 	  0xC03,
 	  0x303,
 	  0xC03,

--- a/arch/ARM/ARMMapping.c
+++ b/arch/ARM/ARMMapping.c
@@ -1010,7 +1010,7 @@ static void add_cs_detail_general(MCInst *MI, arm_op_group op_group,
 				if (TheReg && MClassSysReg_isInRequiredFeatures(
 						      TheReg, ARM_FeatureDSP)) {
 					ARM_set_detail_op_sysreg(
-						MI, TheReg->sysreg.sysreg,
+						MI, TheReg->sysreg.mclasssysreg,
 						IsOutReg);
 					return;
 				}
@@ -1024,7 +1024,7 @@ static void add_cs_detail_general(MCInst *MI, arm_op_group op_group,
 						SYSm);
 				if (TheReg) {
 					ARM_set_detail_op_sysreg(
-						MI, TheReg->sysreg.sysreg,
+						MI, TheReg->sysreg.mclasssysreg,
 						IsOutReg);
 					return;
 				}
@@ -1034,7 +1034,7 @@ static void add_cs_detail_general(MCInst *MI, arm_op_group op_group,
 				SYSm);
 			if (TheReg) {
 				ARM_set_detail_op_sysreg(
-					MI, TheReg->sysreg.sysreg, IsOutReg);
+					MI, TheReg->sysreg.mclasssysreg, IsOutReg);
 				return;
 			}
 
@@ -1440,7 +1440,7 @@ static void add_cs_detail_general(MCInst *MI, arm_op_group op_group,
 		const ARMBankedReg_BankedReg *TheReg =
 			ARMBankedReg_lookupBankedRegByEncoding(Banked);
 		bool IsOutReg = OpNum == 0;
-		ARM_set_detail_op_sysreg(MI, TheReg->sysreg.banked_reg,
+		ARM_set_detail_op_sysreg(MI, TheReg->sysreg.bankedreg,
 					 IsOutReg);
 		break;
 	}

--- a/include/capstone/arm.h
+++ b/include/capstone/arm.h
@@ -340,7 +340,7 @@ typedef enum {
 
 	// clang-format on
 	// generated content <ARMGenCSSystemOperandsEnum.inc:GET_ENUM_VALUES_BankedReg> end
-} arm_banked_reg;
+} arm_bankedreg;
 
 typedef enum {
 	// generated content <ARMGenCSSystemOperandsEnum.inc:GET_ENUM_VALUES_MClassSysReg> begin
@@ -405,8 +405,8 @@ typedef enum {
 } arm_sysreg;
 
 typedef union {
-  arm_sysreg sysreg;
-  arm_banked_reg banked_reg;
+  arm_sysreg mclasssysreg;
+  arm_bankedreg bankedreg;
 } arm_sysop_reg;
 
 /// Operand type for instruction's operands


### PR DESCRIPTION
Prevents build warnings of implicit enum convertions.