### PR TITLE
[v5] Add meta-programming macros for ARM64/AArch64 name change to capstone.h

### DIFF
--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -60,6 +60,59 @@ extern "C" {
 #define CS_VERSION_MINOR CS_API_MINOR
 #define CS_VERSION_EXTRA 1
 
+/// Macro for meta programming.
+/// Meant for projects using Capstone and need to support multiple
+/// versions of it.
+/// These macros replace several instances of the old "ARM64" with
+/// the new "AArch64" name depending on the CS version.
+#if CS_NEXT_VERSION < 6
+#define CS_AARCH64(x) ARM64##x
+#else
+#define CS_AARCH64(x) AArch64##x
+#endif
+
+#if CS_NEXT_VERSION < 6
+#define CS_AARCH64pre(x) x##ARM64
+#else
+#define CS_AARCH64pre(x) x##AARCH64
+#endif
+
+#if CS_NEXT_VERSION < 6
+#define CS_AARCH64CC(x) ARM64_CC##x
+#else
+#define CS_AARCH64CC(x) AArch64CC##x
+#endif
+
+#if CS_NEXT_VERSION < 6
+#define CS_AARCH64_VL_(x) ARM64_VAS_##x
+#else
+#define CS_AARCH64_VL_(x) AArch64Layout_VL_##x
+#endif
+
+#if CS_NEXT_VERSION < 6
+#define CS_aarch64(x) arm64##x
+#else
+#define CS_aarch64(x) aarch64##x
+#endif
+
+#if CS_NEXT_VERSION < 6
+#define CS_aarch64_op() cs_arm64_op
+#define CS_aarch64_reg() arm64_reg
+#define CS_aarch64_cc() arm64_cc
+#define CS_cs_aarch64() cs_arm64
+#define CS_aarch64_extender() arm64_extender
+#define CS_aarch64_shifter() arm64_shifter
+#define CS_aarch64_vas() arm64_vas
+#else
+#define CS_aarch64_op() cs_aarch64_op
+#define CS_aarch64_reg() aarch64_reg
+#define CS_aarch64_cc() AArch64CC_CondCode
+#define CS_cs_aarch64() cs_aarch64
+#define CS_aarch64_extender() aarch64_extender
+#define CS_aarch64_shifter() aarch64_shifter
+#define CS_aarch64_vas() AArch64Layout_VectorLayout
+#endif
+
 /// Macro to create combined version which can be compared to
 /// result of cs_version() API.
 #define CS_MAKE_VERSION(major, minor) ((major << 8) + minor)

--- a/tests/test_arm64.c
+++ b/tests/test_arm64.c
@@ -1,6 +1,7 @@
 /* Capstone Disassembler Engine */
 /* By Nguyen Anh Quynh <aquynh@gmail.com>, 2013-2019 */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -237,9 +238,27 @@ static void test()
 	}
 }
 
+void test_macros() {
+	assert(CS_AARCH64(_INS_BL) == ARM64_INS_BL);
+	assert(CS_AARCH64pre(CS_ARCH_) == CS_ARCH_ARM64);
+	assert(CS_AARCH64CC(_AL) == ARM64_CC_AL);
+	assert(CS_AARCH64_VL_(16B) == ARM64_VAS_16B);
+	cs_detail detail = { 0 };
+	CS_cs_aarch64() arm64_detail = { 0 };
+	detail.arm64 = arm64_detail;
+	CS_aarch64_op() op = { 0 };
+	detail.CS_aarch64().operands[0] = op;
+	CS_aarch64_reg() reg = 1;
+	CS_aarch64_cc() cc = ARM64_CC_AL;
+	CS_aarch64_extender() arm64_extender = ARM64_EXT_SXTB;
+	CS_aarch64_shifter() arm64_shifter = ARM64_SFT_LSL;
+	CS_aarch64_vas() arm64_vas = ARM64_VAS_16B;
+}
+
 int main()
 {
 	test();
+	test_macros();
 
 	return 0;
 }


### PR DESCRIPTION
Adds the meta programming macros for the `ARM64` -> `AArch64` name change to the `v5` branch.