### PR TITLE
Fix cstool Makefile for non-C99-defaulting compilers

### DIFF
--- a/cstool/Makefile
+++ b/cstool/Makefile
@@ -7,6 +7,7 @@ include ../functions.mk
 LIBNAME = capstone
 
 CFLAGS += -I../include -I.
+CFLAGS += -std=gnu99
 LDFLAGS += -O3 -Wall -L.. -l$(LIBNAME)
 
 TARGET = cstool


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

C99 is necessary for some for(unsigned i; ... loops. Just like in the root Makefile, we enforce it using -std=gnu99.

```
...
  CC      cstool_hppa.o
cstool_hppa.c: In function 'print_insn_detail_hppa':
cstool_hppa.c:20: error: 'for' loop initial declaration used outside C99 mode
cstool_hppa.c:73: error: 'for' loop initial declaration used outside C99 mode
cstool_hppa.c:81: error: 'for' loop initial declaration used outside C99 mode
make[1]: *** [cstool_hppa.o] Error 1
make: *** [all] Error 2
imac:capstone florian$ cc --version
i686-apple-darwin9-gcc-4.0.1 (GCC) 4.0.1 (Apple Inc. build 5493)
Copyright (C) 2005 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

**Test plan**

Build with make and a compiler that does not default to >= C99 when passed no arguments.
