### PR TITLE
Do not use 0b prefix, not supported on old compilers

### DIFF
--- a/arch/TriCore/TriCoreInstPrinter.c
+++ b/arch/TriCore/TriCoreInstPrinter.c
@@ -402,7 +402,7 @@ static void printDisp4Imm(MCInst *MI, int OpNum, SStream *O)
 		case TRICORE_LOOP_sbr:
 			// {27b’111111111111111111111111111, disp4, 0};
 			disp = (int32_t)MI->address +
-			       ((0b111111111111111111111111111 << 5) |
+			       ((0x7ffffff << 5) |
 				(disp << 1));
 			break;
 		default:
@@ -449,7 +449,7 @@ static void printOExtImm_4(MCInst *MI, int OpNum, SStream *O)
 	if (MCOperand_isImm(MO)) {
 		uint32_t imm = MCOperand_getImm(MO);
 		// {27b’111111111111111111111111111, disp4, 0};
-		imm = 0b11111111111111111111111111100000 | (imm << 1);
+		imm = 0xffffffe0 | (imm << 1);
 
 		printInt32Bang(O, imm);
 		fill_imm(MI, imm);


### PR DESCRIPTION
* Fix build on gcc 4.0.1 (the 0b prefix was introduced in gcc5)

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

capstone-v5 doesnt compile on gcc4, the compiler shipped in macos 10.4

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
