### PR TITLE
Disable maybe-uninitialized warning all together.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,22 @@ project(capstone
     VERSION 5.0
 )
 
+set(UNIX_COMPILER_OPTIONS -Werror -Wshift-negative-value -Wreturn-type -Wformat -Wmissing-braces -Wunused-function -Warray-bounds -Wunused-variable -Wparentheses -Wint-in-bool-context -Wmisleading-indentation)
+
+# maybe-unitialzied is only supported by newer versions of GCC.
+# Unfortunately, it is pretty unreliable and reports wrong results.
+# So we disable it for all compilers versions which support it.
+include(CheckCCompilerFlag)
+check_c_compiler_flag("-Wno-maybe-unitialized" SUPPORTS_MU)
+
+if (SUPPORTS_MU)
+    set(UNIX_COMPILER_OPTIONS ${UNIX_COMPILER_OPTIONS} -Wno-maybe-unitialized)
+endif()
+
 if (MSVC)
     add_compile_options(/W1 /w14189)
 else()
-    add_compile_options(-Werror -Wshift-negative-value -Wreturn-type -Wformat -Wmissing-braces -Wunused-function -Warray-bounds -Wunused-variable -Wparentheses -Wint-in-bool-context -Wmisleading-indentation)
+    add_compile_options(${UNIX_COMPILE_OPTIONS})
 endif()
 
 

--- a/arch/AArch64/AArch64AddressingModes.h
+++ b/arch/AArch64/AArch64AddressingModes.h
@@ -823,14 +823,6 @@ static inline uint64_t AArch64_AM_decodeAdvSIMDModImmType12(uint8_t Imm)
 }
 
 
-#if defined( __has_warning )
-#   if __has_warning( "-Wmaybe-uninitialized" )
-#       define WARNING_SUPRESSED
-#				pragma GCC diagnostic push
-#				pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#   endif
-#endif
-
 /// Returns true if Imm is the concatenation of a repeating pattern of type T.
 #define DEFINE_isSVEMaskOfIdenticalElements(T)                                 \
 	static inline bool CONCAT(AArch64_AM_isSVEMaskOfIdenticalElements, T)(int64_t Imm)    \
@@ -846,10 +838,6 @@ DEFINE_isSVEMaskOfIdenticalElements(int8_t);
 DEFINE_isSVEMaskOfIdenticalElements(int16_t);
 DEFINE_isSVEMaskOfIdenticalElements(int32_t);
 DEFINE_isSVEMaskOfIdenticalElements(int64_t);
-
-#ifdef WARNING_SUPRESSED
-#pragma GCC diagnostic pop
-#endif
 
 static inline bool AArch64_AM_isSVEMaskOfIdenticalElements64(int64_t Imm)
 {


### PR DESCRIPTION
Disabling `maybe-unitialized` (which produces false positives) is really annoying if done in code with `pragmas`. 
The option is only supported by a certain subset of `gcc` versions and all the other compilers throw warnings about an unknown option.

I do not think it is worth it and we should disable it for the whole project.