### PR TITLE
Fix #2234.

### DIFF
--- a/arch/AArch64/AArch64GenCSMappingInsn.inc
+++ b/arch/AArch64/AArch64GenCSMappingInsn.inc
@@ -10788,14 +10788,14 @@
   /* bl	$addr */
   AArch64_BL /* 1539 */, AArch64_INS_BL,
   #ifndef CAPSTONE_DIET
-    { AArch64_REG_SP, 0 }, { AArch64_REG_LR, 0 }, { AArch64_GRP_CALL, AArch64_GRP_BRANCH_RELATIVE, 0 }, 0, 0, {{ 0 }}
+    { 0 }, { AArch64_REG_LR, 0 }, { AArch64_GRP_CALL, AArch64_GRP_BRANCH_RELATIVE, 0 }, 1, 0, {{ 0 }},
   #endif
 },
 {
   /* blr	$Rn */
   AArch64_BLR /* 1540 */, AArch64_INS_BLR,
   #ifndef CAPSTONE_DIET
-    { AArch64_REG_SP, 0 }, { AArch64_REG_LR, 0 }, { AArch64_GRP_CALL, 0 }, 0, 0, {{ 0 }}
+    { 0 }, { AArch64_REG_LR, 0 }, { AArch64_GRP_CALL, 0 }, 1, 1, {{ 0 }},
   #endif
 },
 {


### PR DESCRIPTION
BL is no call and does not read SP

New output:
```
./cstool -d aarch64 "\xec\x6a\x01\x95"
 0  ec 6a 01 95  bl	0x405abb0
	ID: 81 (bl)
	op_count: 1
		operands[0].type: IMM = 0x405abb0
		operands[0].access: READ
	Registers modified: x30
	Groups: call branch_relative 

```

No test because we cannot test negative conditions with cstest (no SP read etc.).