### PR TITLE
Run clang-format on PPC

### DIFF
--- a/arch/PowerPC/PPCDisassembler.c
+++ b/arch/PowerPC/PPCDisassembler.c
@@ -47,22 +47,19 @@ DEFINE_PPC_REGCLASSES
 #define DEBUG_TYPE "ppc-disassembler"
 
 DecodeStatus getInstruction(csh ud, const uint8_t *Bytes, size_t BytesLen,
-							MCInst *MI, uint16_t *Size, uint64_t Address,
-							void *Info)
-;
+			    MCInst *MI, uint16_t *Size, uint64_t Address,
+			    void *Info);
 // end anonymous namespace
 
 static DecodeStatus decodeCondBrTarget(MCInst *Inst, unsigned Imm,
-									   uint64_t Address,
-									   const void *Decoder)
+				       uint64_t Address, const void *Decoder)
 {
 	MCOperand_CreateImm0(Inst, (SignExtend32((Imm), 14)));
 	return MCDisassembler_Success;
 }
 
 static DecodeStatus decodeDirectBrTarget(MCInst *Inst, unsigned Imm,
-									   uint64_t Address,
-									   const void *Decoder)
+					 uint64_t Address, const void *Decoder)
 {
 	int32_t Offset = SignExtend32((Imm), 24);
 	MCOperand_CreateImm0(Inst, (Offset));
@@ -73,106 +70,106 @@ static DecodeStatus decodeDirectBrTarget(MCInst *Inst, unsigned Imm,
 // encoding values!
 
 static DecodeStatus decodeRegisterClass(MCInst *Inst, uint64_t RegNo,
-										const MCPhysReg *Regs)
+					const MCPhysReg *Regs)
 {
 	MCOperand_CreateReg0(Inst, (Regs[RegNo]));
 	return MCDisassembler_Success;
 }
 
 static DecodeStatus DecodeCRRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											uint64_t Address,
-											const void *Decoder)
+					    uint64_t Address,
+					    const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, CRRegs);
 }
 
 static DecodeStatus DecodeCRBITRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											   uint64_t Address,
-											   const void *Decoder)
+					       uint64_t Address,
+					       const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, CRBITRegs);
 }
 
 static DecodeStatus DecodeF4RCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											uint64_t Address,
-											const void *Decoder)
+					    uint64_t Address,
+					    const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, FRegs);
 }
 
 static DecodeStatus DecodeF8RCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											uint64_t Address,
-											const void *Decoder)
+					    uint64_t Address,
+					    const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, FRegs);
 }
 
 static DecodeStatus DecodeVFRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											uint64_t Address,
-											const void *Decoder)
+					    uint64_t Address,
+					    const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, VFRegs);
 }
 
 static DecodeStatus DecodeVRRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											uint64_t Address,
-											const void *Decoder)
+					    uint64_t Address,
+					    const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, VRegs);
 }
 
 static DecodeStatus DecodeVSRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											uint64_t Address,
-											const void *Decoder)
+					    uint64_t Address,
+					    const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, VSRegs);
 }
 
 static DecodeStatus DecodeVSFRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											 uint64_t Address,
-											 const void *Decoder)
+					     uint64_t Address,
+					     const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, VSFRegs);
 }
 
 static DecodeStatus DecodeVSSRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											 uint64_t Address,
-											 const void *Decoder)
+					     uint64_t Address,
+					     const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, VSSRegs);
 }
 
 static DecodeStatus DecodeGPRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											uint64_t Address,
-											const void *Decoder)
+					    uint64_t Address,
+					    const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, RRegs);
 }
 
 static DecodeStatus DecodeGPRC_NOR0RegisterClass(MCInst *Inst, uint64_t RegNo,
-												 uint64_t Address,
-												 const void *Decoder)
+						 uint64_t Address,
+						 const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, RRegsNoR0);
 }
 
 static DecodeStatus DecodeG8RCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											uint64_t Address,
-											const void *Decoder)
+					    uint64_t Address,
+					    const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, XRegs);
 }
 
 static DecodeStatus DecodeG8pRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											 uint64_t Address,
-											 const void *Decoder)
+					     uint64_t Address,
+					     const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, XRegs);
 }
 
 static DecodeStatus DecodeG8RC_NOX0RegisterClass(MCInst *Inst, uint64_t RegNo,
-												 uint64_t Address,
-												 const void *Decoder)
+						 uint64_t Address,
+						 const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, XRegsNoX0);
 }
@@ -181,29 +178,29 @@ static DecodeStatus DecodeG8RC_NOX0RegisterClass(MCInst *Inst, uint64_t RegNo,
 #define DecodePointerLikeRegClass1 DecodeGPRC_NOR0RegisterClass
 
 static DecodeStatus DecodeSPERCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											 uint64_t Address,
-											 const void *Decoder)
+					     uint64_t Address,
+					     const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, SPERegs);
 }
 
 static DecodeStatus DecodeACCRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											 uint64_t Address,
-											 const void *Decoder)
+					     uint64_t Address,
+					     const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, ACCRegs);
 }
 
 static DecodeStatus DecodeWACCRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											  uint64_t Address,
-											  const void *Decoder)
+					      uint64_t Address,
+					      const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, WACCRegs);
 }
 
 static DecodeStatus DecodeWACC_HIRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-												 uint64_t Address,
-												 const void *Decoder)
+						 uint64_t Address,
+						 const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, WACC_HIRegs);
 }
@@ -211,21 +208,21 @@ static DecodeStatus DecodeWACC_HIRCRegisterClass(MCInst *Inst, uint64_t RegNo,
 // TODO: Make this function static when the register class is used by a new
 //       instruction.
 DecodeStatus DecodeDMRROWRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-										 uint64_t Address, const void *Decoder)
+					 uint64_t Address, const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, DMRROWRegs);
 }
 
 static DecodeStatus DecodeDMRROWpRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-												 uint64_t Address,
-												 const void *Decoder)
+						 uint64_t Address,
+						 const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, DMRROWpRegs);
 }
 
 static DecodeStatus DecodeDMRRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											 uint64_t Address,
-											 const void *Decoder)
+					     uint64_t Address,
+					     const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, DMRRegs);
 }
@@ -233,14 +230,14 @@ static DecodeStatus DecodeDMRRCRegisterClass(MCInst *Inst, uint64_t RegNo,
 // TODO: Make this function static when the register class is used by a new
 //       instruction.
 DecodeStatus DecodeDMRpRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-									   uint64_t Address, const void *Decoder)
+				       uint64_t Address, const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, DMRpRegs);
 }
 
 static DecodeStatus DecodeVSRpRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-											  uint64_t Address,
-											  const void *Decoder)
+					      uint64_t Address,
+					      const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, VSRpRegs);
 }
@@ -249,38 +246,40 @@ static DecodeStatus DecodeVSRpRCRegisterClass(MCInst *Inst, uint64_t RegNo,
 #define DecodeQBRCRegisterClass DecodeQFRCRegisterClass
 
 static DecodeStatus DecodeQFRCRegisterClass(MCInst *Inst, uint64_t RegNo,
-		uint64_t Address, const void *Decoder)
+					    uint64_t Address,
+					    const void *Decoder)
 {
 	return decodeRegisterClass(Inst, RegNo, QFRegs);
 }
 
-#define DEFINE_decodeUImmOperand(N)                                            \
-	static DecodeStatus CONCAT(decodeUImmOperand, N)(                          \
-		MCInst * Inst, uint64_t Imm, int64_t Address, const void *Decoder)     \
-	{                                                                          \
-                                                                               \
-		MCOperand_CreateImm0(Inst, (Imm));                                     \
-		return MCDisassembler_Success;                                         \
+#define DEFINE_decodeUImmOperand(N) \
+	static DecodeStatus CONCAT(decodeUImmOperand, \
+				   N)(MCInst * Inst, uint64_t Imm, \
+				      int64_t Address, const void *Decoder) \
+	{ \
+		MCOperand_CreateImm0(Inst, (Imm)); \
+		return MCDisassembler_Success; \
 	}
 DEFINE_decodeUImmOperand(5) DEFINE_decodeUImmOperand(16)
 	DEFINE_decodeUImmOperand(6) DEFINE_decodeUImmOperand(10)
 		DEFINE_decodeUImmOperand(8) DEFINE_decodeUImmOperand(7)
 			DEFINE_decodeUImmOperand(12)
 
-#define DEFINE_decodeSImmOperand(N)                                            \
-	static DecodeStatus CONCAT(decodeSImmOperand, N)(                          \
-		MCInst * Inst, uint64_t Imm, int64_t Address, const void *Decoder)     \
-	{                                                                          \
-                                                                               \
-		MCOperand_CreateImm0(Inst, (SignExtend64(Imm, N)));            \
-		return MCDisassembler_Success;                                         \
+#define DEFINE_decodeSImmOperand(N) \
+	static DecodeStatus CONCAT(decodeSImmOperand, \
+				   N)(MCInst * Inst, uint64_t Imm, \
+				      int64_t Address, const void *Decoder) \
+	{ \
+		MCOperand_CreateImm0(Inst, (SignExtend64(Imm, N))); \
+		return MCDisassembler_Success; \
 	}
-				DEFINE_decodeSImmOperand(16) DEFINE_decodeSImmOperand(5)
-					DEFINE_decodeSImmOperand(34)
+				DEFINE_decodeSImmOperand(16)
+					DEFINE_decodeSImmOperand(5)
+						DEFINE_decodeSImmOperand(34)
 
-						static DecodeStatus
+							static DecodeStatus
 	decodeImmZeroOperand(MCInst *Inst, uint64_t Imm, int64_t Address,
-						 const void *Decoder)
+			     const void *Decoder)
 {
 	if (Imm != 0)
 		return MCDisassembler_Fail;
@@ -289,8 +288,8 @@ DEFINE_decodeUImmOperand(5) DEFINE_decodeUImmOperand(16)
 }
 
 static DecodeStatus decodeVSRpEvenOperands(MCInst *Inst, uint64_t RegNo,
-										   uint64_t Address,
-										   const void *Decoder)
+					   uint64_t Address,
+					   const void *Decoder)
 {
 	if (RegNo & 1)
 		return MCDisassembler_Fail;
@@ -299,7 +298,7 @@ static DecodeStatus decodeVSRpEvenOperands(MCInst *Inst, uint64_t RegNo,
 }
 
 static DecodeStatus decodeMemRIOperands(MCInst *Inst, uint64_t Imm,
-										int64_t Address, const void *Decoder)
+					int64_t Address, const void *Decoder)
 {
 	// Decode the memri field (imm, reg), which has the low 16-bits as the
 	// displacement and the next 5 bits as the register #.
@@ -324,7 +323,8 @@ static DecodeStatus decodeMemRIOperands(MCInst *Inst, uint64_t Imm,
 	case PPC_STWU:
 	case PPC_STFSU:
 	case PPC_STFDU:
-		MCInst_insert0(Inst, 0, MCOperand_CreateReg1(Inst, RRegsNoR0[Base]));
+		MCInst_insert0(Inst, 0,
+			       MCOperand_CreateReg1(Inst, RRegsNoR0[Base]));
 		break;
 	}
 
@@ -334,7 +334,7 @@ static DecodeStatus decodeMemRIOperands(MCInst *Inst, uint64_t Imm,
 }
 
 static DecodeStatus decodeMemRIXOperands(MCInst *Inst, uint64_t Imm,
-										 int64_t Address, const void *Decoder)
+					 int64_t Address, const void *Decoder)
 {
 	// Decode the memrix field (imm, reg), which has the low 14-bits as the
 	// displacement and the next 5 bits as the register #.
@@ -346,7 +346,8 @@ static DecodeStatus decodeMemRIXOperands(MCInst *Inst, uint64_t Imm,
 		// Add the tied output operand.
 		MCOperand_CreateReg0(Inst, (RRegsNoR0[Base]));
 	else if (MCInst_getOpcode(Inst) == PPC_STDU)
-		MCInst_insert0(Inst, 0, MCOperand_CreateReg1(Inst, RRegsNoR0[Base]));
+		MCInst_insert0(Inst, 0,
+			       MCOperand_CreateReg1(Inst, RRegsNoR0[Base]));
 
 	MCOperand_CreateImm0(Inst, (SignExtend64(Disp << 2, 16)));
 	MCOperand_CreateReg0(Inst, (RRegsNoR0[Base]));
@@ -354,8 +355,8 @@ static DecodeStatus decodeMemRIXOperands(MCInst *Inst, uint64_t Imm,
 }
 
 static DecodeStatus decodeMemRIHashOperands(MCInst *Inst, uint64_t Imm,
-											int64_t Address,
-											const void *Decoder)
+					    int64_t Address,
+					    const void *Decoder)
 {
 	// Decode the memrix field for a hash store or hash check operation.
 	// The field is composed of a register and an immediate value that is 6 bits
@@ -370,7 +371,7 @@ static DecodeStatus decodeMemRIHashOperands(MCInst *Inst, uint64_t Imm,
 }
 
 static DecodeStatus decodeMemRIX16Operands(MCInst *Inst, uint64_t Imm,
-										   int64_t Address, const void *Decoder)
+					   int64_t Address, const void *Decoder)
 {
 	// Decode the memrix16 field (imm, reg), which has the low 12-bits as the
 	// displacement with 16-byte aligned, and the next 5 bits as the register #.
@@ -384,8 +385,8 @@ static DecodeStatus decodeMemRIX16Operands(MCInst *Inst, uint64_t Imm,
 }
 
 static DecodeStatus decodeMemRI34PCRelOperands(MCInst *Inst, uint64_t Imm,
-											   int64_t Address,
-											   const void *Decoder)
+					       int64_t Address,
+					       const void *Decoder)
 {
 	// Decode the memri34_pcrel field (imm, reg), which has the low 34-bits as
 	// the displacement, and the next 5 bits as an immediate 0.
@@ -397,7 +398,7 @@ static DecodeStatus decodeMemRI34PCRelOperands(MCInst *Inst, uint64_t Imm,
 }
 
 static DecodeStatus decodeMemRI34Operands(MCInst *Inst, uint64_t Imm,
-										  int64_t Address, const void *Decoder)
+					  int64_t Address, const void *Decoder)
 {
 	// Decode the memri34 field (imm, reg), which has the low 34-bits as the
 	// displacement, and the next 5 bits as the register #.
@@ -410,7 +411,7 @@ static DecodeStatus decodeMemRI34Operands(MCInst *Inst, uint64_t Imm,
 }
 
 static DecodeStatus decodeSPE8Operands(MCInst *Inst, uint64_t Imm,
-									   int64_t Address, const void *Decoder)
+				       int64_t Address, const void *Decoder)
 {
 	// Decode the spe8disp field (imm, reg), which has the low 5-bits as the
 	// displacement with 8-byte aligned, and the next 5 bits as the register #.
@@ -424,7 +425,7 @@ static DecodeStatus decodeSPE8Operands(MCInst *Inst, uint64_t Imm,
 }
 
 static DecodeStatus decodeSPE4Operands(MCInst *Inst, uint64_t Imm,
-									   int64_t Address, const void *Decoder)
+				       int64_t Address, const void *Decoder)
 {
 	// Decode the spe4disp field (imm, reg), which has the low 5-bits as the
 	// displacement with 4-byte aligned, and the next 5 bits as the register #.
@@ -438,7 +439,7 @@ static DecodeStatus decodeSPE4Operands(MCInst *Inst, uint64_t Imm,
 }
 
 static DecodeStatus decodeSPE2Operands(MCInst *Inst, uint64_t Imm,
-									   int64_t Address, const void *Decoder)
+				       int64_t Address, const void *Decoder)
 {
 	// Decode the spe2disp field (imm, reg), which has the low 5-bits as the
 	// displacement with 2-byte aligned, and the next 5 bits as the register #.
@@ -452,7 +453,7 @@ static DecodeStatus decodeSPE2Operands(MCInst *Inst, uint64_t Imm,
 }
 
 static DecodeStatus decodeCRBitMOperand(MCInst *Inst, uint64_t Imm,
-										int64_t Address, const void *Decoder)
+					int64_t Address, const void *Decoder)
 {
 	// The cr bit encoding is 0x80 >> cr_reg_num.
 
@@ -467,8 +468,8 @@ static DecodeStatus decodeCRBitMOperand(MCInst *Inst, uint64_t Imm,
 #include "PPCGenDisassemblerTables.inc"
 
 DecodeStatus getInstruction(csh ud, const uint8_t *Bytes, size_t BytesLen,
-							MCInst *MI, uint16_t *Size, uint64_t Address,
-							void *Info)
+			    MCInst *MI, uint16_t *Size, uint64_t Address,
+			    void *Info)
 {
 	// If this is an 8-byte prefixed instruction, handle it here.
 	// Note: prefixed instructions aren't technically 8-byte entities - the
@@ -480,7 +481,7 @@ DecodeStatus getInstruction(csh ud, const uint8_t *Bytes, size_t BytesLen,
 	//       different decoder tables. It may be possible to only call once by
 	//       looking at the top 6 bits of the instruction.
 	if (PPC_getFeatureBits(MI->csh->mode, PPC_FeaturePrefixInstrs) &&
-		BytesLen >= 8) {
+	    BytesLen >= 8) {
 		uint32_t Prefix = readBytes32(MI, Bytes);
 		uint32_t BaseInst = readBytes32(MI, Bytes + 4);
 		uint64_t Inst = BaseInst | (uint64_t)Prefix << 32;
@@ -503,17 +504,18 @@ DecodeStatus getInstruction(csh ud, const uint8_t *Bytes, size_t BytesLen,
 	uint64_t Inst = readBytes32(MI, Bytes);
 
 	if (PPC_getFeatureBits(MI->csh->mode, PPC_FeatureQPX)) {
-		DecodeStatus result =
-			decodeInstruction_4(DecoderTableQPX32, MI, Inst, Address);
+		DecodeStatus result = decodeInstruction_4(DecoderTableQPX32, MI,
+							  Inst, Address);
 		if (result != MCDisassembler_Fail)
 			return result;
-	}	else if (PPC_getFeatureBits(MI->csh->mode, PPC_FeatureSPE)) {
-		DecodeStatus result =
-			decodeInstruction_4(DecoderTableSPE32, MI, Inst, Address);
+	} else if (PPC_getFeatureBits(MI->csh->mode, PPC_FeatureSPE)) {
+		DecodeStatus result = decodeInstruction_4(DecoderTableSPE32, MI,
+							  Inst, Address);
 		if (result != MCDisassembler_Fail)
 			return result;
 	} else if (PPC_getFeatureBits(MI->csh->mode, PPC_FeaturePS)) {
-		DecodeStatus result = decodeInstruction_4(DecoderTablePS32, MI, Inst, Address);
+		DecodeStatus result = decodeInstruction_4(DecoderTablePS32, MI,
+							  Inst, Address);
 		if (result != MCDisassembler_Fail)
 			return result;
 	}
@@ -521,8 +523,10 @@ DecodeStatus getInstruction(csh ud, const uint8_t *Bytes, size_t BytesLen,
 	return decodeInstruction_4(DecoderTable32, MI, Inst, Address);
 }
 
-DecodeStatus PPC_LLVM_getInstruction(csh handle, const uint8_t *Bytes, size_t BytesLen,
-							MCInst *MI, uint16_t *Size, uint64_t Address,
-							void *Info) {
+DecodeStatus PPC_LLVM_getInstruction(csh handle, const uint8_t *Bytes,
+				     size_t BytesLen, MCInst *MI,
+				     uint16_t *Size, uint64_t Address,
+				     void *Info)
+{
 	return getInstruction(handle, Bytes, BytesLen, MI, Size, Address, Info);
 }

--- a/arch/PowerPC/PPCInstPrinter.c
+++ b/arch/PowerPC/PPCInstPrinter.c
@@ -50,18 +50,20 @@
 
 // Static function declarations. These are functions which have the same identifiers
 // over all architectures. Therefor they need to be static.
-static void printCustomAliasOperand(MCInst *MI, uint64_t Address, unsigned OpIdx,
-							 unsigned PrintMethodIdx, SStream *O);
+static void printCustomAliasOperand(MCInst *MI, uint64_t Address,
+				    unsigned OpIdx, unsigned PrintMethodIdx,
+				    SStream *O);
 static void printOperand(MCInst *MI, unsigned OpNo, SStream *O);
 static void printPredicateOperand(MCInst *MI, unsigned OpNo, SStream *O,
-						   const char *Modifier);
+				  const char *Modifier);
 static void printInst(MCInst *MI, uint64_t Address, const char *Annot,
-			   SStream *O);
+		      SStream *O);
 
 #define PRINT_ALIAS_INSTR
 #include "PPCGenAsmWriter.inc"
 
-static void printInst(MCInst *MI, uint64_t Address, const char *Annot, SStream *O)
+static void printInst(MCInst *MI, uint64_t Address, const char *Annot,
+		      SStream *O)
 {
 	bool isAlias = false;
 	bool useAliasDetails = false;
@@ -70,10 +72,9 @@ static void printInst(MCInst *MI, uint64_t Address, const char *Annot, SStream *
 	// operation, i.e:
 	//     Transform:  addis $rD, $rA, $src --> addis $rD, $src($rA).
 	if (PPC_getFeatureBits(MI->csh->mode, PPC_FeatureModernAIXAs) &&
-		(MCInst_getOpcode(MI) == PPC_ADDIS8 ||
-		 MCInst_getOpcode(MI) == PPC_ADDIS) &&
-		MCOperand_isExpr(MCInst_getOperand(MI, (2)))) {
-
+	    (MCInst_getOpcode(MI) == PPC_ADDIS8 ||
+	     MCInst_getOpcode(MI) == PPC_ADDIS) &&
+	    MCOperand_isExpr(MCInst_getOperand(MI, (2)))) {
 		SStream_concat0(O, "\taddis ");
 		printOperand(MI, 0, O);
 		SStream_concat0(O, ", ");
@@ -111,7 +112,8 @@ static void printInst(MCInst *MI, uint64_t Address, const char *Annot, SStream *
 			SH = 32 - SH;
 		}
 		useAliasDetails |= map_use_alias_details(MI);
-		map_set_fill_detail_ops(MI, useAliasDetails && useSubstituteMnemonic);
+		map_set_fill_detail_ops(MI, useAliasDetails &&
+						    useSubstituteMnemonic);
 		if (useSubstituteMnemonic) {
 			isAlias |= true;
 			MCInst_setIsAlias(MI, isAlias);
@@ -129,7 +131,7 @@ static void printInst(MCInst *MI, uint64_t Address, const char *Annot, SStream *
 	}
 
 	if (MCInst_getOpcode(MI) == PPC_RLDICR ||
-		MCInst_getOpcode(MI) == PPC_RLDICR_32) {
+	    MCInst_getOpcode(MI) == PPC_RLDICR_32) {
 		unsigned char SH = MCOperand_getImm(MCInst_getOperand(MI, (2)));
 		unsigned char ME = MCOperand_getImm(MCInst_getOperand(MI, (3)));
 
@@ -163,8 +165,8 @@ static void printInst(MCInst *MI, uint64_t Address, const char *Annot, SStream *
 	// On AIX, only emit the extended mnemonics for dcbt and dcbtst if
 	// the "modern assembler" is available.
 	if ((MCInst_getOpcode(MI) == PPC_DCBT ||
-		 MCInst_getOpcode(MI) == PPC_DCBTST) &&
-		(!PPC_getFeatureBits(MI->csh->mode, PPC_FeatureModernAIXAs))) {
+	     MCInst_getOpcode(MI) == PPC_DCBTST) &&
+	    (!PPC_getFeatureBits(MI->csh->mode, PPC_FeatureModernAIXAs))) {
 		unsigned char TH = MCOperand_getImm(MCInst_getOperand(MI, (0)));
 		SStream_concat0(O, "\tdcbt");
 		if (MCInst_getOpcode(MI) == PPC_DCBTST)
@@ -173,7 +175,8 @@ static void printInst(MCInst *MI, uint64_t Address, const char *Annot, SStream *
 			SStream_concat0(O, "t");
 		SStream_concat0(O, " ");
 
-		bool IsBookE = PPC_getFeatureBits(MI->csh->mode, PPC_FeatureBookE);
+		bool IsBookE =
+			PPC_getFeatureBits(MI->csh->mode, PPC_FeatureBookE);
 		if (IsBookE && TH != 0 && TH != 16) {
 			SStream_concat(O, "%s", (unsigned int)TH);
 			SStream_concat0(O, ", ");
@@ -235,7 +238,7 @@ static void printInst(MCInst *MI, uint64_t Address, const char *Annot, SStream *
 }
 
 void printPredicateOperand(MCInst *MI, unsigned OpNo, SStream *O,
-						   const char *Modifier)
+			   const char *Modifier)
 {
 	add_cs_detail(MI, PPC_OP_GROUP_PredicateOperand, OpNo, Modifier);
 	unsigned Code = MCOperand_getImm(MCInst_getOperand(MI, (OpNo)));
@@ -469,7 +472,8 @@ void printS16ImmOperand(MCInst *MI, unsigned OpNo, SStream *O)
 {
 	add_cs_detail(MI, PPC_OP_GROUP_S16ImmOperand, OpNo);
 	if (MCOperand_isImm(MCInst_getOperand(MI, (OpNo))))
-		printInt32(O, (short)MCOperand_getImm(MCInst_getOperand(MI, (OpNo))));
+		printInt32(O, (short)MCOperand_getImm(
+				      MCInst_getOperand(MI, (OpNo))));
 	else
 		printOperand(MI, OpNo, O);
 }
@@ -478,7 +482,8 @@ void printS34ImmOperand(MCInst *MI, unsigned OpNo, SStream *O)
 {
 	add_cs_detail(MI, PPC_OP_GROUP_S34ImmOperand, OpNo);
 	if (MCOperand_isImm(MCInst_getOperand(MI, (OpNo)))) {
-		long long Value = MCOperand_getImm(MCInst_getOperand(MI, (OpNo)));
+		long long Value =
+			MCOperand_getImm(MCInst_getOperand(MI, (OpNo)));
 
 		printInt64(O, (long long)Value);
 	} else
@@ -489,8 +494,8 @@ void printU16ImmOperand(MCInst *MI, unsigned OpNo, SStream *O)
 {
 	add_cs_detail(MI, PPC_OP_GROUP_U16ImmOperand, OpNo);
 	if (MCOperand_isImm(MCInst_getOperand(MI, (OpNo))))
-		printUInt32(
-			O, (unsigned short)MCOperand_getImm(MCInst_getOperand(MI, (OpNo))));
+		printUInt32(O, (unsigned short)MCOperand_getImm(
+				       MCInst_getOperand(MI, (OpNo))));
 	else
 		printOperand(MI, OpNo, O);
 }
@@ -501,7 +506,9 @@ void printBranchOperand(MCInst *MI, uint64_t Address, unsigned OpNo, SStream *O)
 	if (!MCOperand_isImm(MCInst_getOperand(MI, (OpNo))))
 		return printOperand(MI, OpNo, O);
 	int32_t Imm = SignExtend32(
-		((unsigned)MCOperand_getImm(MCInst_getOperand(MI, (OpNo))) << 2), 32);
+		((unsigned)MCOperand_getImm(MCInst_getOperand(MI, (OpNo)))
+		 << 2),
+		32);
 	if (!MI->csh->PrintBranchImmNotAsAddress) {
 		uint64_t Target = Address + Imm;
 		if (!IS_64BIT(MI->csh->mode))
@@ -528,10 +535,10 @@ void printAbsBranchOperand(MCInst *MI, unsigned OpNo, SStream *O)
 	if (!MCOperand_isImm(MCInst_getOperand(MI, (OpNo))))
 		return printOperand(MI, OpNo, O);
 
-	printInt32(
-		O, SignExtend32(
-			   ((unsigned)MCOperand_getImm(MCInst_getOperand(MI, (OpNo))) << 2),
-			   32));
+	printInt32(O, SignExtend32(((unsigned)MCOperand_getImm(
+					    MCInst_getOperand(MI, (OpNo)))
+				    << 2),
+				   32));
 }
 
 void printcrbitm(MCInst *MI, unsigned OpNo, SStream *O)
@@ -655,8 +662,9 @@ void printTLSCall(MCInst *MI, unsigned OpNo, SStream *O)
 /// printed with a percentage symbol as prefix.
 bool showRegistersWithPercentPrefix(const MCInst *MI, const char *RegName)
 {
-	if ((MI->csh->syntax & CS_OPT_SYNTAX_NOREGNAME) || !(MI->csh->syntax & CS_OPT_SYNTAX_PERCENT) ||
-		PPC_getFeatureBits(MI->csh->mode, PPC_FeatureModernAIXAs))
+	if ((MI->csh->syntax & CS_OPT_SYNTAX_NOREGNAME) ||
+	    !(MI->csh->syntax & CS_OPT_SYNTAX_PERCENT) ||
+	    PPC_getFeatureBits(MI->csh->mode, PPC_FeatureModernAIXAs))
 		return false;
 
 	switch (RegName[0]) {
@@ -674,19 +682,21 @@ bool showRegistersWithPercentPrefix(const MCInst *MI, const char *RegName)
 /// getVerboseConditionalRegName - This method expands the condition register
 /// when requested explicitly or targetting Darwin.
 const char *getVerboseConditionRegName(const MCInst *MI, unsigned RegNum,
-									   unsigned RegEncoding)
+				       unsigned RegEncoding)
 {
 	if (MI->csh->syntax & CS_OPT_SYNTAX_NOREGNAME)
 		return NULL;
 	if (RegNum < PPC_CR0EQ || RegNum > PPC_CR7UN)
 		return NULL;
 	const char *CRBits[] = {
-		"lt",		"gt",		"eq",		"un",		"4*cr1+lt", "4*cr1+gt",
-		"4*cr1+eq", "4*cr1+un", "4*cr2+lt", "4*cr2+gt", "4*cr2+eq", "4*cr2+un",
-		"4*cr3+lt", "4*cr3+gt", "4*cr3+eq", "4*cr3+un", "4*cr4+lt", "4*cr4+gt",
-		"4*cr4+eq", "4*cr4+un", "4*cr5+lt", "4*cr5+gt", "4*cr5+eq", "4*cr5+un",
-		"4*cr6+lt", "4*cr6+gt", "4*cr6+eq", "4*cr6+un", "4*cr7+lt", "4*cr7+gt",
-		"4*cr7+eq", "4*cr7+un"};
+		"lt",	    "gt",	"eq",	    "un",	"4*cr1+lt",
+		"4*cr1+gt", "4*cr1+eq", "4*cr1+un", "4*cr2+lt", "4*cr2+gt",
+		"4*cr2+eq", "4*cr2+un", "4*cr3+lt", "4*cr3+gt", "4*cr3+eq",
+		"4*cr3+un", "4*cr4+lt", "4*cr4+gt", "4*cr4+eq", "4*cr4+un",
+		"4*cr5+lt", "4*cr5+gt", "4*cr5+eq", "4*cr5+un", "4*cr6+lt",
+		"4*cr6+gt", "4*cr6+eq", "4*cr6+un", "4*cr7+lt", "4*cr7+gt",
+		"4*cr7+eq", "4*cr7+un"
+	};
 	return CRBits[RegEncoding];
 }
 
@@ -708,8 +718,8 @@ void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 				&PPCInsts[MCInst_getOpcode(MI)], Reg, OpNo);
 
 		const char *RegName;
-		RegName =
-			getVerboseConditionRegName(MI, Reg, MI->MRI->RegEncodingTable[Reg]);
+		RegName = getVerboseConditionRegName(
+			MI, Reg, MI->MRI->RegEncodingTable[Reg]);
 		if (RegName == NULL)
 			RegName = getRegisterName(Reg);
 		if (showRegistersWithPercentPrefix(MI, RegName))
@@ -727,10 +737,13 @@ void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 	}
 }
 
-const char *PPC_LLVM_getRegisterName(unsigned RegNo) {
+const char *PPC_LLVM_getRegisterName(unsigned RegNo)
+{
 	return getRegisterName(RegNo);
 }
 
-void PPC_LLVM_printInst(MCInst *MI, uint64_t Address, const char *Annot, SStream *O) {
+void PPC_LLVM_printInst(MCInst *MI, uint64_t Address, const char *Annot,
+			SStream *O)
+{
 	printInst(MI, Address, Annot, O);
 }

--- a/arch/PowerPC/PPCInstPrinter.h
+++ b/arch/PowerPC/PPCInstPrinter.h
@@ -63,7 +63,7 @@ void printS34ImmOperand(MCInst *MI, unsigned OpNo, SStream *O);
 void printU16ImmOperand(MCInst *MI, unsigned OpNo, SStream *O);
 void printImmZeroOperand(MCInst *MI, unsigned OpNo, SStream *O);
 void printBranchOperand(MCInst *MI, uint64_t Address, unsigned OpNo,
-						SStream *O);
+			SStream *O);
 void printAbsBranchOperand(MCInst *MI, unsigned OpNo, SStream *O);
 void printTLSCall(MCInst *MI, unsigned OpNo, SStream *O);
 void printcrbitm(MCInst *MI, unsigned OpNo, SStream *O);

--- a/arch/PowerPC/PPCInstrInfo.h
+++ b/arch/PowerPC/PPCInstrInfo.h
@@ -8,11 +8,13 @@
 
 extern const MCInstrDesc PPCInsts[];
 
-static bool isVFRegister(unsigned Reg) {
-  return Reg >= PPC_VF0 && Reg <= PPC_VF31;
+static bool isVFRegister(unsigned Reg)
+{
+	return Reg >= PPC_VF0 && Reg <= PPC_VF31;
 }
-static bool isVRRegister(unsigned Reg) {
-  return Reg >= PPC_V0 && Reg <= PPC_V31;
+static bool isVRRegister(unsigned Reg)
+{
+	return Reg >= PPC_V0 && Reg <= PPC_V31;
 }
 
 /// getRegNumForOperand - some operands use different numbering schemes
@@ -23,28 +25,29 @@ static bool isVRRegister(unsigned Reg) {
 /// The operand number argument will be useful when we need to extend this
 /// to instructions that use both Altivec and VSX numbering (for different
 /// operands).
-static unsigned PPCInstrInfo_getRegNumForOperand(const MCInstrDesc *Desc, unsigned Reg,
-                                    unsigned OpNo) {
-  int16_t regClass = Desc->OpInfo[OpNo].RegClass;
-  switch (regClass) {
-    // We store F0-F31, VF0-VF31 in MCOperand and it should be F0-F31,
-    // VSX32-VSX63 during encoding/disassembling
-    case PPC_VSSRCRegClassID:
-    case PPC_VSFRCRegClassID:
-      if (isVFRegister(Reg))
-        return PPC_VSX32 + (Reg - PPC_VF0);
-      break;
-    // We store VSL0-VSL31, V0-V31 in MCOperand and it should be VSL0-VSL31,
-    // VSX32-VSX63 during encoding/disassembling
-    case PPC_VSRCRegClassID:
-      if (isVRRegister(Reg))
-        return PPC_VSX32 + (Reg - PPC_V0);
-      break;
-    // Other RegClass doesn't need mapping
-    default:
-      break;
-  }
-  return Reg;
+static unsigned PPCInstrInfo_getRegNumForOperand(const MCInstrDesc *Desc,
+						 unsigned Reg, unsigned OpNo)
+{
+	int16_t regClass = Desc->OpInfo[OpNo].RegClass;
+	switch (regClass) {
+	// We store F0-F31, VF0-VF31 in MCOperand and it should be F0-F31,
+	// VSX32-VSX63 during encoding/disassembling
+	case PPC_VSSRCRegClassID:
+	case PPC_VSFRCRegClassID:
+		if (isVFRegister(Reg))
+			return PPC_VSX32 + (Reg - PPC_VF0);
+		break;
+	// We store VSL0-VSL31, V0-V31 in MCOperand and it should be VSL0-VSL31,
+	// VSX32-VSX63 during encoding/disassembling
+	case PPC_VSRCRegClassID:
+		if (isVRRegister(Reg))
+			return PPC_VSX32 + (Reg - PPC_V0);
+		break;
+	// Other RegClass doesn't need mapping
+	default:
+		break;
+	}
+	return Reg;
 }
 
 #endif // CS_PPC_INSTRINFO_H

--- a/arch/PowerPC/PPCLinkage.h
+++ b/arch/PowerPC/PPCLinkage.h
@@ -12,10 +12,11 @@
 #include "../../SStream.h"
 #include "capstone/capstone.h"
 
-DecodeStatus PPC_LLVM_getInstruction(csh handle, const uint8_t *Bytes, size_t ByteLen,
-							MCInst *MI, uint16_t *Size, uint64_t Address,
-							void *Info);
+DecodeStatus PPC_LLVM_getInstruction(csh handle, const uint8_t *Bytes,
+				     size_t ByteLen, MCInst *MI, uint16_t *Size,
+				     uint64_t Address, void *Info);
 const char *PPC_LLVM_getRegisterName(unsigned RegNo);
-void PPC_LLVM_printInst(MCInst *MI, uint64_t Address, const char *Annot, SStream *O);
+void PPC_LLVM_printInst(MCInst *MI, uint64_t Address, const char *Annot,
+			SStream *O);
 
 #endif // CS_PPC_LINKAGE_H

--- a/arch/PowerPC/PPCMCTargetDesc.h
+++ b/arch/PowerPC/PPCMCTargetDesc.h
@@ -120,100 +120,102 @@ static inline bool isRunOfOnes64(uint64_t Val, unsigned *MB, unsigned *ME)
 #define GET_SUBTARGETINFO_ENUM
 #include "PPCGenSubtargetInfo.inc"
 
-#define PPC_REGS0_7(X)                                                         \
-	{                                                                          \
-		X##0, X##1, X##2, X##3, X##4, X##5, X##6, X##7                         \
+#define PPC_REGS0_7(X) \
+	{ \
+		X##0, X##1, X##2, X##3, X##4, X##5, X##6, X##7 \
 	}
 
-#define PPC_REGS0_31(X)                                                        \
-	{                                                                          \
-		X##0, X##1, X##2, X##3, X##4, X##5, X##6, X##7, X##8, X##9, X##10,     \
-			X##11, X##12, X##13, X##14, X##15, X##16, X##17, X##18, X##19,     \
-			X##20, X##21, X##22, X##23, X##24, X##25, X##26, X##27, X##28,     \
-			X##29, X##30, X##31                                                \
+#define PPC_REGS0_31(X) \
+	{ \
+		X##0, X##1, X##2, X##3, X##4, X##5, X##6, X##7, X##8, X##9, \
+			X##10, X##11, X##12, X##13, X##14, X##15, X##16, \
+			X##17, X##18, X##19, X##20, X##21, X##22, X##23, \
+			X##24, X##25, X##26, X##27, X##28, X##29, X##30, X##31 \
 	}
 
-#define PPC_REGS0_63(X)                                                        \
-	{                                                                          \
-		X##0, X##1, X##2, X##3, X##4, X##5, X##6, X##7, X##8, X##9, X##10,     \
-			X##11, X##12, X##13, X##14, X##15, X##16, X##17, X##18, X##19,     \
-			X##20, X##21, X##22, X##23, X##24, X##25, X##26, X##27, X##28,     \
-			X##29, X##30, X##31, X##32, X##33, X##34, X##35, X##36, X##37,     \
-			X##38, X##39, X##40, X##41, X##42, X##43, X##44, X##45, X##46,     \
-			X##47, X##48, X##49, X##50, X##51, X##52, X##53, X##54, X##55,     \
-			X##56, X##57, X##58, X##59, X##60, X##61, X##62, X##63             \
+#define PPC_REGS0_63(X) \
+	{ \
+		X##0, X##1, X##2, X##3, X##4, X##5, X##6, X##7, X##8, X##9, \
+			X##10, X##11, X##12, X##13, X##14, X##15, X##16, \
+			X##17, X##18, X##19, X##20, X##21, X##22, X##23, \
+			X##24, X##25, X##26, X##27, X##28, X##29, X##30, \
+			X##31, X##32, X##33, X##34, X##35, X##36, X##37, \
+			X##38, X##39, X##40, X##41, X##42, X##43, X##44, \
+			X##45, X##46, X##47, X##48, X##49, X##50, X##51, \
+			X##52, X##53, X##54, X##55, X##56, X##57, X##58, \
+			X##59, X##60, X##61, X##62, X##63 \
 	}
 
-#define PPC_REGS_NO0_31(Z, X)                                                  \
-	{                                                                          \
-		Z, X##1, X##2, X##3, X##4, X##5, X##6, X##7, X##8, X##9, X##10, X##11, \
-			X##12, X##13, X##14, X##15, X##16, X##17, X##18, X##19, X##20,     \
-			X##21, X##22, X##23, X##24, X##25, X##26, X##27, X##28, X##29,     \
-			X##30, X##31                                                       \
+#define PPC_REGS_NO0_31(Z, X) \
+	{ \
+		Z, X##1, X##2, X##3, X##4, X##5, X##6, X##7, X##8, X##9, \
+			X##10, X##11, X##12, X##13, X##14, X##15, X##16, \
+			X##17, X##18, X##19, X##20, X##21, X##22, X##23, \
+			X##24, X##25, X##26, X##27, X##28, X##29, X##30, X##31 \
 	}
 
-#define PPC_REGS_LO_HI(LO, HI)                                                 \
-	{                                                                          \
-		LO##0, LO##1, LO##2, LO##3, LO##4, LO##5, LO##6, LO##7, LO##8, LO##9,  \
-			LO##10, LO##11, LO##12, LO##13, LO##14, LO##15, LO##16, LO##17,    \
-			LO##18, LO##19, LO##20, LO##21, LO##22, LO##23, LO##24, LO##25,    \
-			LO##26, LO##27, LO##28, LO##29, LO##30, LO##31, HI##0, HI##1,      \
-			HI##2, HI##3, HI##4, HI##5, HI##6, HI##7, HI##8, HI##9, HI##10,    \
-			HI##11, HI##12, HI##13, HI##14, HI##15, HI##16, HI##17, HI##18,    \
-			HI##19, HI##20, HI##21, HI##22, HI##23, HI##24, HI##25, HI##26,    \
-			HI##27, HI##28, HI##29, HI##30, HI##31                             \
+#define PPC_REGS_LO_HI(LO, HI) \
+	{ \
+		LO##0, LO##1, LO##2, LO##3, LO##4, LO##5, LO##6, LO##7, LO##8, \
+			LO##9, LO##10, LO##11, LO##12, LO##13, LO##14, LO##15, \
+			LO##16, LO##17, LO##18, LO##19, LO##20, LO##21, \
+			LO##22, LO##23, LO##24, LO##25, LO##26, LO##27, \
+			LO##28, LO##29, LO##30, LO##31, HI##0, HI##1, HI##2, \
+			HI##3, HI##4, HI##5, HI##6, HI##7, HI##8, HI##9, \
+			HI##10, HI##11, HI##12, HI##13, HI##14, HI##15, \
+			HI##16, HI##17, HI##18, HI##19, HI##20, HI##21, \
+			HI##22, HI##23, HI##24, HI##25, HI##26, HI##27, \
+			HI##28, HI##29, HI##30, HI##31 \
 	}
 
-#define PPC_REGS0_7(X)                                                         \
-	{                                                                          \
-		X##0, X##1, X##2, X##3, X##4, X##5, X##6, X##7                         \
+#define PPC_REGS0_7(X) \
+	{ \
+		X##0, X##1, X##2, X##3, X##4, X##5, X##6, X##7 \
 	}
 
-#define PPC_REGS0_3(X)                                                         \
-	{                                                                          \
-		X##0, X##1, X##2, X##3                                                 \
+#define PPC_REGS0_3(X) \
+	{ \
+		X##0, X##1, X##2, X##3 \
 	}
 
-#define DEFINE_PPC_REGCLASSES                                                  \
-	static const MCPhysReg RRegs[32] = PPC_REGS0_31(PPC_R);                   \
-	static const MCPhysReg XRegs[32] = PPC_REGS0_31(PPC_X);                   \
-	static const MCPhysReg FRegs[32] = PPC_REGS0_31(PPC_F);                   \
-	static const MCPhysReg VSRpRegs[32] = PPC_REGS0_31(PPC_VSRp);             \
-	static const MCPhysReg SPERegs[32] = PPC_REGS0_31(PPC_S);                 \
-	static const MCPhysReg VFRegs[32] = PPC_REGS0_31(PPC_VF);                 \
-	static const MCPhysReg VRegs[32] = PPC_REGS0_31(PPC_V);                   \
-	static const MCPhysReg RRegsNoR0[32] = PPC_REGS_NO0_31(PPC_ZERO, PPC_R); \
-	static const MCPhysReg XRegsNoX0[32] =                                     \
-		PPC_REGS_NO0_31(PPC_ZERO8, PPC_X);                                   \
-	static const MCPhysReg VSRegs[64] = PPC_REGS_LO_HI(PPC_VSL, PPC_V);      \
-	static const MCPhysReg VSFRegs[64] = PPC_REGS_LO_HI(PPC_F, PPC_VF);      \
-	static const MCPhysReg VSSRegs[64] = PPC_REGS_LO_HI(PPC_F, PPC_VF);      \
-	static const MCPhysReg CRBITRegs[32] =                                     \
-		{                                                                      \
-			PPC_CR0LT, PPC_CR0GT, PPC_CR0EQ, PPC_CR0UN, PPC_CR1LT,        \
-			PPC_CR1GT, PPC_CR1EQ, PPC_CR1UN, PPC_CR2LT, PPC_CR2GT,        \
-			PPC_CR2EQ, PPC_CR2UN, PPC_CR3LT, PPC_CR3GT, PPC_CR3EQ,        \
-			PPC_CR3UN, PPC_CR4LT, PPC_CR4GT, PPC_CR4EQ, PPC_CR4UN,        \
-			PPC_CR5LT, PPC_CR5GT, PPC_CR5EQ, PPC_CR5UN, PPC_CR6LT,        \
-			PPC_CR6GT, PPC_CR6EQ, PPC_CR6UN, PPC_CR7LT, PPC_CR7GT,        \
-			PPC_CR7EQ, PPC_CR7UN};                                           \
-	static const MCPhysReg CRRegs[8] = PPC_REGS0_7(PPC_CR);                   \
-	static const MCPhysReg ACCRegs[8] = PPC_REGS0_7(PPC_ACC);                 \
-	static const MCPhysReg WACCRegs[8] = PPC_REGS0_7(PPC_WACC);               \
-	static const MCPhysReg WACC_HIRegs[8] = PPC_REGS0_7(PPC_WACC_HI);         \
-	static const MCPhysReg DMRROWpRegs[32] = PPC_REGS0_31(PPC_DMRROWp);       \
-	static const MCPhysReg DMRROWRegs[64] = PPC_REGS0_63(PPC_DMRROW);         \
-	static const MCPhysReg DMRRegs[8] = PPC_REGS0_7(PPC_DMR);                 \
+#define DEFINE_PPC_REGCLASSES \
+	static const MCPhysReg RRegs[32] = PPC_REGS0_31(PPC_R); \
+	static const MCPhysReg XRegs[32] = PPC_REGS0_31(PPC_X); \
+	static const MCPhysReg FRegs[32] = PPC_REGS0_31(PPC_F); \
+	static const MCPhysReg VSRpRegs[32] = PPC_REGS0_31(PPC_VSRp); \
+	static const MCPhysReg SPERegs[32] = PPC_REGS0_31(PPC_S); \
+	static const MCPhysReg VFRegs[32] = PPC_REGS0_31(PPC_VF); \
+	static const MCPhysReg VRegs[32] = PPC_REGS0_31(PPC_V); \
+	static const MCPhysReg RRegsNoR0[32] = \
+		PPC_REGS_NO0_31(PPC_ZERO, PPC_R); \
+	static const MCPhysReg XRegsNoX0[32] = \
+		PPC_REGS_NO0_31(PPC_ZERO8, PPC_X); \
+	static const MCPhysReg VSRegs[64] = PPC_REGS_LO_HI(PPC_VSL, PPC_V); \
+	static const MCPhysReg VSFRegs[64] = PPC_REGS_LO_HI(PPC_F, PPC_VF); \
+	static const MCPhysReg VSSRegs[64] = PPC_REGS_LO_HI(PPC_F, PPC_VF); \
+	static const MCPhysReg CRBITRegs[32] = { \
+		PPC_CR0LT, PPC_CR0GT, PPC_CR0EQ, PPC_CR0UN, PPC_CR1LT, \
+		PPC_CR1GT, PPC_CR1EQ, PPC_CR1UN, PPC_CR2LT, PPC_CR2GT, \
+		PPC_CR2EQ, PPC_CR2UN, PPC_CR3LT, PPC_CR3GT, PPC_CR3EQ, \
+		PPC_CR3UN, PPC_CR4LT, PPC_CR4GT, PPC_CR4EQ, PPC_CR4UN, \
+		PPC_CR5LT, PPC_CR5GT, PPC_CR5EQ, PPC_CR5UN, PPC_CR6LT, \
+		PPC_CR6GT, PPC_CR6EQ, PPC_CR6UN, PPC_CR7LT, PPC_CR7GT, \
+		PPC_CR7EQ, PPC_CR7UN \
+	}; \
+	static const MCPhysReg CRRegs[8] = PPC_REGS0_7(PPC_CR); \
+	static const MCPhysReg ACCRegs[8] = PPC_REGS0_7(PPC_ACC); \
+	static const MCPhysReg WACCRegs[8] = PPC_REGS0_7(PPC_WACC); \
+	static const MCPhysReg WACC_HIRegs[8] = PPC_REGS0_7(PPC_WACC_HI); \
+	static const MCPhysReg DMRROWpRegs[32] = PPC_REGS0_31(PPC_DMRROWp); \
+	static const MCPhysReg DMRROWRegs[64] = PPC_REGS0_63(PPC_DMRROW); \
+	static const MCPhysReg DMRRegs[8] = PPC_REGS0_7(PPC_DMR); \
 	static const MCPhysReg DMRpRegs[4] = PPC_REGS0_3(PPC_DMRp);
 
 static const MCPhysReg QFRegs[] = {
-	PPC_QF0, PPC_QF1, PPC_QF2, PPC_QF3,
-	PPC_QF4, PPC_QF5, PPC_QF6, PPC_QF7,
-	PPC_QF8, PPC_QF9, PPC_QF10, PPC_QF11,
-	PPC_QF12, PPC_QF13, PPC_QF14, PPC_QF15,
-	PPC_QF16, PPC_QF17, PPC_QF18, PPC_QF19,
-	PPC_QF20, PPC_QF21, PPC_QF22, PPC_QF23,
-	PPC_QF24, PPC_QF25, PPC_QF26, PPC_QF27,
+	PPC_QF0,  PPC_QF1,  PPC_QF2,  PPC_QF3,	PPC_QF4,  PPC_QF5,  PPC_QF6,
+	PPC_QF7,  PPC_QF8,  PPC_QF9,  PPC_QF10, PPC_QF11, PPC_QF12, PPC_QF13,
+	PPC_QF14, PPC_QF15, PPC_QF16, PPC_QF17, PPC_QF18, PPC_QF19, PPC_QF20,
+	PPC_QF21, PPC_QF22, PPC_QF23, PPC_QF24, PPC_QF25, PPC_QF26, PPC_QF27,
 	PPC_QF28, PPC_QF29, PPC_QF30, PPC_QF31
 };
 

--- a/arch/PowerPC/PPCMapping.h
+++ b/arch/PowerPC/PPCMapping.h
@@ -19,10 +19,10 @@ void PPC_init_cs_detail(MCInst *MI);
 // return name of regiser in friendly string
 const char *PPC_reg_name(csh handle, unsigned int reg);
 
-void PPC_printer(MCInst *MI, SStream *O, void * /* MCRegisterInfo* */info);
+void PPC_printer(MCInst *MI, SStream *O, void * /* MCRegisterInfo* */ info);
 bool PPC_getInstruction(csh handle, const uint8_t *code, size_t code_len,
-						MCInst *instr, uint16_t *size, uint64_t address,
-						void *info);
+			MCInst *instr, uint16_t *size, uint64_t address,
+			void *info);
 
 // given internal insn id, return public instruction info
 void PPC_get_insn_id(cs_struct *h, cs_insn *insn, unsigned int id);
@@ -31,7 +31,7 @@ const char *PPC_insn_name(csh handle, unsigned int id);
 const char *PPC_group_name(csh handle, unsigned int id);
 
 typedef struct {
-	unsigned int id;	// instruction id
+	unsigned int id; // instruction id
 	const char *mnem;
 } ppc_alias_id;
 
@@ -60,7 +60,8 @@ static inline void add_cs_detail(MCInst *MI, ppc_op_group op_group, ...)
 
 void PPC_set_detail_op_reg(MCInst *MI, unsigned OpNum, ppc_reg Reg);
 void PPC_set_detail_op_imm(MCInst *MI, unsigned OpNum, int64_t Imm);
-void PPC_set_detail_op_mem(MCInst *MI, unsigned OpNum, uint64_t Val, bool is_off_reg);
+void PPC_set_detail_op_mem(MCInst *MI, unsigned OpNum, uint64_t Val,
+			   bool is_off_reg);
 
 void PPC_insert_detail_op_imm_at(MCInst *MI, unsigned index, int64_t Val,
 				 cs_ac_type access);
@@ -72,4 +73,3 @@ void PPC_check_updates_cr0(MCInst *MI);
 void PPC_set_instr_map_data(MCInst *MI, const uint8_t *Bytes, size_t BytesLen);
 
 #endif
-

--- a/arch/PowerPC/PPCModule.c
+++ b/arch/PowerPC/PPCModule.c
@@ -12,7 +12,7 @@
 cs_err PPC_global_init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
-	mri = (MCRegisterInfo *) cs_mem_malloc(sizeof(*mri));
+	mri = (MCRegisterInfo *)cs_mem_malloc(sizeof(*mri));
 
 	PPC_init_mri(mri);
 	ud->printer = PPC_printer;
@@ -32,7 +32,7 @@ cs_err PPC_global_init(cs_struct *ud)
 cs_err PPC_option(cs_struct *handle, cs_opt_type type, size_t value)
 {
 	if (type == CS_OPT_SYNTAX)
-		handle->syntax = (int) value;
+		handle->syntax = (int)value;
 
 	if (type == CS_OPT_MODE) {
 		handle->mode |= (cs_mode)value;

--- a/arch/PowerPC/PPCPredicates.h
+++ b/arch/PowerPC/PPCPredicates.h
@@ -58,7 +58,8 @@ static inline unsigned PPC_getPredicateHint(PPC_Predicate Opcode)
 /// Return predicate consisting of specified condition and hint bits.
 static inline PPC_Predicate PPC_getPredicate(unsigned Condition, unsigned Hint)
 {
-	return (PPC_Predicate)((Condition & ~PPC_BR_HINT_MASK) | (Hint & PPC_BR_HINT_MASK));
+	return (PPC_Predicate)((Condition & ~PPC_BR_HINT_MASK) |
+			       (Hint & PPC_BR_HINT_MASK));
 }
 
 #endif // CS_PPC_PREDICATES_H

--- a/arch/PowerPC/PPCRegisterInfo.h
+++ b/arch/PowerPC/PPCRegisterInfo.h
@@ -8,51 +8,54 @@
 
 /// stripRegisterPrefix - This method strips the character prefix from a
 /// register name so that only the number is left.  Used by for linux asm.
-static const char *PPCRegisterInfo_stripRegisterPrefix(const char *RegName) {
-  switch (RegName[0]) {
-    case 'a':
-      if (RegName[1] == 'c' && RegName[2] == 'c')
-        return RegName + 3;
-    break;
-    case 'r':
-    case 'f':
-    case 'v':
-      if (RegName[1] == 's') {
-        if (RegName[2] == 'p')
-          return RegName + 3;
-        return RegName + 2;
-      }
-      return RegName + 1;
-    case 'c':
-      if (RegName[1] == 'r')
-        return RegName + 2;
-      break;
-    case 'w':
-      // For wacc and wacc_hi
-      if (RegName[1] == 'a' && RegName[2] == 'c' && RegName[3] == 'c') {
-        if (RegName[4] == '_')
-          return RegName + 7;
-        else
-          return RegName + 4;
-      }
-      break;
-    case 'd':
-      // For dmr, dmrp, dmrrow, dmrrowp
-      if (RegName[1] == 'm' && RegName[2] == 'r') {
-        if (RegName[3] == 'r' && RegName[4] == 'o' && RegName[5] == 'w' &&
-            RegName[6] == 'p')
-          return RegName + 7;
-        else if (RegName[3] == 'r' && RegName[4] == 'o' && RegName[5] == 'w')
-          return RegName + 6;
-        else if (RegName[3] == 'p')
-          return RegName + 4;
-        else
-          return RegName + 3;
-      }
-      break;
-  }
+static const char *PPCRegisterInfo_stripRegisterPrefix(const char *RegName)
+{
+	switch (RegName[0]) {
+	case 'a':
+		if (RegName[1] == 'c' && RegName[2] == 'c')
+			return RegName + 3;
+		break;
+	case 'r':
+	case 'f':
+	case 'v':
+		if (RegName[1] == 's') {
+			if (RegName[2] == 'p')
+				return RegName + 3;
+			return RegName + 2;
+		}
+		return RegName + 1;
+	case 'c':
+		if (RegName[1] == 'r')
+			return RegName + 2;
+		break;
+	case 'w':
+		// For wacc and wacc_hi
+		if (RegName[1] == 'a' && RegName[2] == 'c' &&
+		    RegName[3] == 'c') {
+			if (RegName[4] == '_')
+				return RegName + 7;
+			else
+				return RegName + 4;
+		}
+		break;
+	case 'd':
+		// For dmr, dmrp, dmrrow, dmrrowp
+		if (RegName[1] == 'm' && RegName[2] == 'r') {
+			if (RegName[3] == 'r' && RegName[4] == 'o' &&
+			    RegName[5] == 'w' && RegName[6] == 'p')
+				return RegName + 7;
+			else if (RegName[3] == 'r' && RegName[4] == 'o' &&
+				 RegName[5] == 'w')
+				return RegName + 6;
+			else if (RegName[3] == 'p')
+				return RegName + 4;
+			else
+				return RegName + 3;
+		}
+		break;
+	}
 
-  return RegName;
+	return RegName;
 }
 
 #endif // CS_PPC_REGISTERINFO_H

--- a/include/capstone/ppc.h
+++ b/include/capstone/ppc.h
@@ -61,10 +61,8 @@ typedef enum ppc_bc {
 	PPC_PRED_GE = (0 << 5) | 4,
 	PPC_PRED_GT = (1 << 5) | 12,
 	PPC_PRED_NE = (2 << 5) | 4,
-	PPC_PRED_UN = (3 << 5) |
-		      12, ///< Unordered (after floating-point comparision)
-	PPC_PRED_NU = (3 << 5) |
-		      4,  ///< Not Unordered (after floating-point comparision)
+	PPC_PRED_UN = (3 << 5) | 12, ///< Unordered (after fp comparision)
+	PPC_PRED_NU = (3 << 5) | 4,  ///< Not Unordered (after fp comparision)
 	PPC_PRED_SO = (3 << 5) | 12, ///< summary overflow
 	PPC_PRED_NS = (3 << 5) | 4,  ///< not summary overflow
 

--- a/include/capstone/ppc.h
+++ b/include/capstone/ppc.h
@@ -12,7 +12,7 @@ extern "C" {
 #include "platform.h"
 
 #ifdef _MSC_VER
-#pragma warning(disable:4201)
+#pragma warning(disable : 4201)
 #endif
 
 /// Enum was moved from PPCPredicates.h so we do not have duplicates.
@@ -61,14 +61,16 @@ typedef enum ppc_bc {
 	PPC_PRED_GE = (0 << 5) | 4,
 	PPC_PRED_GT = (1 << 5) | 12,
 	PPC_PRED_NE = (2 << 5) | 4,
-	PPC_PRED_UN = (3 << 5) | 12, ///< Unordered (after floating-point comparision)
-	PPC_PRED_NU = (3 << 5) | 4, ///< Not Unordered (after floating-point comparision)
-	PPC_PRED_SO = (3 << 5) | 12,	///< summary overflow
-	PPC_PRED_NS = (3 << 5) | 4,	///< not summary overflow
+	PPC_PRED_UN = (3 << 5) |
+		      12, ///< Unordered (after floating-point comparision)
+	PPC_PRED_NU = (3 << 5) |
+		      4,  ///< Not Unordered (after floating-point comparision)
+	PPC_PRED_SO = (3 << 5) | 12, ///< summary overflow
+	PPC_PRED_NS = (3 << 5) | 4,  ///< not summary overflow
 
 	/// CTR predicates
 	PPC_PRED_NZ = (0 << 5) | 16,
-	PPC_PRED_Z  = (0 << 5) | 18,
+	PPC_PRED_Z = (0 << 5) | 18,
 	// Likely not taken
 	PPC_PRED_LT_MINUS = (0 << 5) | 14,
 	PPC_PRED_LE_MINUS = (1 << 5) | 6,
@@ -79,7 +81,7 @@ typedef enum ppc_bc {
 	PPC_PRED_UN_MINUS = (3 << 5) | 14,
 	PPC_PRED_NU_MINUS = (3 << 5) | 6,
 	PPC_PRED_NZ_MINUS = (0 << 5) | 24,
-	PPC_PRED_Z_MINUS  = (0 << 5) | 26,
+	PPC_PRED_Z_MINUS = (0 << 5) | 26,
 	// Likely taken
 	PPC_PRED_LT_PLUS = (0 << 5) | 15,
 	PPC_PRED_LE_PLUS = (1 << 5) | 7,
@@ -90,7 +92,7 @@ typedef enum ppc_bc {
 	PPC_PRED_UN_PLUS = (3 << 5) | 15,
 	PPC_PRED_NU_PLUS = (3 << 5) | 7,
 	PPC_PRED_NZ_PLUS = (0 << 5) | 17,
-	PPC_PRED_Z_PLUS  = (0 << 5) | 19,
+	PPC_PRED_Z_PLUS = (0 << 5) | 19,
 
 	// SPE scalar compare instructions always set the GT bit.
 	PPC_PRED_SPE = PPC_PRED_GT,
@@ -103,20 +105,20 @@ typedef enum ppc_bc {
 
 /// CR field indices and their meaning.
 typedef enum {
-	PPC_BI_LT = 0, ///< CR bit Less Then
-	PPC_BI_GT = 1, ///< CR bit Greater Then
-	PPC_BI_Z = 2, ///< CR bit Zero
-	PPC_BI_SO = 3, ///< CR bit Summary Overflow
+	PPC_BI_LT = 0,	       ///< CR bit Less Then
+	PPC_BI_GT = 1,	       ///< CR bit Greater Then
+	PPC_BI_Z = 2,	       ///< CR bit Zero
+	PPC_BI_SO = 3,	       ///< CR bit Summary Overflow
 	PPC_BI_INVALID = 0xff, ///< CR bit was not set/invalid
 } ppc_cr_bit;
 
 /// Masks of flags in the BO field.
 typedef enum {
-	PPC_BO_TEST_CR = 0b10000, ///< Flag mask: Test CR bit.
-	PPC_BO_CR_CMP = 0b01000, ///< Flag mask: Compare CR bit to 0 or 1.
+	PPC_BO_TEST_CR = 0b10000,  ///< Flag mask: Test CR bit.
+	PPC_BO_CR_CMP = 0b01000,   ///< Flag mask: Compare CR bit to 0 or 1.
 	PPC_BO_DECR_CTR = 0b00100, ///< Flag mask: Decrement counter.
-	PPC_BO_CTR_CMP = 0b00010, ///< Flag mask: Compare CTR to 0 or 1.
-	PPC_BO_T = 0b00001, ///< Either ignored (z) or hint bit t
+	PPC_BO_CTR_CMP = 0b00010,  ///< Flag mask: Compare CTR to 0 or 1.
+	PPC_BO_T = 0b00001,	   ///< Either ignored (z) or hint bit t
 } ppc_bo_mask;
 
 /// Bit for branch taken (plus) or not-taken (minus) hint
@@ -127,7 +129,7 @@ typedef enum {
 	PPC_BR_NOT_GIVEN = 0b00,
 	PPC_BR_RESERVED = 0b01,
 	PPC_BR_NOT_TAKEN = 0b10, ///< Minus
-	PPC_BR_TAKEN = 0b11, ///< Plus
+	PPC_BR_TAKEN = 0b11,	 ///< Plus
 	PPC_BR_HINT_MASK = 0b11,
 } ppc_br_hint;
 
@@ -142,7 +144,8 @@ typedef enum {
 } ppc_bh;
 
 /// Returns the hint encoded in the BO bits a and t.
-static inline ppc_br_hint PPC_get_hint(uint8_t bo) {
+static inline ppc_br_hint PPC_get_hint(uint8_t bo)
+{
 	bool DecrCTR = (bo & PPC_BO_DECR_CTR) == 0;
 	bool TestCR = (bo & PPC_BO_TEST_CR) == 0;
 	if (!DecrCTR && !TestCR)
@@ -160,12 +163,13 @@ static inline ppc_br_hint PPC_get_hint(uint8_t bo) {
 ///
 /// It returns PPC_PRED_INVALID if the CR predicate is requested, but no
 /// CR predicate is encoded in BI and BO. Same for the CTR predicate.
-static inline ppc_pred PPC_get_branch_pred(uint8_t bi, uint8_t bo, bool get_cr_pred) {
+static inline ppc_pred PPC_get_branch_pred(uint8_t bi, uint8_t bo,
+					   bool get_cr_pred)
+{
 	bool TestCR = ((bo & PPC_BO_TEST_CR) == 0);
 	bool DecrCTR = ((bo & PPC_BO_DECR_CTR) == 0);
 
-	if ((get_cr_pred && !TestCR) ||
-			(!get_cr_pred && !DecrCTR))
+	if ((get_cr_pred && !TestCR) || (!get_cr_pred && !DecrCTR))
 		return PPC_PRED_INVALID;
 
 	if (TestCR && DecrCTR) {
@@ -184,9 +188,9 @@ static inline ppc_pred PPC_get_branch_pred(uint8_t bi, uint8_t bo, bool get_cr_p
 /// Operand type for instruction's operands
 typedef enum ppc_op_type {
 	PPC_OP_INVALID = CS_OP_INVALID, ///< Uninitialized.
-	PPC_OP_REG = CS_OP_REG, ///< Register operand.
-	PPC_OP_IMM = CS_OP_IMM, ///< Immediate operand.
-	PPC_OP_MEM = CS_OP_MEM, ///< Memory operand.
+	PPC_OP_REG = CS_OP_REG,		///< Register operand.
+	PPC_OP_IMM = CS_OP_IMM,		///< Immediate operand.
+	PPC_OP_MEM = CS_OP_MEM,		///< Memory operand.
 } ppc_op_type;
 
 /// PPC registers
@@ -737,7 +741,7 @@ typedef enum ppc_reg {
 typedef struct ppc_op_mem {
 	ppc_reg base;	///< base register
 	int32_t disp;	///< displacement/offset value
-	ppc_reg offset;	///< Offset register
+	ppc_reg offset; ///< Offset register
 } ppc_op_mem;
 
 /// Instruction operand
@@ -745,8 +749,8 @@ typedef struct cs_ppc_op {
 	ppc_op_type type;	///< operand type
 	union {
 		ppc_reg reg;	///< register value for REG operand
-		int64_t imm;		///< immediate value for IMM operand
-		ppc_op_mem mem;		///< base/disp value for MEM operand
+		int64_t imm;	///< immediate value for IMM operand
+		ppc_op_mem mem; ///< base/disp value for MEM operand
 	};
 	cs_ac_type access;
 } cs_ppc_op;
@@ -755,16 +759,17 @@ typedef struct {
 	uint8_t bo; ///< BO field of branch condition. UINT8_MAX if invalid.
 	uint8_t bi; ///< BI field of branch condition. UINT8_MAX if invalid.
 	ppc_cr_bit crX_bit; ///< CR field bit to test.
-	ppc_reg crX; ///< The CR field accessed.
-	ppc_br_hint hint; ///< The encoded hint.
-	ppc_pred pred_cr; ///< CR-bit branch predicate
-	ppc_pred pred_ctr; ///< CTR branch predicate
-	ppc_bh bh; ///< The BH field hint if any is present.
+	ppc_reg crX;	    ///< The CR field accessed.
+	ppc_br_hint hint;   ///< The encoded hint.
+	ppc_pred pred_cr;   ///< CR-bit branch predicate
+	ppc_pred pred_ctr;  ///< CTR branch predicate
+	ppc_bh bh;	    ///< The BH field hint if any is present.
 } ppc_bc;
 
 /// Returns true if the CTR is decremented.
 /// False otherwise.
-static inline bool cs_ppc_bc_decr_ctr(uint8_t bo) {
+static inline bool cs_ppc_bc_decr_ctr(uint8_t bo)
+{
 	if (bo != UINT8_MAX && (bo & PPC_BO_DECR_CTR) == 0)
 		return true;
 	return false;
@@ -773,15 +778,18 @@ static inline bool cs_ppc_bc_decr_ctr(uint8_t bo) {
 /// Returns true if the CTR is compared to 0
 /// Implies that the CTR is decremented at all.
 /// False otherwise.
-static inline bool cs_ppc_bc_tests_ctr_is_zero(uint8_t bo) {
-	if (bo != UINT8_MAX && (bo & PPC_BO_CTR_CMP) != 0 && cs_ppc_bc_decr_ctr(bo))
+static inline bool cs_ppc_bc_tests_ctr_is_zero(uint8_t bo)
+{
+	if (bo != UINT8_MAX && (bo & PPC_BO_CTR_CMP) != 0 &&
+	    cs_ppc_bc_decr_ctr(bo))
 		return true;
 	return false;
 }
 
 /// Returns true if a CR bit is tested.
 /// False otherwise.
-static inline bool cs_ppc_bc_cr_is_tested(uint8_t bo) {
+static inline bool cs_ppc_bc_cr_is_tested(uint8_t bo)
+{
 	if (bo != UINT8_MAX && (bo & PPC_BO_TEST_CR) == 0)
 		return true;
 	return false;
@@ -790,8 +798,10 @@ static inline bool cs_ppc_bc_cr_is_tested(uint8_t bo) {
 /// Returns true if a CR bit is compared to 1.
 /// Implies that the CR field is tested at all.
 /// False otherwise.
-static inline bool cs_ppc_bc_cr_bit_is_one(uint8_t bo) {
-	if (bo != UINT8_MAX && (bo & PPC_BO_CR_CMP) != 0 && cs_ppc_bc_cr_is_tested(bo))
+static inline bool cs_ppc_bc_cr_bit_is_one(uint8_t bo)
+{
+	if (bo != UINT8_MAX && (bo & PPC_BO_CR_CMP) != 0 &&
+	    cs_ppc_bc_cr_is_tested(bo))
 		return true;
 	return false;
 }
@@ -3171,10 +3181,10 @@ typedef enum ppc_insn_group {
 
 	// Generic groups
 	// all jump instructions (conditional+direct+indirect jumps)
-	PPC_GRP_JUMP,	///< = CS_GRP_JUMP
-	PPC_GRP_CALL,	///< = CS_GRP_CALL
-	PPC_GRP_INT = 4, ///< = CS_GRP_INT
-	PPC_GRP_PRIVILEGE = 6, ///< = CS_GRP_PRIVILEGE
+	PPC_GRP_JUMP,		 ///< = CS_GRP_JUMP
+	PPC_GRP_CALL,		 ///< = CS_GRP_CALL
+	PPC_GRP_INT = 4,	 ///< = CS_GRP_INT
+	PPC_GRP_PRIVILEGE = 6,	 ///< = CS_GRP_PRIVILEGE
 	PPC_GRP_BRANCH_RELATIVE, ///< = CS_GRP_BRANCH_RELATIVE
 
 	// Architecture-specific groups
@@ -3204,7 +3214,7 @@ typedef enum ppc_insn_group {
 	// clang-format on
 	// generated content <PPCGenCSFeatureEnum.inc> end
 
-	PPC_GRP_ENDING,   // <-- mark the end of the list of groups
+	PPC_GRP_ENDING, // <-- mark the end of the list of groups
 } ppc_insn_group;
 
 /// PPC instruction formats. To get details about them please
@@ -3340,10 +3350,11 @@ typedef enum {
 	// generated content <PPCGenCSInsnFormatsEnum.inc> end
 } ppc_insn_form;
 
-static inline bool ppc_is_b_form(ppc_insn_form form) {
+static inline bool ppc_is_b_form(ppc_insn_form form)
+{
 	switch (form) {
 	default:
-		return false;		
+		return false;
 	case PPC_INSN_FORM_BFORM:
 	case PPC_INSN_FORM_BFORM_3:
 	case PPC_INSN_FORM_BFORM_3_AT:


### PR DESCRIPTION
This does not format the `inc` files. For AArch64 formatting the inc files takes forever (huge line count). So I suggest to exclude them from the formatting.