### PR TITLE
Use `union` in `AArch64_AM_isSVEMaskOfIdenticalElements` type punning fix

### DIFF
--- a/arch/AArch64/AArch64AddressingModes.h
+++ b/arch/AArch64/AArch64AddressingModes.h
@@ -827,8 +827,12 @@ static inline uint64_t AArch64_AM_decodeAdvSIMDModImmType12(uint8_t Imm)
 #define DEFINE_isSVEMaskOfIdenticalElements(T)                                 \
 	static inline bool CONCAT(AArch64_AM_isSVEMaskOfIdenticalElements, T)(int64_t Imm)    \
 	{                                                                          \
-		T Parts[sizeof(int64_t) / sizeof(T)];                  \
-		memcpy(Parts, &Imm, sizeof(int64_t) / sizeof(T) * sizeof(T));                 \
+		union {                                   \
+			uint64_t L;                                   \
+			T A[sizeof(int64_t) / sizeof(T)];                                   \
+		} U;                                   \
+		U.L = Imm;                                   \
+		T *Parts = U.A;                                   \
 		for (int i = 0; i < (sizeof(int64_t) / sizeof(T)); i++) {   \
 			if (Parts[i] != Parts[0]) \
 				return false; \


### PR DESCRIPTION
This minor edit improves on #2237 by using `union` instead of `memcpy` thus dropping the dependence on `memcpy` and `string.h`. It also appears faster. It has been tested by the Rizin CI in rizinorg/rizin#4086.

Apparently it's possible for the translator to use this form instead of the form in #2237.