### PR TITLE
Support pkg-config --static flag in capstone.pc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -631,6 +631,7 @@ define generate-pkgcfg
 	echo 'includedir=$(INCDIR)/capstone' >> $(PKGCFGF)
 	echo 'archive=$${libdir}/libcapstone.a' >> $(PKGCFGF)
 	echo 'Libs: -L$${libdir} -lcapstone' >> $(PKGCFGF)
+	echo 'Libs.private: -L$${libdir} -l:libcapstone.a' >> $(PKGCFGF)
 	echo 'Cflags: -I$${includedir}' >> $(PKGCFGF)
 	echo 'archs=${CAPSTONE_ARCHS}' >> $(PKGCFGF)
 endef

--- a/capstone.pc.in
+++ b/capstone.pc.in
@@ -9,5 +9,6 @@ Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
 URL: https://www.capstone-engine.org/
 archive=${libdir}/libcapstone.a
 Libs: -L${libdir} -lcapstone
+Libs.private: -L${libdir} -l:libcapstone.a
 Cflags: -I${includedir}/capstone
 archs=@CAPSTONE_ARCHITECTURES@


### PR DESCRIPTION
Adds support for `pkg-config`'s `--static` flag so that downstream users don't need to manually specify the path to `libcapstone.a` when statically linking.

Before change:
```
$ pkg-config --libs capstone
-lcapstone
$ pkg-config --libs capstone --static
-lcapstone
```
After change:
```
$ pkg-config --libs capstone
-lcapstone
$ pkg-config --libs capstone --static
-lcapstone -l:libcapstone.a
```