### PR TITLE
Fix crash on x86 when building with MSVC

### DIFF
--- a/arch/AArch64/AArch64GenAsmWriter.inc
+++ b/arch/AArch64/AArch64GenAsmWriter.inc
@@ -16829,7 +16829,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
   assert(Bits != 0 && "Cannot print this instruction.");
 
   // Fragment 0 encoded into 7 bits for 78 unique commands.
-  switch ((Bits >> 14) & 127) {
+  switch ((uint32_t)((Bits >> 14) & 127)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // DBG_VALUE, DBG_VALUE_LIST, DBG_INSTR_REF, DBG_PHI, DBG_LABEL, BUNDLE, ...
@@ -17339,7 +17339,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 1 encoded into 7 bits for 89 unique commands.
-  switch ((Bits >> 21) & 127) {
+  switch ((uint32_t)((Bits >> 21) & 127)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // TLSDESCCALL, AUTDZA, AUTDZB, AUTIZA, AUTIZB, BLR, BLRAAZ, BLRABZ, BR, ...
@@ -17790,7 +17790,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 2 encoded into 7 bits for 89 unique commands.
-  switch ((Bits >> 28) & 127) {
+  switch ((uint32_t)((Bits >> 28) & 127)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ABSWr, ABSXr, ABSv1i64, ADCSWr, ADCSXr, ADCWr, ADCXr, ADDG, ADDPL_XXI,...
@@ -18267,7 +18267,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 3 encoded into 7 bits for 128 unique commands.
-  switch ((Bits >> 35) & 127) {
+  switch ((uint32_t)((Bits >> 35) & 127)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ABSWr, ABSXr, ABSv1i64, AESIMC_ZZ_B, AESMC_ZZ_B, AUTDA, AUTDB, AUTIA, ...
@@ -18927,7 +18927,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 4 encoded into 7 bits for 88 unique commands.
-  switch ((Bits >> 42) & 127) {
+  switch ((uint32_t)((Bits >> 42) & 127)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ABS_ZPmZ_B, ADDHNB_ZZZ_H, ADD_VG2_2ZZ_D, ADD_VG2_2ZZ_H, ADD_VG2_2ZZ_S,...
@@ -19395,7 +19395,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 5 encoded into 7 bits for 88 unique commands.
-  switch ((Bits >> 49) & 127) {
+  switch ((uint32_t)((Bits >> 49) & 127)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ADCLB_ZZZ_D, ADCLB_ZZZ_S, ADCLT_ZZZ_D, ADCLT_ZZZ_S, ADCSWr, ADCSXr, AD...
@@ -19862,7 +19862,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 6 encoded into 6 bits for 44 unique commands.
-  switch ((Bits >> 56) & 63) {
+  switch ((uint32_t)((Bits >> 56) & 63)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ADDG, ASRD_ZPmI_B, ASRD_ZPmI_D, ASRD_ZPmI_S, ASR_ZPmI_B, ASR_ZPmI_D, A...

--- a/arch/ARM/ARMGenAsmWriter.inc
+++ b/arch/ARM/ARMGenAsmWriter.inc
@@ -9634,7 +9634,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O)
 	assert(Bits != 0 && "Cannot print this instruction.");
 
 	// Fragment 0 encoded into 6 bits for 43 unique commands.
-	switch ((Bits >> 13) & 63) {
+	switch ((uint32_t)((Bits >> 13) & 63)) {
 	default:
 		assert(0 && "Invalid command number.");
 	case 0:
@@ -9860,7 +9860,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O)
 	}
 
 	// Fragment 1 encoded into 7 bits for 89 unique commands.
-	switch ((Bits >> 19) & 127) {
+	switch ((uint32_t)((Bits >> 19) & 127)) {
 	default:
 		assert(0 && "Invalid command number.");
 	case 0:
@@ -10462,7 +10462,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O)
 	}
 
 	// Fragment 2 encoded into 7 bits for 69 unique commands.
-	switch ((Bits >> 26) & 127) {
+	switch ((uint32_t)((Bits >> 26) & 127)) {
 	default:
 		assert(0 && "Invalid command number.");
 	case 0:
@@ -10877,7 +10877,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O)
 	}
 
 	// Fragment 3 encoded into 6 bits for 39 unique commands.
-	switch ((Bits >> 33) & 63) {
+	switch ((uint32_t)((Bits >> 33) & 63)) {
 	default:
 		assert(0 && "Invalid command number.");
 	case 0:
@@ -11085,7 +11085,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O)
 	}
 
 	// Fragment 4 encoded into 7 bits for 77 unique commands.
-	switch ((Bits >> 39) & 127) {
+	switch ((uint32_t)((Bits >> 39) & 127)) {
 	default:
 		assert(0 && "Invalid command number.");
 	case 0:
@@ -11527,7 +11527,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O)
 	}
 
 	// Fragment 5 encoded into 5 bits for 27 unique commands.
-	switch ((Bits >> 46) & 31) {
+	switch ((uint32_t)((Bits >> 46) & 31)) {
 	default:
 		assert(0 && "Invalid command number.");
 	case 0:
@@ -11689,7 +11689,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O)
 	}
 
 	// Fragment 6 encoded into 6 bits for 38 unique commands.
-	switch ((Bits >> 51) & 63) {
+	switch ((uint32_t)((Bits >> 51) & 63)) {
 	default:
 		assert(0 && "Invalid command number.");
 	case 0:
@@ -11897,7 +11897,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O)
 	}
 
 	// Fragment 7 encoded into 4 bits for 16 unique commands.
-	switch ((Bits >> 57) & 15) {
+	switch ((uint32_t)((Bits >> 57) & 15)) {
 	default:
 		assert(0 && "Invalid command number.");
 	case 0:

--- a/arch/Alpha/AlphaGenAsmWriter.inc
+++ b/arch/Alpha/AlphaGenAsmWriter.inc
@@ -1221,7 +1221,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
   assert(Bits != 0 && "Cannot print this instruction.");
 
   // Fragment 0 encoded into 3 bits for 5 unique commands.
-  switch ((Bits >> 11) & 7) {
+  switch ((uint32_t)((Bits >> 11) & 7)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // DBG_VALUE, DBG_VALUE_LIST, DBG_INSTR_REF, DBG_PHI, DBG_LABEL, BUNDLE, ...
@@ -1252,7 +1252,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 1 encoded into 4 bits for 13 unique commands.
-  switch ((Bits >> 14) & 15) {
+  switch ((uint32_t)((Bits >> 14) & 15)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ADJUSTSTACKDOWN, ADJUSTSTACKUP, BR, RC, RPCC, RS
@@ -1343,7 +1343,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 2 encoded into 2 bits for 4 unique commands.
-  switch ((Bits >> 18) & 3) {
+  switch ((uint32_t)((Bits >> 18) & 3)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ADDLi, ADDLr, ADDQi, ADDQr, ADDS, ADDT, ANDi, ANDr, BICi, BICr, BISi, ...
@@ -1369,7 +1369,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 3 encoded into 3 bits for 6 unique commands.
-  switch ((Bits >> 20) & 7) {
+  switch ((uint32_t)((Bits >> 20) & 7)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ADDLi, ADDLr, ADDQi, ADDQr, ADDS, ADDT, ANDi, ANDr, BICi, BICr, BISi, ...

--- a/arch/Mips/MipsGenAsmWriter.inc
+++ b/arch/Mips/MipsGenAsmWriter.inc
@@ -4703,7 +4703,7 @@ static void printInstruction(MCInst *MI, SStream *O, const MCRegisterInfo *MRI)
 
   // Fragment 0 encoded into 4 bits for 11 unique commands.
   //printf("Frag-0: %"PRIu64"\n", (Bits >> 14) & 15);
-  switch ((Bits >> 14) & 15) {
+  switch ((uint32_t)((Bits >> 14) & 15)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // DBG_VALUE, BUNDLE, LIFETIME_START, LIFETIME_END, Break16, CONSTPOOL_EN...
@@ -4765,7 +4765,7 @@ static void printInstruction(MCInst *MI, SStream *O, const MCRegisterInfo *MRI)
 
   // Fragment 1 encoded into 5 bits for 17 unique commands.
   //printf("Frag-1: %"PRIu64"\n", (Bits >> 18) & 31);
-  switch ((Bits >> 18) & 31) {
+  switch ((uint32_t)((Bits >> 18) & 31)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // ABSQ_S_PH, ABSQ_S_QB, ABSQ_S_W, ADD, ADDIUPC, ADDIUPC_MM, ADDIUR1SP_MM...
@@ -4865,7 +4865,7 @@ static void printInstruction(MCInst *MI, SStream *O, const MCRegisterInfo *MRI)
 
   // Fragment 2 encoded into 4 bits for 12 unique commands.
   //printf("Frag-2: %"PRIu64"\n", (Bits >> 23) & 15);
-  switch ((Bits >> 23) & 15) {
+  switch ((uint32_t)((Bits >> 23) & 15)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // ABSQ_S_PH, ABSQ_S_QB, ABSQ_S_W, ADD, ADDIUPC, ADDIUPC_MM, ADDIUR1SP_MM...
@@ -4938,7 +4938,7 @@ static void printInstruction(MCInst *MI, SStream *O, const MCRegisterInfo *MRI)
 
   // Fragment 3 encoded into 4 bits for 15 unique commands.
   //printf("Frag-3: %"PRIu64"\n", (Bits >> 27) & 15);
-  switch ((Bits >> 27) & 15) {
+  switch ((uint32_t)((Bits >> 27) & 15)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // ABSQ_S_PH, ABSQ_S_QB, ABSQ_S_W, ADDIUPC, ADDIUPC_MM, ADDIUR1SP_MM, ALU...
@@ -5033,7 +5033,7 @@ static void printInstruction(MCInst *MI, SStream *O, const MCRegisterInfo *MRI)
 
   // Fragment 4 encoded into 3 bits for 5 unique commands.
   //printf("Frag-4: %"PRIu64"\n", (Bits >> 31) & 7);
-  switch ((Bits >> 31) & 7) {
+  switch ((uint32_t)((Bits >> 31) & 7)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // ADD, ADDIUR2_MM, ADDQH_PH, ADDQH_R_PH, ADDQH_R_W, ADDQH_W, ADDQ_PH, AD...
@@ -5060,7 +5060,7 @@ static void printInstruction(MCInst *MI, SStream *O, const MCRegisterInfo *MRI)
 
   // Fragment 5 encoded into 2 bits for 3 unique commands.
   //printf("Frag-5: %"PRIu64"\n", (Bits >> 34) & 3);
-  switch ((Bits >> 34) & 3) {
+  switch ((uint32_t)((Bits >> 34) & 3)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // ADD, ADDIUR2_MM, ADDQH_PH, ADDQH_R_PH, ADDQH_R_W, ADDQH_W, ADDQ_PH, AD...

--- a/arch/PowerPC/PPCGenAsmWriter.inc
+++ b/arch/PowerPC/PPCGenAsmWriter.inc
@@ -10473,7 +10473,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
   assert(Bits != 0 && "Cannot print this instruction.");
 
   // Fragment 0 encoded into 5 bits for 22 unique commands.
-  switch ((Bits >> 15) & 31) {
+  switch ((uint32_t)((Bits >> 15) & 31)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // DBG_VALUE, DBG_VALUE_LIST, DBG_INSTR_REF, DBG_PHI, DBG_LABEL, BUNDLE, ...
@@ -10604,7 +10604,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 1 encoded into 5 bits for 24 unique commands.
-  switch ((Bits >> 20) & 31) {
+  switch ((uint32_t)((Bits >> 20) & 31)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // BUILD_UACC, CLRLSLDI, CLRLSLDI_rec, CLRLSLWI, CLRLSLWI_rec, CLRRDI, CL...
@@ -10758,7 +10758,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 2 encoded into 5 bits for 31 unique commands.
-  switch ((Bits >> 25) & 31) {
+  switch ((uint32_t)((Bits >> 25) & 31)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // BUILD_UACC, CLRLSLDI, CLRLSLDI_rec, CLRLSLWI, CLRLSLWI_rec, CLRRDI, CL...
@@ -10929,7 +10929,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 3 encoded into 3 bits for 6 unique commands.
-  switch ((Bits >> 30) & 7) {
+  switch ((uint32_t)((Bits >> 30) & 7)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // BUILD_UACC, DCBTCT, DCBTDS, DCBTSTCT, DCBTSTDS, ADDME, ADDME8, ADDME8O...
@@ -10967,7 +10967,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 4 encoded into 5 bits for 23 unique commands.
-  switch ((Bits >> 33) & 31) {
+  switch ((uint32_t)((Bits >> 33) & 31)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // CLRLSLDI, CLRLSLDI_rec, CLRRDI, CLRRDI_rec, EXTLDI, EXTLDI_rec, EXTRDI...
@@ -11089,7 +11089,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 5 encoded into 2 bits for 4 unique commands.
-  switch ((Bits >> 38) & 3) {
+  switch ((uint32_t)((Bits >> 38) & 3)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // CLRLSLDI, CLRLSLDI_rec, CLRLSLWI, CLRLSLWI_rec, EXTLDI, EXTLDI_rec, EX...
@@ -11113,7 +11113,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 6 encoded into 4 bits for 11 unique commands.
-  switch ((Bits >> 40) & 15) {
+  switch ((uint32_t)((Bits >> 40) & 15)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // CLRLSLDI, CLRLSLDI_rec, EXTLDI, EXTLDI_rec, EXTRDI, EXTRDI_rec, INSRDI...
@@ -11170,7 +11170,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 7 encoded into 2 bits for 4 unique commands.
-  switch ((Bits >> 44) & 3) {
+  switch ((uint32_t)((Bits >> 44) & 3)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // CLRLSLWI, CLRLSLWI_rec, EXTLWI, EXTLWI_rec, EXTRWI, EXTRWI_rec, INSLWI...
@@ -11193,7 +11193,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 8 encoded into 3 bits for 7 unique commands.
-  switch ((Bits >> 46) & 7) {
+  switch ((uint32_t)((Bits >> 46) & 7)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // PMXVBF16GER2, PMXVBF16GER2W, PMXVF16GER2, PMXVF16GER2W, PMXVF32GER, PM...
@@ -11231,7 +11231,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 9 encoded into 3 bits for 5 unique commands.
-  switch ((Bits >> 49) & 7) {
+  switch ((uint32_t)((Bits >> 49) & 7)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // PMXVBF16GER2, PMXVBF16GER2W, PMXVF16GER2, PMXVF16GER2W, PMXVI16GER2, P...
@@ -11260,7 +11260,7 @@ static void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 10 encoded into 2 bits for 3 unique commands.
-  switch ((Bits >> 52) & 3) {
+  switch ((uint32_t)((Bits >> 52) & 3)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // PMXVBF16GER2, PMXVBF16GER2W, PMXVF16GER2, PMXVF16GER2W, PMXVI16GER2, P...

--- a/arch/RISCV/RISCVGenAsmWriter.inc
+++ b/arch/RISCV/RISCVGenAsmWriter.inc
@@ -1197,7 +1197,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
 
   // Fragment 0 encoded into 2 bits for 4 unique commands.
-  switch ((Bits >> 12) & 3) {
+  switch ((uint32_t)((Bits >> 12) & 3)) {
   default: CS_ASSERT(0 && "Invalid command number.");
   case 0:
     // DBG_VALUE, DBG_LABEL, BUNDLE, LIFETIME_START, LIFETIME_END, FENTRY_CAL...
@@ -1225,7 +1225,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
 
   // Fragment 1 encoded into 2 bits for 3 unique commands.
-  switch ((Bits >> 14) & 3) {
+  switch ((uint32_t)((Bits >> 14) & 3)) {
   default: CS_ASSERT(0 && "Invalid command number.");
   case 0:
     // PseudoCALL, PseudoTAIL, C_J, C_JAL, C_JALR, C_JR
@@ -1246,7 +1246,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
 
   // Fragment 2 encoded into 2 bits for 3 unique commands.
-  switch ((Bits >> 16) & 3) {
+  switch ((uint32_t)((Bits >> 16) & 3)) {
   default: CS_ASSERT(0 && "Invalid command number.");
   case 0:
     // PseudoLA, PseudoLI, PseudoLLA, ADD, ADDI, ADDIW, ADDW, AND, ANDI, AUIP...
@@ -1267,7 +1267,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
 
   // Fragment 3 encoded into 2 bits for 4 unique commands.
-  switch ((Bits >> 18) & 3) {
+  switch ((uint32_t)((Bits >> 18) & 3)) {
   default: CS_ASSERT(0 && "Invalid command number.");
   case 0:
     // PseudoLA, PseudoLI, PseudoLLA, AUIPC, C_BEQZ, C_BNEZ, C_LI, C_LUI, C_M...

--- a/arch/Sparc/SparcGenAsmWriter.inc
+++ b/arch/Sparc/SparcGenAsmWriter.inc
@@ -836,7 +836,7 @@ static void printInstruction(MCInst *MI, SStream *O, const MCRegisterInfo *MRI)
 
   // Fragment 0 encoded into 4 bits for 12 unique commands.
   // printf("Frag-0: %u\n", (Bits >> 12) & 15);
-  switch ((Bits >> 12) & 15) {
+  switch ((uint32_t)((Bits >> 12) & 15)) {
   default:   // unreachable.
   case 0:
     // DBG_VALUE, BUNDLE, LIFETIME_START, LIFETIME_END, FLUSHW, NOP, SELECT_C...
@@ -907,7 +907,7 @@ static void printInstruction(MCInst *MI, SStream *O, const MCRegisterInfo *MRI)
 
   // Fragment 1 encoded into 4 bits for 16 unique commands.
   // printf("Frag-1: %u\n", (Bits >> 16) & 15);
-  switch ((Bits >> 16) & 15) {
+  switch ((uint32_t)((Bits >> 16) & 15)) {
   default:   // unreachable.
   case 0:
     // ADDCCri, ADDCCrr, ADDCri, ADDCrr, ADDEri, ADDErr, ADDXC, ADDXCCC, ADDX...
@@ -1020,7 +1020,7 @@ static void printInstruction(MCInst *MI, SStream *O, const MCRegisterInfo *MRI)
 
   // Fragment 2 encoded into 2 bits for 3 unique commands.
   // printf("Frag-2: %u\n", (Bits >> 20) & 3);
-  switch ((Bits >> 20) & 3) {
+  switch ((uint32_t)((Bits >> 20) & 3)) {
   default:   // unreachable.
   case 0:
     // ADDCCri, ADDCCrr, ADDCri, ADDCrr, ADDEri, ADDErr, ADDXC, ADDXCCC, ADDX...
@@ -1041,7 +1041,7 @@ static void printInstruction(MCInst *MI, SStream *O, const MCRegisterInfo *MRI)
 
   // Fragment 3 encoded into 2 bits for 4 unique commands.
   // printf("Frag-3: %u\n", (Bits >> 22) & 3);
-  switch ((Bits >> 22) & 3) {
+  switch ((uint32_t)((Bits >> 22) & 3)) {
   default:   // unreachable.
   case 0:
     // ADDCCri, ADDCCrr, ADDCri, ADDCrr, ADDEri, ADDErr, ADDXC, ADDXCCC, ADDX...
@@ -1068,7 +1068,7 @@ static void printInstruction(MCInst *MI, SStream *O, const MCRegisterInfo *MRI)
 
   // Fragment 4 encoded into 2 bits for 3 unique commands.
   // printf("Frag-4: %u\n", (Bits >> 24) & 3);
-  switch ((Bits >> 24) & 3) {
+  switch ((uint32_t)((Bits >> 24) & 3)) {
   default:   // unreachable.
   case 0:
     // FLCMPD, FLCMPS, V9FCMPD, V9FCMPED, V9FCMPEQ, V9FCMPES, V9FCMPQ, V9FCMP...

--- a/arch/SystemZ/SystemZGenAsmWriter.inc
+++ b/arch/SystemZ/SystemZGenAsmWriter.inc
@@ -10646,7 +10646,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 0 encoded into 5 bits for 18 unique commands.
   // printf("Fragment 0 = %" PRIu64 "\n", (Bits >> 14) & 31);
-  switch ((Bits >> 14) & 31) {
+  switch ((uint32_t)((Bits >> 14) & 31)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // DBG_VALUE, DBG_LABEL, BUNDLE, LIFETIME_START, LIFETIME_END, FENTRY_CAL...
@@ -10754,7 +10754,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 1 encoded into 5 bits for 17 unique commands.
   // printf("Fragment 1 = %" PRIu64 "\n", (Bits >> 19) & 31);
-  switch ((Bits >> 19) & 31) {
+  switch ((uint32_t)((Bits >> 19) & 31)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // A, AD, ADB, ADBR, ADR, ADTR, ADTRA, AE, AEB, AEBR, AER, AFI, AG, AGF, ...
@@ -10848,7 +10848,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 2 encoded into 6 bits for 34 unique commands.
   // printf("Fragment 2 = %" PRIu64 "\n", (Bits >> 24) & 63);
-  switch ((Bits >> 24) & 63) {
+  switch ((uint32_t)((Bits >> 24) & 63)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // A, AD, ADB, AE, AEB, AG, AGF, AGH, AH, AHY, AL, ALC, ALCG, ALG, ALGF, ...
@@ -11015,7 +11015,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 3 encoded into 5 bits for 20 unique commands.
   // printf("Fragment 3 = %" PRIu64 "\n", (Bits >> 30) & 31);
-  switch ((Bits >> 30) & 31) {
+  switch ((uint32_t)((Bits >> 30) & 31)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // A, AD, ADB, ADBR, ADR, AE, AEB, AEBR, AER, AG, AGF, AGFR, AGH, AGHI, A...
@@ -11121,7 +11121,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 4 encoded into 6 bits for 33 unique commands.
   // printf("Fragment 4 = %" PRIu64 "\n", (Bits >> 35) & 63);
-  switch ((Bits >> 35) & 63) {
+  switch ((uint32_t)((Bits >> 35) & 63)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // ADTR, ADTRA, AGRK, AHHHR, AHHLR, ALGRK, ALHHHR, ALHHLR, ALRK, ARK, AXT...
@@ -11283,7 +11283,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 5 encoded into 4 bits for 9 unique commands.
   // printf("Fragment 5 = %" PRIu64 "\n", (Bits >> 41) & 15);
-  switch ((Bits >> 41) & 15) {
+  switch ((uint32_t)((Bits >> 41) & 15)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // ADTR, AGRK, AHHHR, AHHLR, ALGRK, ALHHHR, ALHHLR, ALRK, ARK, AXTR, BXH,...
@@ -11336,7 +11336,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 6 encoded into 4 bits for 11 unique commands.
   // printf("Fragment 6 = %" PRIu64 "\n", (Bits >> 45) & 15);
-  switch ((Bits >> 45) & 15) {
+  switch ((uint32_t)((Bits >> 45) & 15)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // ADTRA, AXTRA, CRDTE, DDTRA, DXTRA, IDTE, IPTE, MDTRA, MXTRA, SDTRA, SX...
@@ -11405,7 +11405,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 8 encoded into 2 bits for 3 unique commands.
   // printf("Fragment 8 = %" PRIu64 "\n", (Bits >> 50) & 3);
-  switch ((Bits >> 50) & 3) {
+  switch ((uint32_t)((Bits >> 50) & 3)) {
   default: // llvm_unreachable("Invalid command number.");
   case 0:
     // RISBG, RISBG32, RISBGN, RISBHG, RISBLG, RNSBG, ROSBG, RXSBG

--- a/arch/TMS320C64x/TMS320C64xGenAsmWriter.inc
+++ b/arch/TMS320C64x/TMS320C64xGenAsmWriter.inc
@@ -438,7 +438,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI) {
 
 
   // Fragment 0 encoded into 3 bits for 8 unique commands.
-  switch ((Bits >> 10) & 7) {
+  switch ((uint32_t)((Bits >> 10) & 7)) {
   default:
   case 0:
     // DBG_VALUE, BUNDLE, LIFETIME_START, LIFETIME_END, B_s7_irp, B_s7_nrp
@@ -486,7 +486,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI) {
 
 
   // Fragment 1 encoded into 3 bits for 7 unique commands.
-  switch ((Bits >> 13) & 7) {
+  switch ((uint32_t)((Bits >> 13) & 7)) {
   default:
   case 0:
     // ABS2_l2_rr, ABS_l1_rr, ADDKPC_s3_iir, ADDK_s2_ir, BDEC_s8_ir, BITC4_m2...
@@ -524,7 +524,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI) {
 
 
   // Fragment 2 encoded into 3 bits for 8 unique commands.
-  switch ((Bits >> 16) & 7) {
+  switch ((uint32_t)((Bits >> 16) & 7)) {
   default:
   case 0:
     // ABS2_l2_rr, ABS_l1_rr, ADDK_s2_ir, BDEC_s8_ir, BITC4_m2_rr, BPOS_s8_ir...

--- a/arch/TriCore/TriCoreGenAsmWriter.inc
+++ b/arch/TriCore/TriCoreGenAsmWriter.inc
@@ -3018,7 +3018,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
   assert(Bits != 0 && "Cannot print this instruction.");
 
   // Fragment 0 encoded into 4 bits for 13 unique commands.
-  switch ((Bits >> 12) & 15) {
+  switch ((uint32_t)((Bits >> 12) & 15)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // DBG_VALUE, DBG_VALUE_LIST, DBG_INSTR_REF, DBG_PHI, DBG_LABEL, BUNDLE, ...
@@ -3092,7 +3092,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 1 encoded into 4 bits for 16 unique commands.
-  switch ((Bits >> 16) & 15) {
+  switch ((uint32_t)((Bits >> 16) & 15)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ABSDIFS_B_rr_v110, ABSDIFS_H_rr, ABSDIFS_rc, ABSDIFS_rr, ABSDIF_B_rr, ...
@@ -3188,7 +3188,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 2 encoded into 5 bits for 19 unique commands.
-  switch ((Bits >> 20) & 31) {
+  switch ((uint32_t)((Bits >> 20) & 31)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ABSDIFS_B_rr_v110, ABSDIFS_H_rr, ABSDIFS_rc, ABSDIFS_rr, ABSDIF_B_rr, ...
@@ -3289,7 +3289,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 3 encoded into 4 bits for 12 unique commands.
-  switch ((Bits >> 25) & 15) {
+  switch ((uint32_t)((Bits >> 25) & 15)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ABSDIFS_B_rr_v110, ABSDIFS_H_rr, ABSDIFS_rc, ABSDIFS_rr, ABSDIF_B_rr, ...
@@ -3358,7 +3358,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 4 encoded into 4 bits for 14 unique commands.
-  switch ((Bits >> 29) & 15) {
+  switch ((uint32_t)((Bits >> 29) & 15)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ABSDIFS_B_rr_v110, ABSDIFS_H_rr, ABSDIFS_rc, ABSDIFS_rr, ABSDIF_B_rr, ...
@@ -3440,7 +3440,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 5 encoded into 4 bits for 10 unique commands.
-  switch ((Bits >> 33) & 15) {
+  switch ((uint32_t)((Bits >> 33) & 15)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ABSDIFS_B_rr_v110, ABSDIFS_H_rr, ABSDIFS_rc, ABSDIFS_rr, ABSDIF_B_rr, ...
@@ -3499,7 +3499,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 6 encoded into 4 bits for 12 unique commands.
-  switch ((Bits >> 37) & 15) {
+  switch ((uint32_t)((Bits >> 37) & 15)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // ADDSC_A_rr, ADDSC_A_rr_v110, DIFSC_A_rr_v110, MULR_H_rr_v110, MULR_Q_r...
@@ -3568,7 +3568,7 @@ void printInstruction(MCInst *MI, uint64_t Address, SStream *O) {
 
 
   // Fragment 7 encoded into 2 bits for 4 unique commands.
-  switch ((Bits >> 41) & 3) {
+  switch ((uint32_t)((Bits >> 41) & 3)) {
   default: assert(0 && "Invalid command number.");
   case 0:
     // DEXTR_rrpw, DEXTR_rrrr, INSERT_rcrr, INSERT_rrrr

--- a/arch/X86/X86GenAsmWriter.inc
+++ b/arch/X86/X86GenAsmWriter.inc
@@ -47585,7 +47585,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 0 encoded into 7 bits for 103 unique commands.
   // printf("Fragment 0: %"PRIu64"\n", ((Bits >> 14) & 127));
-  switch ((Bits >> 14) & 127) {
+  switch ((uint32_t)((Bits >> 14) & 127)) {
   default: // unreachable
   case 0:
     // DBG_VALUE, DBG_LABEL, BUNDLE, LIFETIME_START, LIFETIME_END, FENTRY_CAL...
@@ -48135,7 +48135,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 1 encoded into 7 bits for 99 unique commands.
   // printf("Fragment 1: %"PRIu64"\n", ((Bits >> 21) & 127));
-  switch ((Bits >> 21) & 127) {
+  switch ((uint32_t)((Bits >> 21) & 127)) {
   default: // unreachable
   case 0:
     // AAD8i8, AAM8i8, ADD_FPrST0, ADD_FST0r, ADD_FrST0, BSWAP16r_BAD, BSWAP3...
@@ -48638,7 +48638,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 2 encoded into 6 bits for 54 unique commands.
   // printf("Fragment 2: %"PRIu64"\n", ((Bits >> 28) & 63));
-  switch ((Bits >> 28) & 63) {
+  switch ((uint32_t)((Bits >> 28) & 63)) {
   default: // unreachable
   case 0:
     // ADC16mi, ADC16mi8, ADC16mr, ADC16ri, ADC16ri8, ADC16rm, ADC16rr, ADC16...
@@ -48971,7 +48971,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 3 encoded into 4 bits for 15 unique commands.
   // printf("Fragment 3: %"PRIu64"\n", ((Bits >> 34) & 15));
-  switch ((Bits >> 34) & 15) {
+  switch ((uint32_t)((Bits >> 34) & 15)) {
   default: // unreachable
   case 0:
     // ADC32rm, ADC64rm, ADCX32rm, ADCX64rm, ADD32rm, ADD64rm, ADDSDrm, ADDSD...
@@ -49049,7 +49049,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 4 encoded into 4 bits for 10 unique commands.
   // printf("Fragment 4: %"PRIu64"\n", ((Bits >> 38) & 15));
-  switch ((Bits >> 38) & 15) {
+  switch ((uint32_t)((Bits >> 38) & 15)) {
   default: // unreachable
   case 0:
     // AESKEYGENASSIST128rm, ANDN32rr, ANDN64rr, BEXTR32rm, BEXTR32rr, BEXTR6...
@@ -49104,7 +49104,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 5 encoded into 3 bits for 6 unique commands.
   // printf("Fragment 5: %"PRIu64"\n", ((Bits >> 42) & 7));
-  switch ((Bits >> 42) & 7) {
+  switch ((uint32_t)((Bits >> 42) & 7)) {
   default: // unreachable
   case 0:
     // VADDPDZ128rmbk, VADDPDZ256rmbk, VADDPDZrmbk, VADDPSZ128rmbk, VADDPSZ25...
@@ -49139,7 +49139,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 6 encoded into 3 bits for 5 unique commands.
   // printf("Fragment 6: %"PRIu64"\n", ((Bits >> 45) & 7));
-  switch ((Bits >> 45) & 7) {
+  switch ((uint32_t)((Bits >> 45) & 7)) {
   default: // unreachable
   case 0:
     // VADDPDZ128rmbk, VADDPDZ256rmbk, VADDPDZrmbk, VADDPSZ128rmbk, VADDPSZ25...

--- a/arch/X86/X86GenAsmWriter1.inc
+++ b/arch/X86/X86GenAsmWriter1.inc
@@ -31924,7 +31924,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 0 encoded into 6 bits for 52 unique commands.
   // printf("Fragment 0: %"PRIu64"\n", ((Bits >> 14) & 63));
-  switch ((Bits >> 14) & 63) {
+  switch ((uint32_t)((Bits >> 14) & 63)) {
   default: // unreachable
   case 0:
     // DBG_VALUE, DBG_LABEL, BUNDLE, LIFETIME_START, LIFETIME_END, FENTRY_CAL...
@@ -32199,7 +32199,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 1 encoded into 5 bits for 25 unique commands.
   // printf("Fragment 1: %"PRIu64"\n", ((Bits >> 20) & 31));
-  switch ((Bits >> 20) & 31) {
+  switch ((uint32_t)((Bits >> 20) & 31)) {
   default: // unreachable
   case 0:
     // AAD8i8, AAM8i8, ADC16i16, ADC32i32, ADC64i32, ADC8i8, ADD16i16, ADD32i...
@@ -32336,7 +32336,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 2 encoded into 6 bits for 38 unique commands.
   // printf("Fragment 2: %"PRIu64"\n", ((Bits >> 25) & 63));
-  switch ((Bits >> 25) & 63) {
+  switch ((uint32_t)((Bits >> 25) & 63)) {
   default: // unreachable
   case 0:
     // ADC16mi, ADC16mi8, ADC16mr, ADC32mi, ADC32mi8, ADC32mr, ADC64mi32, ADC...
@@ -32518,7 +32518,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 3 encoded into 6 bits for 36 unique commands.
   // printf("Fragment 3: %"PRIu64"\n", ((Bits >> 31) & 63));
-  switch ((Bits >> 31) & 63) {
+  switch ((uint32_t)((Bits >> 31) & 63)) {
   default: // unreachable
   case 0:
     // ADC16mi, ADC16mi8, ADC16mr, ADC16ri, ADC16ri8, ADC16rm, ADC16rr, ADC16...
@@ -32709,7 +32709,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 4 encoded into 6 bits for 39 unique commands.
   // printf("Fragment 4: %"PRIu64"\n", ((Bits >> 37) & 63));
-  switch ((Bits >> 37) & 63) {
+  switch ((uint32_t)((Bits >> 37) & 63)) {
   default: // unreachable
   case 0:
     // AESKEYGENASSIST128rm, EXTRACTPSmr, MMX_PSHUFWmi, PCMPESTRIrm, PCMPESTR...
@@ -32887,7 +32887,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 5 encoded into 4 bits for 12 unique commands.
   // printf("Fragment 5: %"PRIu64"\n", ((Bits >> 43) & 15));
-  switch ((Bits >> 43) & 15) {
+  switch ((uint32_t)((Bits >> 43) & 15)) {
   default: // unreachable
   case 0:
     // ANDN32rm, ANDN32rr, ANDN64rm, ANDN64rr, BEXTR32rm, BEXTR32rr, BEXTR64r...
@@ -32953,7 +32953,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 6 encoded into 5 bits for 31 unique commands.
   // printf("Fragment 6: %"PRIu64"\n", ((Bits >> 47) & 31));
-  switch ((Bits >> 47) & 31) {
+  switch ((uint32_t)((Bits >> 47) & 31)) {
   default: // unreachable
   case 0:
     // INSERTQI, VCVTPS2PHZ128rrk, VCVTPS2PHZ256rrk, VCVTPS2PHZrrbk, VCVTPS2P...
@@ -33090,7 +33090,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 7 encoded into 4 bits for 12 unique commands.
   // printf("Fragment 7: %"PRIu64"\n", ((Bits >> 52) & 15));
-  switch ((Bits >> 52) & 15) {
+  switch ((uint32_t)((Bits >> 52) & 15)) {
   default: // unreachable
   case 0:
     // V4FMADDPSrmk, V4FMADDPSrmkz, V4FMADDSSrmk, V4FMADDSSrmkz, V4FNMADDPSrm...
@@ -33156,7 +33156,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 8 encoded into 3 bits for 6 unique commands.
   // printf("Fragment 8: %"PRIu64"\n", ((Bits >> 56) & 7));
-  switch ((Bits >> 56) & 7) {
+  switch ((uint32_t)((Bits >> 56) & 7)) {
   default: // unreachable
   case 0:
     // VADDPDZrrbk, VADDPSZrrbk, VADDSDZrrb_Intk, VADDSSZrrb_Intk, VCVTSD2SSZ...

--- a/arch/X86/X86GenAsmWriter1_reduce.inc
+++ b/arch/X86/X86GenAsmWriter1_reduce.inc
@@ -2115,7 +2115,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 0 encoded into 6 bits for 33 unique commands.
   // printf("Fragment 0: %"PRIu64"\n", ((Bits >> 12) & 63));
-  switch ((Bits >> 12) & 63) {
+  switch ((uint32_t)((Bits >> 12) & 63)) {
   default: // unreachable
   case 0:
     // DBG_VALUE, DBG_LABEL, BUNDLE, LIFETIME_START, LIFETIME_END, FENTRY_CAL...
@@ -2291,7 +2291,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 1 encoded into 4 bits for 10 unique commands.
   // printf("Fragment 1: %"PRIu64"\n", ((Bits >> 18) & 15));
-  switch ((Bits >> 18) & 15) {
+  switch ((uint32_t)((Bits >> 18) & 15)) {
   default: // unreachable
   case 0:
     // AAD8i8, AAM8i8, ADC16i16, ADC32i32, ADC64i32, ADC8i8, ADD16i16, ADD32i...
@@ -2354,7 +2354,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 2 encoded into 5 bits for 22 unique commands.
   // printf("Fragment 2: %"PRIu64"\n", ((Bits >> 22) & 31));
-  switch ((Bits >> 22) & 31) {
+  switch ((uint32_t)((Bits >> 22) & 31)) {
   default: // unreachable
   case 0:
     // ADC16mi, ADC16mi8, ADC16mr, ADC32mi, ADC32mi8, ADC32mr, ADC64mi32, ADC...
@@ -2465,7 +2465,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 3 encoded into 2 bits for 3 unique commands.
   // printf("Fragment 3: %"PRIu64"\n", ((Bits >> 27) & 3));
-  switch ((Bits >> 27) & 3) {
+  switch ((uint32_t)((Bits >> 27) & 3)) {
   default: // unreachable
   case 0:
     // ADC16mi, ADC16mi8, ADC16mr, ADC16ri, ADC16ri8, ADC16rr, ADC16rr_REV, A...
@@ -2486,7 +2486,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 4 encoded into 3 bits for 7 unique commands.
   // printf("Fragment 4: %"PRIu64"\n", ((Bits >> 29) & 7));
-  switch ((Bits >> 29) & 7) {
+  switch ((uint32_t)((Bits >> 29) & 7)) {
   default: // unreachable
   case 0:
     // ANDN32rm, MULX32rm, PDEP32rm, PEXT32rm

--- a/arch/X86/X86GenAsmWriter_reduce.inc
+++ b/arch/X86/X86GenAsmWriter_reduce.inc
@@ -2388,7 +2388,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 0 encoded into 6 bits for 47 unique commands.
   // printf("Fragment 0: %"PRIu64"\n", ((Bits >> 13) & 63));
-  switch ((Bits >> 13) & 63) {
+  switch ((uint32_t)((Bits >> 13) & 63)) {
   default: // unreachable
   case 0:
     // DBG_VALUE, DBG_LABEL, BUNDLE, LIFETIME_START, LIFETIME_END, FENTRY_CAL...
@@ -2649,7 +2649,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 1 encoded into 5 bits for 19 unique commands.
   // printf("Fragment 1: %"PRIu64"\n", ((Bits >> 19) & 31));
-  switch ((Bits >> 19) & 31) {
+  switch ((uint32_t)((Bits >> 19) & 31)) {
   default: // unreachable
   case 0:
     // AAD8i8, AAM8i8, BSWAP16r_BAD, BSWAP32r, BSWAP64r, CALL16r, CALL16r_NT,...
@@ -2760,7 +2760,7 @@ static void printInstruction(MCInst *MI, SStream *O)
 
   // Fragment 2 encoded into 5 bits for 17 unique commands.
   // printf("Fragment 2: %"PRIu64"\n", ((Bits >> 24) & 31));
-  switch ((Bits >> 24) & 31) {
+  switch ((uint32_t)((Bits >> 24) & 31)) {
   default: // unreachable
   case 0:
     // ADC16ri, ADC16ri8, ADC16rm, ADC16rr, ADC32ri, ADC32ri8, ADC32rm, ADC32...

--- a/arch/XCore/XCoreGenAsmWriter.inc
+++ b/arch/XCore/XCoreGenAsmWriter.inc
@@ -431,7 +431,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
   // Fragment 0 encoded into 2 bits for 4 unique commands.
   //printf(">>%s\n", AsmStrs+(Bits & 2047)-1);
   //printf("Frag-0: %u\n", (Bits >> 11) & 3);
-  switch ((Bits >> 11) & 3) {
+  switch ((uint32_t)((Bits >> 11) & 3)) {
   default:   // unreachable.
   case 0:
     // DBG_VALUE, BUNDLE, LIFETIME_START, LIFETIME_END, CLRE_0R, DCALL_0R, DE...
@@ -456,7 +456,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 1 encoded into 5 bits for 17 unique commands.
   //printf("Frag-1: %u\n", (Bits >> 13) & 31);
-  switch ((Bits >> 13) & 31) {
+  switch ((uint32_t)((Bits >> 13) & 31)) {
   default:   // unreachable.
   case 0:
     // ADD_2rus, ADD_3r, ANDNOT_2r, AND_3r, ASHR_l2rus, ASHR_l3r, BITREV_l2r,...
@@ -577,7 +577,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 2 encoded into 3 bits for 5 unique commands.
   //printf("Frag-2: %u\n", (Bits >> 18) & 7);
-  switch ((Bits >> 18) & 7) {
+  switch ((uint32_t)((Bits >> 18) & 7)) {
   default:   // unreachable.
   case 0:
     // ADD_2rus, ADD_3r, AND_3r, ASHR_l2rus, ASHR_l3r, BITREV_l2r, BRBF_lru6,...
@@ -607,7 +607,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 3 encoded into 3 bits for 8 unique commands.
   //printf("Frag-3: %u\n", (Bits >> 21) & 7);
-  switch ((Bits >> 21) & 7) {
+  switch ((uint32_t)((Bits >> 21) & 7)) {
   default:   // unreachable.
   case 0:
     // ADD_2rus, ADD_3r, AND_3r, ASHR_l2rus, ASHR_l3r, CRC_l3r, DIVS_l3r, DIV...
@@ -664,7 +664,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 4 encoded into 3 bits for 5 unique commands.
   //printf("Frag-4: %u\n", (Bits >> 24) & 7);
-  switch ((Bits >> 24) & 7) {
+  switch ((uint32_t)((Bits >> 24) & 7)) {
   default:   // unreachable.
   case 0:
     // ADD_2rus, ADD_3r, AND_3r, ASHR_l2rus, ASHR_l3r, DIVS_l3r, DIVU_l3r, EQ...
@@ -697,7 +697,7 @@ static void printInstruction(MCInst *MI, SStream *O, MCRegisterInfo *MRI)
 
   // Fragment 5 encoded into 2 bits for 4 unique commands.
   //printf("Frag-5: %u\n", (Bits >> 27) & 3);
-  switch ((Bits >> 27) & 3) {
+  switch ((uint32_t)((Bits >> 27) & 3)) {
   default:   // unreachable.
   case 0:
     // ADD_2rus, ADD_3r, AND_3r, ASHR_l2rus, ASHR_l3r, DIVS_l3r, DIVU_l3r, EQ...


### PR DESCRIPTION
There is an MSVC compiler bug (still as of 19.36.32535): given `switch (x)`, where `x` is 64 bits wide, the compiler generates code that computes an incorrect jump table index. E.g. if `x` is zero, it ends up reading the table entry at index -1.