### PR TITLE
Mapping - return NULL if compiled with DIET

### DIFF
--- a/Mapping.c
+++ b/Mapping.c
@@ -235,6 +235,8 @@ const void *map_get_suppl_info(MCInst *MI, const insn_map *imap)
 
 	unsigned Opcode = MCInst_getOpcode(MI);
 	return &imap[Opcode].suppl_info;
+#else
+	return NULL;
 #endif // CAPSTONE_DIET
 }
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

It should fix the error when Capstone compiled with DIET define

**Test plan**

Builds fine with DIET option

Reported by @numas13