### PR TITLE
[v6] Move meta-programming macros for ARM64/AArch64 to capstone.h

### DIFF
--- a/include/capstone/aarch64.h
+++ b/include/capstone/aarch64.h
@@ -17,59 +17,6 @@ extern "C" {
 #pragma warning(disable : 4201)
 #endif
 
-/// Macro for meta programming.
-/// Meant for projects using Capstone and need to support multiple
-/// versions of it.
-/// These macros replace several instances of the old "ARM64" with
-/// the new "AArch64" name depending on the CS version.
-#if CS_NEXT_VERSION < 6
-#define CS_AARCH64(x) ARM64##x
-#else
-#define CS_AARCH64(x) AArch64##x
-#endif
-
-#if CS_NEXT_VERSION < 6
-#define CS_AARCH64pre(x) x##ARM64
-#else
-#define CS_AARCH64pre(x) x##AARCH64
-#endif
-
-#if CS_NEXT_VERSION < 6
-#define CS_AARCH64CC(x) ARM64_CC##x
-#else
-#define CS_AARCH64CC(x) AArch64CC##x
-#endif
-
-#if CS_NEXT_VERSION < 6
-#define CS_AARCH64_VL_(x) ARM64_VAS_##x
-#else
-#define CS_AARCH64_VL_(x) AArch64Layout_VL_##x
-#endif
-
-#if CS_NEXT_VERSION < 6
-#define CS_aarch64(x) arm64##x
-#else
-#define CS_aarch64(x) aarch64##x
-#endif
-
-#if CS_NEXT_VERSION < 6
-#define CS_aarch64_op() cs_arm64_op
-#define CS_aarch64_reg() arm64_reg
-#define CS_aarch64_cc() arm64_cc
-#define CS_cs_aarch64() cs_arm64
-#define CS_aarch64_extender() arm64_extender
-#define CS_aarch64_shifter() arm64_shifter
-#define CS_aarch64_vas() arm64_vas
-#else
-#define CS_aarch64_op() cs_aarch64_op
-#define CS_aarch64_reg() aarch64_reg
-#define CS_aarch64_cc() AArch64CC_CondCode
-#define CS_cs_aarch64() cs_aarch64
-#define CS_aarch64_extender() aarch64_extender
-#define CS_aarch64_shifter() aarch64_shifter
-#define CS_aarch64_vas() AArch64Layout_VectorLayout
-#endif
-
 /// AArch64 shift type
 typedef enum aarch64_shifter {
   AArch64_SFT_INVALID = 0,

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -61,6 +61,59 @@ extern "C" {
 #define CS_VERSION_MINOR CS_API_MINOR
 #define CS_VERSION_EXTRA 0
 
+/// Macro for meta programming.
+/// Meant for projects using Capstone and need to support multiple
+/// versions of it.
+/// These macros replace several instances of the old "ARM64" with
+/// the new "AArch64" name depending on the CS version.
+#if CS_NEXT_VERSION < 6
+#define CS_AARCH64(x) ARM64##x
+#else
+#define CS_AARCH64(x) AArch64##x
+#endif
+
+#if CS_NEXT_VERSION < 6
+#define CS_AARCH64pre(x) x##ARM64
+#else
+#define CS_AARCH64pre(x) x##AARCH64
+#endif
+
+#if CS_NEXT_VERSION < 6
+#define CS_AARCH64CC(x) ARM64_CC##x
+#else
+#define CS_AARCH64CC(x) AArch64CC##x
+#endif
+
+#if CS_NEXT_VERSION < 6
+#define CS_AARCH64_VL_(x) ARM64_VAS_##x
+#else
+#define CS_AARCH64_VL_(x) AArch64Layout_VL_##x
+#endif
+
+#if CS_NEXT_VERSION < 6
+#define CS_aarch64(x) arm64##x
+#else
+#define CS_aarch64(x) aarch64##x
+#endif
+
+#if CS_NEXT_VERSION < 6
+#define CS_aarch64_op() cs_arm64_op
+#define CS_aarch64_reg() arm64_reg
+#define CS_aarch64_cc() arm64_cc
+#define CS_cs_aarch64() cs_arm64
+#define CS_aarch64_extender() arm64_extender
+#define CS_aarch64_shifter() arm64_shifter
+#define CS_aarch64_vas() arm64_vas
+#else
+#define CS_aarch64_op() cs_aarch64_op
+#define CS_aarch64_reg() aarch64_reg
+#define CS_aarch64_cc() AArch64CC_CondCode
+#define CS_cs_aarch64() cs_aarch64
+#define CS_aarch64_extender() aarch64_extender
+#define CS_aarch64_shifter() aarch64_shifter
+#define CS_aarch64_vas() AArch64Layout_VectorLayout
+#endif
+
 /// Macro to create combined version which can be compared to
 /// result of cs_version() API.
 #define CS_MAKE_VERSION(major, minor) ((major << 8) + minor)

--- a/tests/test_aarch64.c
+++ b/tests/test_aarch64.c
@@ -332,9 +332,30 @@ static void test()
 	}
 }
 
+int test_macros() {
+	assert(CS_AARCH64(_INS_BL) == AArch64_INS_BL);
+	assert(CS_AARCH64pre(CS_ARCH_) == CS_ARCH_AARCH64);
+	assert(CS_AARCH64CC(_AL) == AArch64CC_AL);
+	assert(CS_AARCH64_VL_(16B) == AArch64Layout_VL_16B);
+	cs_detail detail = { 0 };
+	CS_cs_aarch64() aarch64_detail = { 0 };
+	detail.aarch64 = aarch64_detail;
+	CS_aarch64_op() op = { 0 };
+	detail.CS_aarch64().operands[0] = op;
+	CS_aarch64_reg() reg = 1;
+	CS_aarch64_cc() cc = AArch64CC_AL;
+	CS_aarch64_extender() aarch64_extender = AArch64_EXT_SXTB;
+	CS_aarch64_shifter() aarch64_shifter = AArch64_SFT_LSL;
+	CS_aarch64_vas() aarch64_vas = AArch64Layout_VL_16B;
+	// Do something with them to prevent compiler warnings.
+	return reg + cc + aarch64_extender + aarch64_shifter + aarch64_vas + detail.aarch64.cc;
+
+}
+
 int main()
 {
 	test();
+	test_macros();
 
 	return 0;
 }


### PR DESCRIPTION
Move the meta-programming macros for `ARM64` -> `AArch64` name change to `capstone.h` so it is consistent with https://github.com/capstone-engine/capstone/pull/2199 and https://github.com/capstone-engine/capstone/pull/2200