### PR TITLE
Fix invalid comparison with HPPA_OP_INVALID

### DIFF
--- a/arch/HPPA/HPPAInstPrinter.c
+++ b/arch/HPPA/HPPAInstPrinter.c
@@ -609,7 +609,7 @@ static void print_operand(MCInst *MI, SStream *O, const cs_hppa_op *op)
 		break;
 	case HPPA_OP_MEM:
 		SStream_concat(O, "(");
-		if (op->mem.space != HPPA_OP_INVALID &&
+		if (op->mem.space != HPPA_REG_INVALID &&
 		    op->mem.space != HPPA_REG_SR0) {
 			SStream_concat(O, HPPA_reg_name((csh)MI->csh,
 							op->mem.space));

--- a/arch/HPPA/HPPAMapping.c
+++ b/arch/HPPA/HPPAMapping.c
@@ -419,7 +419,7 @@ void HPPA_reg_access(const cs_insn *insn, cs_regs regs_read,
 			}
 			break;
 		case HPPA_OP_MEM:
-			if (op->mem.space != HPPA_OP_INVALID)
+			if (op->mem.space != HPPA_REG_INVALID)
 				regs_read[read_count++] = op->mem.space;
 			if (op->mem.base_access & CS_AC_READ) {
 				regs_read[read_count++] = op->mem.base;

--- a/bindings/python/test_hppa.py
+++ b/bindings/python/test_hppa.py
@@ -42,7 +42,7 @@ def print_insn_detail(insn):
                 print("\t\toperands[%u].type: DISP = 0x%s" % (c, to_x(i.imm)))
             if i.type == HPPA_OP_MEM:
                 print("\t\toperands[%u].type: MEM" % c)
-                if i.mem.space != HPPA_OP_INVALID:
+                if i.mem.space != HPPA_REG_INVALID:
                     print("\t\t\toperands[%u].mem.space: REG = %s" % (c, insn.reg_name(i.mem.space)))
                 print("\t\t\toperands[%u].mem.base: REG = %s" % (c, insn.reg_name(i.mem.base)))
             if i.type == HPPA_OP_TARGET:

--- a/cstool/cstool_hppa.c
+++ b/cstool/cstool_hppa.c
@@ -51,7 +51,7 @@ void print_insn_detail_hppa(csh handle, cs_insn *ins)
 			break;
 		case HPPA_OP_MEM:
 			printf("\t\toperands[%u].type:  MEM\n", i);
-			if (op->mem.space != HPPA_OP_INVALID) {
+			if (op->mem.space != HPPA_REG_INVALID) {
 				printf("\t\t\toperands[%u].mem.space: REG = %s\n",
 				       i, cs_reg_name(handle, op->mem.space));
 			}

--- a/suite/cstest/src/hppa_detail.c
+++ b/suite/cstest/src/hppa_detail.c
@@ -48,7 +48,7 @@ char *get_detail_hppa(csh *p_handle, cs_mode mode, cs_insn *ins)
 			break;
 		case HPPA_OP_MEM:
 			add_str(&result, "\t\toperands[%u].type:  MEM\n", i);
-			if (op->mem.space != HPPA_OP_INVALID) {
+			if (op->mem.space != HPPA_REG_INVALID) {
 				add_str(&result,
 					"\t\t\toperands[%u].mem.space: REG = %s\n",
 					i, cs_reg_name(handle, op->mem.space));

--- a/tests/test_hppa.c
+++ b/tests/test_hppa.c
@@ -64,7 +64,7 @@ static void print_insn_detail(cs_insn *ins)
 			break;
 		case HPPA_OP_MEM:
 			printf("\t\toperands[%u].type: MEM\n", i);
-			if (op->mem.space != HPPA_OP_INVALID) {
+			if (op->mem.space != HPPA_REG_INVALID) {
 				printf("\t\t\toperands[%u].mem.space: REG = %s\n",
 				       i, cs_reg_name(handle, op->mem.space));
 			}


### PR DESCRIPTION
**Detailed description**

This PR fixes error: comparison between `hppa_reg` and `enum hppa_op_type` 

**Closing issues**
closes #2299 
