### PR TITLE
fix: correct typo in COMPILE_CMAKE.TXT

### DIFF
--- a/COMPILE_CMAKE.TXT
+++ b/COMPILE_CMAKE.TXT
@@ -37,7 +37,7 @@ Get CMake for free from http://www.cmake.org.
   - CAPSTONE_X86_WASM: support Web Assembly. Run cmake with -DCAPSTONE_WASM_SUPPORT=0 to remove WASM.
   - CAPSTONE_BPF_SUPPORT: support BPF. Run cmake with -DCAPSTONE_BPF_SUPPORT=0 to remove BPF.
   - CAPSTONE_RISCV_SUPPORT: support RISCV. Run cmake with -DCAPSTONE_RISCV_SUPPORT=0 to remove RISCV.
-  - CAPSTONE_ARCHITECUTRE_DEFAULT: Whether architectures are enabled by default.
+  - CAPSTONE_ARCHITECTURE_DEFAULT: Whether architectures are enabled by default.
       Set this of OFF with -DCAPSTONE_ARCHITECTURE_DEFAULT=OFF to disable all architectures by default.
       You can then enable them again with one of the CAPSTONE_<ARCH>_SUPPORT options.
 


### PR DESCRIPTION
Fix typo in `CAPSTONE_ARCHITECUTRE_DEFAULT`