### PR TITLE
fix compile errors in capstone_static - unresolved external symbols

### DIFF
--- a/msvc/capstone_static/capstone_static.vcxproj
+++ b/msvc/capstone_static/capstone_static.vcxproj
@@ -89,6 +89,7 @@
     <ClCompile Include="..\..\arch\XCore\XCoreMapping.c" />
     <ClCompile Include="..\..\arch\XCore\XCoreModule.c" />
     <ClCompile Include="..\..\cs.c" />
+    <ClCompile Include="..\..\Mapping.c" />
     <ClCompile Include="..\..\MCInst.c" />
     <ClCompile Include="..\..\MCInstrDesc.c" />
     <ClCompile Include="..\..\MCRegisterInfo.c" />


### PR DESCRIPTION
basically the same fix that already was done for capstone_dll in https://github.com/capstone-engine/capstone/commit/5be5aa766b75c94a73b0441cda872d84ae705a03