### PR TITLE
[next] Fix #2244: Don't apply pseudo-instr. offset to `vcmp` id

### DIFF
--- a/cs.c
+++ b/cs.c
@@ -1209,7 +1209,7 @@ size_t CAPSTONE_API cs_disasm(csh ud, const uint8_t *buffer, size_t size, uint64
 			fill_insn(handle, insn_cache, ss.buffer, &mci, handle->post_printer, buffer);
 
 			// adjust for pseudo opcode (X86)
-			if (handle->arch == CS_ARCH_X86)
+			if (handle->arch == CS_ARCH_X86 && insn_cache->id != X86_INS_VCMP)
 				insn_cache->id += mci.popcode_adjust;
 
 			next_offset = insn_size;

--- a/suite/cstest/issues.cs
+++ b/suite/cstest/issues.cs
@@ -1074,3 +1074,7 @@
 !# issue 2079
 !# CS_ARCH_X86, CS_MODE_32, CS_OPT_DETAIL
 0x0: 0xd1,0x10 == rcl	dword ptr [eax] ; operands[1].type: IMM = 0x1
+
+!# issue 2244
+!# CS_ARCH_X86, CS_MODE_64, CS_OPT_DETAIL
+0x0: 0xc5,0xfb,0xc2,0xda,0x06 == vcmpnlesd	xmm3, xmm0, xmm2 ; ID: 797

--- a/suite/cstest/src/x86_detail.c
+++ b/suite/cstest/src/x86_detail.c
@@ -203,6 +203,7 @@ char *get_detail_x86(csh *ud, cs_mode mode, cs_insn *ins)
 
 	x86 = &(ins->detail->x86);
 
+	add_str(&result, " ; ID: %" PRIu32 , ins->id);
 	print_string_hex(&result, " ; Prefix:", x86->prefix, 4);
 	print_string_hex(&result, " ; Opcode:", x86->opcode, 4);
 	add_str(&result, " ; rex: 0x%x", x86->rex);


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

There is an offset for instruction IDs, which get applied to some of them.
For `vcmp` it seems they get applied incorrectly though.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Added

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes https://github.com/capstone-engine/capstone/issues/2244
