### PR TITLE
Revert constant value of CS_OP_MEM to `v5.0.1`

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -150,8 +150,8 @@ __all__ = [
     'CS_OP_INVALID',
     'CS_OP_REG',
     'CS_OP_IMM',
-    'CS_OP_FP',
     'CS_OP_MEM',
+    'CS_OP_FP',
 
     'CS_GRP_INVALID',
     'CS_GRP_JUMP',
@@ -290,8 +290,8 @@ CS_OPT_ON = 3              # Turn ON an option (CS_OPT_DETAIL)
 CS_OP_INVALID = 0  # uninitialized/invalid operand.
 CS_OP_REG = 1  # Register operand.
 CS_OP_IMM = 2  # Immediate operand.
-CS_OP_FP  = 3  # Floating-Point operand.
-CS_OP_MEM = 0x80  # Memory operand. Can be ORed with another operand type.
+CS_OP_MEM = 3  # Memory operand. Can be ORed with another operand type.
+CS_OP_FP  = 4  # Floating-Point operand.
 
 # Common instruction groups - to be consistent across all architectures.
 CS_GRP_INVALID = 0  # uninitialized/invalid group.

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -289,9 +289,8 @@ typedef enum cs_op_type {
 	CS_OP_INVALID = 0, ///< uninitialized/invalid operand.
 	CS_OP_REG,	   ///< Register operand.
 	CS_OP_IMM,	   ///< Immediate operand.
+	CS_OP_MEM,	   ///< Memory operand. Can be ORed with another operand type.
 	CS_OP_FP,	   ///< Floating-Point operand.
-	CS_OP_MEM =
-		0x80, ///< Memory operand. Can be ORed with another operand type.
 } cs_op_type;
 
 /// Common instruction operand access types - to be consistent across all architectures.


### PR DESCRIPTION
Testing fix for https://github.com/capstone-engine/capstone/issues/2274

The value was changed with the addition of TriCore. But it differs now between `v5.0.0` and `v5.0.1`.

@imbillow Could you please check and make sure that it doesn't affect the TriCore module. Even if the tests succeed.