### PR TITLE
Change RegVal type to 64bit.

### DIFF
--- a/MCInst.h
+++ b/MCInst.h
@@ -42,7 +42,7 @@ struct MCOperand {
 	unsigned char Kind;
 
 	union {
-		unsigned RegVal;
+		uint64_t RegVal;
 		int64_t ImmVal;
 		double FPImmVal;
 	};


### PR DESCRIPTION
It does become an endian issue on big endian machines, if the operand is an immediate value with the high 32bits set, but `getRegVal() == 0` is checked on it.


@kabeor Sorry, of cause I missed the endian issue in the last PR -.-