### PR TITLE
auto-sync: Fix some tree-sitter queries

### DIFF
--- a/suite/auto-sync/Updater/CppTranslator/Patches/FeatureBits.py
+++ b/suite/auto-sync/Updater/CppTranslator/Patches/FeatureBits.py
@@ -18,7 +18,7 @@ class FeatureBits(Patch):
         return (
             "(subscript_expression "
             '   ((identifier) @id (#match? @id "[fF]eatureBits"))'
-            "   ((qualified_identifier) @qid)"
+            "   (subscript_argument_list ((qualified_identifier) @qid))"
             ") @feature_bits"
         )
 

--- a/suite/auto-sync/Updater/CppTranslator/Patches/NamespaceArch.py
+++ b/suite/auto-sync/Updater/CppTranslator/Patches/NamespaceArch.py
@@ -16,7 +16,7 @@ class NamespaceArch(Patch):
         super().__init__(priority)
 
     def get_search_pattern(self) -> str:
-        return "(namespace_definition" "   (identifier)" "   (declaration_list) @decl_list" ") @namespace_def"
+        return "(namespace_definition" "   (namespace_identifier)" "   (declaration_list) @decl_list" ") @namespace_def"
 
     def get_main_capture_name(self) -> str:
         return "namespace_def"

--- a/suite/auto-sync/Updater/CppTranslator/Patches/NamespaceLLVM.py
+++ b/suite/auto-sync/Updater/CppTranslator/Patches/NamespaceLLVM.py
@@ -18,7 +18,7 @@ class NamespaceLLVM(Patch):
     def get_search_pattern(self) -> str:
         return (
             "(namespace_definition"
-            '   (identifier) @id (#eq? @id "llvm")'
+            '   (namespace_identifier) @id (#eq? @id "llvm")'
             "   (declaration_list) @decl_list"
             ") @namespace_def"
         )

--- a/suite/auto-sync/Updater/CppTranslator/Patches/STIFeatureBits.py
+++ b/suite/auto-sync/Updater/CppTranslator/Patches/STIFeatureBits.py
@@ -25,7 +25,7 @@ class STIFeatureBits(Patch):
             "       )"
             "       (argument_list)"
             "   )"
-            "   ((qualified_identifier) @flag)"
+            "   (subscript_argument_list ((qualified_identifier) @flag))"
             ") @sti_feature_bits"
         )
 


### PR DESCRIPTION
This pr fixes some auto-sync patch tree-sitter queries so that when the auto-sync `ASUpdater.py` is invoked, tree-sitter doesn't abort with a tree-sitter `SyntaxError` (which looks almost like a Python `SyntaxError` except that it has a can-be-unhelpful offset).