### PR TITLE
[ARM] Return first the system register name then the banked one

### DIFF
--- a/arch/ARM/ARMMapping.c
+++ b/arch/ARM/ARMMapping.c
@@ -51,15 +51,18 @@ const char *ARM_reg_name(csh handle, unsigned int reg)
 		return alias;
 
 	if (reg == ARM_REG_INVALID || reg >= ARM_REG_ENDING) {
-		// This might be a system register encoding.
-		const ARMBankedReg_BankedReg *banked_reg =
-			ARMBankedReg_lookupBankedRegByEncoding(reg);
-		if (banked_reg)
-			return banked_reg->Name;
+		// This might be a system register or banked register encoding.
+		// Note: The system and banked register encodings can overlap.
+		// So this might return a system register name although a
+		// banked register name is expected.
 		const ARMSysReg_MClassSysReg *sys_reg =
 			ARMSysReg_lookupMClassSysRegByEncoding(reg);
 		if (sys_reg)
 			return sys_reg->Name;
+		const ARMBankedReg_BankedReg *banked_reg =
+			ARMBankedReg_lookupBankedRegByEncoding(reg);
+		if (banked_reg)
+			return banked_reg->Name;
 	}
 
 	if (syntax_opt & CS_OPT_SYNTAX_NOREGNAME) {

--- a/cstool/cstool_arm.c
+++ b/cstool/cstool_arm.c
@@ -71,7 +71,7 @@ void print_insn_detail_arm(csh handle, cs_insn *ins)
 				printf("\t\toperands[%u].type: SETEND = %s\n", i, op->setend == ARM_SETEND_BE? "be" : "le");
 				break;
 			case ARM_OP_SYSREG:
-				printf("\t\toperands[%u].type: SYSREG = %u\n", i, op->reg);
+				printf("\t\toperands[%u].type: SYSREG = %s\n", i, cs_reg_name(handle, op->reg));
 				break;
 		}
 


### PR DESCRIPTION
closes https://github.com/capstone-engine/capstone/issues/1713

System registers and banked register encodings overlap. So this might lead to problems. But cstool only asks for system registers. So it should be fine for now.