### PR TITLE
check if decode[idx] is callable

### DIFF
--- a/arch/SH/SHDisassembler.c
+++ b/arch/SH/SHDisassembler.c
@@ -2163,7 +2163,7 @@ static bool sh_disassemble(const uint8_t *code, MCInst *MI, uint64_t address,
 		idx = ((insn >> 8) & 0xf0) | (insn & 0x000f);
 	}
 
-	if (idx < sizeof(decode)/sizeof(decode[0]) &&  decode[idx]) {
+	if (idx < ARR_SIZE(decode) && decode[idx]) {
 		return decode[idx](insn, address, MI, mode, info, detail);
 	} else {
 		return MCDisassembler_Fail;

--- a/arch/SH/SHDisassembler.c
+++ b/arch/SH/SHDisassembler.c
@@ -2163,7 +2163,7 @@ static bool sh_disassemble(const uint8_t *code, MCInst *MI, uint64_t address,
 		idx = ((insn >> 8) & 0xf0) | (insn & 0x000f);
 	}
 
-	if (decode[idx]) {
+	if (idx < sizeof(decode)/sizeof(decode[0]) &&  decode[idx]) {
 		return decode[idx](insn, address, MI, mode, info, detail);
 	} else {
 		return MCDisassembler_Fail;


### PR DESCRIPTION
idx can be bigger than 256, this pr will check the size of decode before calling it