### PR TITLE
Remove __GNUC__ check for warning suppression.

### DIFF
--- a/arch/AArch64/AArch64AddressingModes.h
+++ b/arch/AArch64/AArch64AddressingModes.h
@@ -823,7 +823,7 @@ static inline uint64_t AArch64_AM_decodeAdvSIMDModImmType12(uint8_t Imm)
 }
 
 
-#if __GNUC__ && defined( __has_warning )
+#if defined( __has_warning )
 #   if __has_warning( "-Wmaybe-uninitialized" )
 #       define WARNING_SUPRESSED
 #				pragma GCC diagnostic push


### PR DESCRIPTION
The warning still appears in some build configurations. Likely because the `__GNU__` check fails.