### PR TITLE
[v4] Add CS_aarch64 macro without parameter.

### DIFF
--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -90,6 +90,12 @@ extern "C" {
 #endif
 
 #if CS_NEXT_VERSION < 6
+#define CS_aarch64_ arm64
+#else
+#define CS_aarch64_ aarch64
+#endif
+
+#if CS_NEXT_VERSION < 6
 #define CS_aarch64(x) arm64##x
 #else
 #define CS_aarch64(x) aarch64##x

--- a/tests/test_arm64.c
+++ b/tests/test_arm64.c
@@ -232,7 +232,7 @@ void test_macros() {
 	CS_cs_aarch64() arm64_detail = { 0 };
 	detail.arm64 = arm64_detail;
 	CS_aarch64_op() op = { 0 };
-	detail.CS_aarch64().operands[0] = op;
+	detail.CS_aarch64_.operands[0] = op;
 	CS_aarch64_reg() reg = 1;
 	CS_aarch64_cc() cc = ARM64_CC_AL;
 	CS_aarch64_extender() arm64_extender = ARM64_EXT_SXTB;


### PR DESCRIPTION
MSVC will throw C4003 if a macro with an argument is used, without setting the argument. Hence we need one for this use case.