### PR TITLE
Fix label assignment for LLVM generated files.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,7 @@ LLVM-core-files:
   - MC*.[ch]
 
 LLVM-generated-files:
-  - any-glob-to-any-file: '**/*.inc'
+  - arch/*/*.inc
 
 Documentation:
   - any-glob-to-any-file: '**/*.md'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,7 +8,7 @@ LLVM-generated-files:
   - arch/*/*.inc
 
 Documentation:
-  - any-glob-to-any-file: '**/*.md'
+  - '**/*.md'
 
 CS-core-files:
   - cs*.[ch]


### PR DESCRIPTION
The `LLVM-generated-files` label is incorrectly set. E.g. here: https://github.com/capstone-engine/capstone/pull/2242