### PR TITLE
Fix compilation on gcc 12.2.0

### DIFF
--- a/include/capstone/arm.h
+++ b/include/capstone/arm.h
@@ -156,6 +156,7 @@ inline static const char *ARMVPTPredToString(ARMVCC_VPTCodes CC)
     return "e";
   }
   assert(0 && "Unknown VPT code");
+  return "";
 }
 
 inline static unsigned ARMVectorCondCodeFromString(const char CC)


### PR DESCRIPTION
Hi,

When compiling on gcc 12.2.0 (default version on Debian bookworm), this error occurs:

```
In file included from capstone/arch/ARM/../../include/capstone/capstone.h:296,
                 from capstone/arch/ARM/../../Mapping.h:11,
                 from capstone/arch/ARM/ARMInstPrinter.c:32:
capstone/arch/ARM/../../include/capstone/arm.h: In function ‘ARMVPTPredToString’:
capstone/arch/ARM/../../include/capstone/arm.h:159:1: error: control reaches end of non-void function [-Werror=return-type]
  159 | }
      | ^
cc1: all warnings being treated as errors
```

This PR fix the error.

I could have fixed it with a `__builtin_unreachable` but it isn't available on MSVC. The assert & the fact that the switch above should handle all valid values of the enum should be enough to prevent issues anyway.