### PR TITLE
Remove comment stating support for multiple `clang-format` versions

### DIFF
--- a/suite/auto-sync/README.md
+++ b/suite/auto-sync/README.md
@@ -8,7 +8,6 @@ Unfortunately not all architectures are supported yet.
 Install clang-format
 
 ```
-# clang-format version must be at least 16
 sudo apt install clang-format-18
 ```
 


### PR DESCRIPTION
This pr removes the `# clang-format version must be at least 16` comment from the auto-sync updater README because:

1. I don't see code support for multiple `clang-format` versions.
2. It's less of a maintenance burden to support only one `clang-format` version rather than several.