### PR TITLE
Fix comparison using narrow types in loop condition

### DIFF
--- a/Mapping.c
+++ b/Mapping.c
@@ -9,7 +9,7 @@ static unsigned short *make_id2insn(const insn_map *insns, unsigned int size)
 {
 	// NOTE: assume that the max id is always put at the end of insns array
 	unsigned short max_id = insns[size - 1].id;
-	unsigned short i;
+	unsigned int i;
 
 	unsigned short *cache =
 		(unsigned short *)cs_mem_calloc(max_id + 1, sizeof(*cache));


### PR DESCRIPTION
* Spotted by GitHub CodeQL vulnerability scanner
* Related to: CWE-190, CWE-197 and CWE-835.

**Detailed description**

The type of the looping variable is smaller than the one used to end the loop. So it is possible to cause an infinite loop because of the wraparound.

**Test plan**

Probably `next` is affected too. But i'm lazy to test other branches right now.

**Closing issues**

There are no issues refering to this issue