### PR TITLE
Raise minimum requirement to VS2017

### DIFF
--- a/COMPILE_MSVC.TXT
+++ b/COMPILE_MSVC.TXT
@@ -11,10 +11,10 @@ Capstone requires no prerequisite packages with default configurations, so it is
 easy to compile & install. Open the Visual Studio solution "msvc/capstone.sln"
 and follow the instructions below.
 
-NOTE: This requires Visual Studio 2010 or newer versions.
+NOTE: This requires Visual Studio 2017 or newer versions.
 
-If you wish to embed Capstone in a kernel driver, Visual Studio 2013 or newer
-versions, and Windows Driver Kit 8.1 Update 1 or newer versions are required.
+If you wish to embed Capstone in a kernel driver Windows Driver Kit 8.1 Update 1
+or newer versions are required.
 
 
 (0) Tailor Capstone to your need.

--- a/msvc/README
+++ b/msvc/README
@@ -4,7 +4,7 @@ using Microsoft Visual Studio (VS).
 
 NOTE:
 
-(1) Visual Studio 2010 or newer versions is required. Open "capstone.sln" to
+(1) Visual Studio 2017 or newer versions is required. Open "capstone.sln" to
     build the libraries & test code with Visual Studio. The resulted binaries
     are put under either msvc/Debug, msvc/Release, msvc/x64/Debug, or
     msvc/x64/Release, depending on how you choose to compile them.
@@ -17,6 +17,6 @@ NOTE:
 
 (3) The capstone_static_winkernel and test_winkernel projects are for Windows
     kernel drivers and excluded from build by default. In order to build them,
-    you need to install Visual Studio 2013 or newer versions, and Windows Driver
-    Kit 8.1 Update 1 or newer versions, then check "Build" check boxes for those
-    projects on the Configuration Manager through the [Build] menu.
+    you need to install Windows Driver Kit 8.1 Update 1 or newer versions,
+    then check "Build" check boxes for those projects on
+    the Configuration Manager through the [Build] menu.


### PR DESCRIPTION
Since the auto-sync changes Capstone use C99, no Visual Studio below 2015 could compile it. On the other hand, it's 2024 already, and maintainers have no reason to support this ancient software (the latest Visual Studio is VS2022). 

Users of the legacy platforms could either update or use older capstone, or make custom patches/forks. Given [the lack of maintainers](https://github.com/capstone-engine/capstone/issues/2089), supporting those strains limited resources even further.

Instead of VS2015 I used VS2017 just to be safe because in Rizin we check all commits with this version precisely: https://raw.githubusercontent.com/rizinorg/rizin/dev/.appveyor.yml

Closes https://github.com/capstone-engine/capstone/issues/2226