### PR TITLE
[v5] Fix #2079: Add missing 1 immediate to `rcl`

### DIFF
--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -2240,4 +2240,27 @@ unsigned short X86_register_map(unsigned short id)
 	return 0;
 }
 
+/// The post-printer function. Used to fixup flaws in the disassembly information
+/// of certain instructions.
+void X86_postprinter(csh handle, cs_insn *insn, char *mnem, MCInst *mci) {
+	if (!insn || !insn->detail) {
+		return;
+	}
+	switch (insn->id) {
+	default:
+		break;
+	case X86_INS_RCL:
+		// Addmissing 1 immediate
+		if (insn->detail->x86.op_count > 1) {
+			return;
+		}
+		insn->detail->x86.operands[1].imm = 1;
+		insn->detail->x86.operands[1].type = X86_OP_IMM;
+		insn->detail->x86.operands[1].access = CS_AC_READ;
+		insn->detail->x86.op_count++;
+		break;
+	}
+}
+
+
 #endif

--- a/arch/X86/X86Mapping.h
+++ b/arch/X86/X86Mapping.h
@@ -91,4 +91,6 @@ unsigned short X86_register_map(unsigned short id);
 
 unsigned int find_insn(unsigned int id);
 
+void X86_postprinter(csh handle, cs_insn *insn, char *mnem, MCInst *mci);
+
 #endif

--- a/arch/X86/X86Module.c
+++ b/arch/X86/X86Module.c
@@ -26,7 +26,7 @@ cs_err X86_global_init(cs_struct *ud)
 	ud->insn_id = X86_get_insn_id;
 	ud->insn_name = X86_insn_name;
 	ud->group_name = X86_group_name;
-	ud->post_printer = NULL;
+	ud->post_printer = X86_postprinter;
 #ifndef CAPSTONE_DIET
 	ud->reg_access = X86_reg_access;
 #endif

--- a/suite/cstest/issues.cs
+++ b/suite/cstest/issues.cs
@@ -1046,3 +1046,7 @@
 !# issue 2128
 !# CS_ARCH_X86, CS_MODE_64, CS_OPT_DETAIL
 0x0: 0x4c,0x85,0x7d,0x30 == test	qword ptr [rbp + 0x30], r15 ; operands[1].type: REG = r15 ; operands[1].access: READ ; Registers read: rbp r15 ; Registers modified: rflags
+
+!# issue 2079
+!# CS_ARCH_X86, CS_MODE_32, CS_OPT_DETAIL
+0x0: 0xd1,0x10 == rcl	dword ptr [eax] ; operands[1].type: IMM = 0x1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Closes #2079. I kept the disassembly the same, because it is the one currently used in LLVM.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Add to `issues.cs`

```bash
./cstool -d x32 0xd1,0x10
 0  d1 10                                            rcl	dword ptr [eax]
	ID: 615 (rcl)
	Prefix:0x00 0x00 0x00 0x00 
	Opcode:0xd1 0x00 0x00 0x00 
	rex: 0x0
	addr_size: 4
	modrm: 0x10
	disp: 0x0
	sib: 0x0
	imm_count: 1
		imms[1]: 0x1
	op_count: 2
		operands[0].type: MEM
			operands[0].mem.base: REG = eax
		operands[0].size: 4
		operands[0].access: READ
		operands[1].type: IMM = 0x1
		operands[1].size: 0
		operands[1].access: READ
	Registers read: eax
	Registers modified: eflags
	EFLAGS: MOD_CF UNDEF_OF
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #2079