### PR TITLE
allow absolute CMAKE_INSTALL_*DIR

### DIFF
--- a/capstone-config.cmake.in
+++ b/capstone-config.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-set_and_check(capstone_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
-set_and_check(capstone_LIB_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
+set_and_check(capstone_INCLUDE_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
+set_and_check(capstone_LIB_DIR "@CMAKE_INSTALL_FULL_LIBDIR@")
 
 include("${CMAKE_CURRENT_LIST_DIR}/capstone-targets.cmake")

--- a/capstone.pc.in
+++ b/capstone.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: capstone
 Description: Capstone disassembly engine

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -13,8 +13,8 @@ foreach(file ${files})
   endif()
 endforeach()
 
-message(STATUS "Uninstalling @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/capstone")
-file(REMOVE_RECURSE @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/capstone)
+message(STATUS "Uninstalling @CMAKE_INSTALL_FULL_INCLUDEDIR@/capstone")
+file(REMOVE_RECURSE @CMAKE_INSTALL_FULL_INCLUDEDIR@/capstone)
 
-message(STATUS "Uninstalling @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/cmake/capstone")
-file(REMOVE_RECURSE @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/cmake/capstone)
+message(STATUS "Uninstalling @CMAKE_INSTALL_FULL_LIBDIR@/cmake/capstone")
+file(REMOVE_RECURSE @CMAKE_INSTALL_FULL_LIBDIR@/cmake/capstone)


### PR DESCRIPTION
This patch fixes Capstone build on NixOS (assuming `next` is v6, this PR should be backported to v5 as well).

NixOS's build infrastructure sets CMAKE_INSTALL_{LIB,INCLUDE}DIR to absolute paths. Fedora used to do this until 2012, but doesn't set it at all anymore. If you append it to ${prefix}, you get the wrong path. NixOS automatically detects it and links this issue: https://github.com/NixOS/nixpkgs/issues/144170

The other uses of `CMAKE_INSTALL_{LIB,INCLUDE}DIR` shouldn't be an issue.