### PR TITLE
Fix regressions in custom memory allocator support

### DIFF
--- a/arch/AArch64/AArch64GenAsmWriter.inc
+++ b/arch/AArch64/AArch64GenAsmWriter.inc
@@ -33293,11 +33293,11 @@ static bool printAliasInstr(MCInst *MI, uint64_t Address, SStream *OS) {
   while (AsmString[I] != ' ' && AsmString[I] != '\t' &&
          AsmString[I] != '$' && AsmString[I] != '\0')
     ++I;
-  char *substr = malloc(I+1);
+  char *substr = cs_mem_malloc(I+1);
   memcpy(substr, AsmString, I);
   substr[I] = '\0';
   SStream_concat0(OS, substr);
-  free(substr);
+  cs_mem_free(substr);
   if (AsmString[I] != '\0') {
     if (AsmString[I] == ' ' || AsmString[I] == '\t') {
       SStream_concat1(OS, ' ');

--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -1312,7 +1312,7 @@ DEFINE_printMatrix(0);
 		const char *RegName = getRegisterName(MCOperand_getReg(RegOp), AArch64_NoRegAltName); \
 \
 		unsigned buf_len = strlen(RegName) + 1; \
-		char *Base = calloc(1, buf_len); \
+		char *Base = cs_mem_calloc(1, buf_len); \
 		memcpy(Base, RegName, buf_len); \
 		char *Dot = strchr(Base, '.'); \
 		if (!Dot) { \
@@ -1324,7 +1324,7 @@ DEFINE_printMatrix(0);
 		SStream_concat(O, "%s%s", Base, (IsVertical ? "v" : "h")); \
 		SStream_concat1(O, '.'); \
 		SStream_concat0(O, Suffix); \
-		free(Base); \
+		cs_mem_free(Base); \
 	}
 DEFINE_printMatrixTileVector(0);
 DEFINE_printMatrixTileVector(1);

--- a/arch/ARM/ARMDisassembler.c
+++ b/arch/ARM/ARMDisassembler.c
@@ -955,11 +955,8 @@ DecodeStatus AddThumbPredicate(MCInst *MI)
 			assert(TiedOp >= 0 &&
 			       "Inactive register in vpred_r is not tied to an output!");
 			// Copy the operand to ensure it's not invalidated when MI grows.
-			MCOperand *Op = malloc(sizeof(MCOperand));
-			memcpy(Op, MCInst_getOperand(MI, TiedOp),
-			       sizeof(MCOperand));
-			MCInst_insert0(MI, VCCPos + 3, Op);
-			free(Op);
+			MCOperand Op = *MCInst_getOperand(MI, TiedOp);
+			MCInst_insert0(MI, VCCPos + 3, &Op);
 		}
 	} else if (VCC != ARMVCC_None) {
 		Check(&S, MCDisassembler_SoftFail);

--- a/arch/ARM/ARMGenAsmWriter.inc
+++ b/arch/ARM/ARMGenAsmWriter.inc
@@ -13298,11 +13298,11 @@ static bool printAliasInstr(MCInst *MI, uint64_t Address, SStream *OS)
 	while (AsmString[I] != ' ' && AsmString[I] != '\t' &&
 	       AsmString[I] != '$' && AsmString[I] != '\0')
 		++I;
-	char *substr = malloc(I + 1);
+	char *substr = cs_mem_malloc(I + 1);
 	memcpy(substr, AsmString, I);
 	substr[I] = '\0';
 	SStream_concat0(OS, substr);
-	free(substr);
+	cs_mem_free(substr);
 	if (AsmString[I] != '\0') {
 		if (AsmString[I] == ' ' || AsmString[I] == '\t') {
 			SStream_concat1(OS, ' ');

--- a/arch/PowerPC/PPCGenAsmWriter.inc
+++ b/arch/PowerPC/PPCGenAsmWriter.inc
@@ -15689,11 +15689,11 @@ static bool printAliasInstr(MCInst *MI, uint64_t Address, SStream *OS) {
   while (AsmString[I] != ' ' && AsmString[I] != '\t' &&
          AsmString[I] != '$' && AsmString[I] != '\0')
     ++I;
-  char *substr = malloc(I+1);
+  char *substr = cs_mem_malloc(I+1);
   memcpy(substr, AsmString, I);
   substr[I] = '\0';
   SStream_concat0(OS, substr);
-  free(substr);
+  cs_mem_free(substr);
   if (AsmString[I] != '\0') {
     if (AsmString[I] == ' ' || AsmString[I] == '\t') {
       SStream_concat1(OS, ' ');


### PR DESCRIPTION
Where new code started using malloc()/calloc()/free() directly instead of going through cs_mem_*().