### PR TITLE
[CMake] Architecture definition fix

### DIFF
--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -100,6 +100,35 @@ jobs:
         cp libcapstone.* ../tests/
         cp test_* ../tests/
 
+    - name: cstool - reaches disassembler engine
+      run: |
+        cstool -d x64 0x4 | grep "ERROR: invalid assembly code"
+        cstool -d arm 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d aarch64 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d alpha 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d mips64 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d ppc64 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d sparc 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d systemz 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d xcore 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d m68k 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d tms320c64x 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d m6811 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d cpu12 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d hd6309 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d hcs08 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d evm 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d 6502 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d 65c02 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d w65c02 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d 65816 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d wasm 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d bpf 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d ebpf 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d riscv64 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d sh 0x1 | grep "ERROR: invalid assembly code"
+        cstool -d tc162 0x1 | grep "ERROR: invalid assembly code"
+
     - name: cstest
       run: |
         cd suite/cstest && ./build_cstest.sh

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -102,32 +102,7 @@ jobs:
 
     - name: cstool - reaches disassembler engine
       run: |
-        cstool -d x64 0x4 | grep "ERROR: invalid assembly code"
-        cstool -d arm 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d aarch64 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d alpha 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d mips64 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d ppc64 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d sparc 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d systemz 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d xcore 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d m68k 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d tms320c64x 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d m6811 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d cpu12 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d hd6309 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d hcs08 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d evm 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d 6502 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d 65c02 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d w65c02 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d 65816 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d wasm 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d bpf 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d ebpf 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d riscv64 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d sh 0x1 | grep "ERROR: invalid assembly code"
-        cstool -d tc162 0x1 | grep "ERROR: invalid assembly code"
+        sh suite/run_invalid_cstool.sh
 
     - name: cstest
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,15 +76,6 @@ foreach(i RANGE ${count})
     option("CAPSTONE_${supported_architecture}_SUPPORT" "${supported_architecture_label} support" ${CAPSTONE_ARCHITECTURE_DEFAULT})
 endforeach()
 
-# propagate architecture support variables to preprocessor
-foreach(supported_architecture ${SUPPORTED_ARCHITECTURES})
-    set(option_name "CAPSTONE_${supported_architecture}_SUPPORT")
-    if(${option_name})
-        message("Enabling ${option_name}")
-        add_definitions("-D${option_name}")
-    endif()
-endforeach()
-
 option(CAPSTONE_X86_REDUCE "x86 with reduce instruction sets to minimize library" OFF)
 option(CAPSTONE_X86_ATT_DISABLE "Disable x86 AT&T syntax" OFF)
 option(CAPSTONE_OSXKERNEL_SUPPORT "Support to embed Capstone into OS X Kernel extensions" OFF)
@@ -99,6 +90,15 @@ endif()
 
 if(CAPSTONE_USE_ARCH_REGISTRATION)
     add_definitions(-DCAPSTONE_USE_ARCH_REGISTRATION)
+elseif(CAPSTONE_ARCHITECTURE_DEFAULT)
+    # propagate architecture support variables to preprocessor
+    foreach(supported_architecture ${SUPPORTED_ARCHITECTURES})
+        set(option_name "CAPSTONE_${supported_architecture}_SUPPORT")
+        if(${option_name})
+            message("Enabling ${option_name}")
+            add_definitions("-D${option_name}")
+        endif()
+    endforeach()
 endif()
 
 if(CAPSTONE_X86_REDUCE)

--- a/suite/run_invalid_cstool.sh
+++ b/suite/run_invalid_cstool.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+cstool -d x64 0x4 | grep "ERROR: invalid assembly code" &&
+cstool -d arm 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d aarch64 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d alpha 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d mips64 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d ppc64 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d sparc 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d systemz 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d xcore 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d m68k 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d tms320c64x 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d m6811 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d cpu12 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d hd6309 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d hcs08 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d evm 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d 6502 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d 65c02 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d w65c02 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d 65816 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d wasm 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d bpf 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d ebpf 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d riscv64 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d sh 0x1 | grep "ERROR: invalid assembly code" &&
+cstool -d tc162 0x1 | grep "ERROR: invalid assembly code"
+


### PR DESCRIPTION
With https://github.com/capstone-engine/capstone/pull/2252 I had the trouble, that the arch support flags were not added for whatever reason. This fixes it and adds some generic `cstool` tests.
The `cstool` tests are only there to check, if the disassembler engines of each arch is reached.