### PR TITLE
Makefile: Improve Apple detection

### DIFF
--- a/HACK.TXT
+++ b/HACK.TXT
@@ -38,7 +38,7 @@ Capstone source is organized as followings.
 └── xcode           <- Xcode support (for MacOSX compile)
 
 
-Follow instructions in COMPILE.TXT for how to compile and run test code.
+Follow the instructions in COMPILE.TXT for how to compile and run test code.
 
 Note: if you find some strange bugs, it is recommended to firstly clean
 the code and try to recompile/reinstall again. This can be done with:

--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ endif
 API_MAJOR=$(shell echo `grep -e CS_API_MAJOR include/capstone/capstone.h | grep -v = | awk '{print $$3}'` | awk '{print $$1}')
 VERSION_EXT =
 
-IS_APPLE := $(shell $(CC) -dM -E - < /dev/null 2> /dev/null | grep __apple_build_version__ | wc -l | tr -d " ")
+IS_APPLE := $(shell $(CC) -dM -E - < /dev/null 2> /dev/null | grep __APPLE__ | wc -l | tr -d " ")
 ifeq ($(IS_APPLE),1)
 # on MacOS, do not build in Universal format by default
 MACOS_UNIVERSAL ?= no


### PR DESCRIPTION
`__APPLE__` is always defined & set to 1 on Darwin.
`__apple_build_version__` not available on older releases.
This change allows Capstone to build on OS X 10.4.