### PR TITLE
Fix type punning in `AArch64_AM_isSVEMaskOfIdenticalElements`

### DIFF
--- a/arch/AArch64/AArch64AddressingModes.h
+++ b/arch/AArch64/AArch64AddressingModes.h
@@ -827,7 +827,8 @@ static inline uint64_t AArch64_AM_decodeAdvSIMDModImmType12(uint8_t Imm)
 #define DEFINE_isSVEMaskOfIdenticalElements(T)                                 \
 	static inline bool CONCAT(AArch64_AM_isSVEMaskOfIdenticalElements, T)(int64_t Imm)    \
 	{                                                                          \
-		T *Parts = (T *)(&(Imm));					\
+		T Parts[sizeof(int64_t) / sizeof(T)];                  \
+		memcpy(Parts, &Imm, sizeof(int64_t) / sizeof(T) * sizeof(T));                 \
 		for (int i = 0; i < (sizeof(int64_t) / sizeof(T)); i++) {   \
 			if (Parts[i] != Parts[0]) \
 				return false; \


### PR DESCRIPTION
This is a minor edit that fixes the type punning in `AArch64_AM_isSVEMaskOfIdenticalElements` which violates C strict aliasing rules and isn't compatible with gcc optimization level `-O2`, as seen in rizinorg/rizin#4048. A workaround is to use `-fno-strict-aliasing` but it would better if that flag isn't needed. This fix has been tested in rizinorg/rizin#4080 and it appears to have compiler support generally.

I plan to fix the translator after this, after I find out how the translator actually works.