### PR TITLE
[AArch64] Fix incorrect alignment of labels.

### DIFF
--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -2350,7 +2350,7 @@ void printAdrLabel(MCInst *MI, uint64_t Address, unsigned OpNum, SStream *O)
 		const int64_t Offset = MCOperand_getImm(Op);
 		SStream_concat0(O, markup("<imm:"));
 		if (!MI->csh->PrintBranchImmNotAsAddress)
-			printUInt64(O, ((Address & -4096) + Offset));
+			printUInt64(O, ((Address & -4) + Offset));
 		else {
 			printUInt64Bang(O, Offset);
 		}

--- a/arch/AArch64/AArch64Mapping.c
+++ b/arch/AArch64/AArch64Mapping.c
@@ -944,7 +944,7 @@ static void add_cs_detail_general(MCInst *MI, aarch64_op_group op_group,
 	}
 	case AArch64_OP_GROUP_AdrLabel: {
 		int64_t Offset = MCInst_getOpVal(MI, OpNum);
-		AArch64_set_detail_op_imm(MI, OpNum, AArch64_OP_IMM, (MI->address & -4096) + Offset);
+		AArch64_set_detail_op_imm(MI, OpNum, AArch64_OP_IMM, (MI->address & -4) + Offset);
 		break;
 	}
 	case AArch64_OP_GROUP_AdrpLabel: {


### PR DESCRIPTION
`AdrLabel` operands had the wrong alignment performed on it.

@kabeor Be so kind and take a look at it.