### PR TITLE
LIBDIRARCH does not propagate to Makefile

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -77,7 +77,8 @@ install() {
     fi
     ${MAKE} install
   else  # not OSX
-    test -d /usr/lib64 && ${MAKE} LIBDIRARCH=lib64
+    test -d /usr/lib64 && export LIBDIRARCH=lib64
+    ${MAKE}
     ${MAKE} install
   fi
 }
@@ -89,7 +90,7 @@ uninstall() {
     export PKGCFGDIR="$(pkg-config --variable pc_path pkg-config | cut -d ':' -f 1)"
     ${MAKE} uninstall
   else  # not OSX
-    test -d /usr/lib64 && LIBDIRARCH=lib64
+    test -d /usr/lib64 && export LIBDIRARCH=lib64
     ${MAKE} uninstall
   fi
 }


### PR DESCRIPTION
I did not see `lib64` under capstone directory when I installed it via `make.sh` as following:

```
$ PREFIX=/tmp/capstone ./make.sh install
  :
<snip>
  :
$ ls /tmp/capstone
bin  include  lib
```

We could not use `pkg-config` to detect capstone directories because `libdir` in `capstone.pc` points to `lib64`:

```
$ cat /tmp/capstone/lib/pkgconfig/capstone.pc
Name: capstone
Description: Capstone disassembly engine
Version: 5.0.0
libdir=/tmp/capstone/lib64
includedir=/tmp/capstone/include/capstone
archive=${libdir}/libcapstone.a
Libs: -L${libdir} -lcapstone
Libs.private: -L${libdir} -l:libcapstone.a
Cflags: -I${includedir}
archs=arm aarch64 m68k mips powerpc sparc systemz x86 xcore tms320c64x m680x evm riscv mos65xx wasm bpf sh tricore
```

`make.sh` would kick `make` with `LIBDIRARCH=lib64` if `/usr/lib64` exists, but it does not propagate to `make install`. We can see same problem in `uninstall()`. We need to export or set it to each commands.