### PR TITLE
Add CS_aarch64 macro without parameter.

### DIFF
--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -91,6 +91,12 @@ extern "C" {
 #endif
 
 #if CS_NEXT_VERSION < 6
+#define CS_aarch64_ arm64
+#else
+#define CS_aarch64_ aarch64
+#endif
+
+#if CS_NEXT_VERSION < 6
 #define CS_aarch64(x) arm64##x
 #else
 #define CS_aarch64(x) aarch64##x

--- a/tests/test_aarch64.c
+++ b/tests/test_aarch64.c
@@ -341,7 +341,7 @@ int test_macros() {
 	CS_cs_aarch64() aarch64_detail = { 0 };
 	detail.aarch64 = aarch64_detail;
 	CS_aarch64_op() op = { 0 };
-	detail.CS_aarch64().operands[0] = op;
+	detail.CS_aarch64_.operands[0] = op;
 	CS_aarch64_reg() reg = 1;
 	CS_aarch64_cc() cc = AArch64CC_AL;
 	CS_aarch64_extender() aarch64_extender = AArch64_EXT_SXTB;


### PR DESCRIPTION
MSVC will throw C4003 if a macro with an argument is used, without setting the argument.
Hence we need one for this use case.