### PR TITLE
Replace cs_insn.bytes with an union. Breaking API change.

### DIFF
--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -130,12 +130,21 @@ jobs:
       run: |
         sh suite/run_invalid_cstool.sh
 
-    - name: cstest
+    - name: cstest (cmake)
       if: startsWith(matrix.config.build-system, 'cmake')
       run: |
         python suite/cstest/cstest_report.py -D -d suite/MC
         python suite/cstest/cstest_report.py -D -f suite/cstest/issues.cs
         python suite/cstest/cstest_report.py -D -f tests/cs_details/issue.cs
+
+    - name: cstest (make)
+      if: startsWith(matrix.config.build-system, 'make')
+      run: |
+        cd suite/cstest && ./build_cstest.sh
+        python cstest_report.py -D -t build/cstest -d ../MC
+        python cstest_report.py -D -t build/cstest -f issues.cs
+        python cstest_report.py -D -t build/cstest -f ../../tests/cs_details/issue.cs
+        cd ../../
 
     - name: verify python binding
       if: matrix.config.enable-asan == 'OFF'

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -132,8 +132,8 @@ jobs:
 
     - name: cstest
       run: |
-        python suite/cstest/cstest_report.py -D -t $(which cstest | head -n 1) -d suite/MC
-        python suite/cstest/cstest_report.py -D -t $(which cstest | head -n 1) -f suite/cstest/issues.cs
+        python suite/cstest/cstest_report.py -D -d suite/MC
+        python suite/cstest/cstest_report.py -D -f suite/cstest/issues.cs
 
     - name: verify python binding
       run: |

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -67,7 +67,7 @@ jobs:
             }
           - {
               name: 'ubuntu-22.04 x64 python3.11 ASAN',
-              os: ubuntu-22.04,
+              os: ubuntu-latest,
               arch: x64,
               python-arch: x64,
               python-version: '3.11',
@@ -109,7 +109,7 @@ jobs:
         cmake -DCAPSTONE_INSTALL=1 -DCMAKE_INSTALL_PREFIX=/usr ..
         cmake --build . --config Release
         # build shared library
-        cmake -DCAPSTONE_INSTALL=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_ASAN=${asan} ..
+        cmake -DCAPSTONE_INSTALL=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_PREFIX=/usr -DCAPSTONE_BUILD_CSTEST=ON -DENABLE_ASAN=${asan} ..
         sudo cmake --build . --config Release --target install
         cp libcapstone.* ../
         cp libcapstone.* ../tests/
@@ -132,9 +132,8 @@ jobs:
 
     - name: cstest
       run: |
-        cd suite/cstest && ./build_cstest.sh
-        python cstest_report.py -D -t build/cstest -d ../MC
-        python cstest_report.py -D -t build/cstest -f issues.cs; cd ..
+        python suite/cstest/cstest_report.py -D -t $(which cstest | head -n 1) -d suite/MC
+        python suite/cstest/cstest_report.py -D -t $(which cstest | head -n 1) -f suite/cstest/issues.cs
 
     - name: verify python binding
       run: |

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -117,6 +117,7 @@ jobs:
       run: |
         python suite/cstest/cstest_report.py -D -d suite/MC
         python suite/cstest/cstest_report.py -D -f suite/cstest/issues.cs
+        python suite/cstest/cstest_report.py -D -f tests/cs_details/issue.cs
 
     - name: verify python binding
       if: matrix.config.enable-asan == 'OFF'

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -121,6 +121,11 @@ jobs:
         clang -lcapstone  src/test_arm64_compatibility_header.c -o test_arm64_compatibility_header
         ./test_arm64_compatibility_header
 
+    - name: Lower number of KASL randomized address bits
+      run: |
+        # Work-around ASAN bug https://github.com/google/sanitizers/issues/1716
+        sudo sysctl vm.mmap_rnd_bits=28
+
     - name: cstool - reaches disassembler engine
       run: |
         sh suite/run_invalid_cstool.sh

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -39,6 +39,15 @@ jobs:
               enable-asan: 'OFF'
             }
           - {
+              name: 'ubuntu-22.04 x64 python3.9 make',
+              os: ubuntu-22.04,
+              arch: x64,
+              python-arch: x64,
+              python-version: '3.9',
+              build-system: 'make',
+              enable-asan: 'OFF'
+            }
+          - {
               name: 'ubuntu-22.04 x64 python3.9 cmake',
               os: ubuntu-22.04,
               arch: x64,
@@ -81,6 +90,14 @@ jobs:
         unzip -q corpus-libFuzzer-capstone_fuzz_disasmnext-latest.zip -d suite/fuzz
         git clone https://git.cryptomilk.org/projects/cmocka.git suite/cstest/cmocka
         chmod +x suite/cstest/build_cstest.sh
+
+    - name: make
+      if: startsWith(matrix.config.build-system, 'make')
+      run: |
+        ./make.sh
+        make check
+        sudo make install
+        cp libcapstone.so.5 libcapstone.so.5.0
 
     - name: cmake
       if: startsWith(matrix.config.build-system, 'cmake')

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -131,6 +131,7 @@ jobs:
         sh suite/run_invalid_cstool.sh
 
     - name: cstest
+      if: startsWith(matrix.config.build-system, 'cmake')
       run: |
         python suite/cstest/cstest_report.py -D -d suite/MC
         python suite/cstest/cstest_report.py -D -f suite/cstest/issues.cs

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -136,6 +136,7 @@ jobs:
         python suite/cstest/cstest_report.py -D -f suite/cstest/issues.cs
 
     - name: verify python binding
+      if: matrix.config.enable-asan == 'OFF'
       run: |
         mkdir -p bindings/python/capstone/lib && cp libcapstone.so.5.* bindings/python/capstone/lib/libcapstone.so
         cd bindings/python
@@ -155,6 +156,7 @@ jobs:
         make check
 
     - name: run python binding test
+      if: matrix.config.enable-asan == 'OFF'
       run: |
         cp libcapstone.* bindings/python/prebuilt
         cd bindings/python
@@ -163,6 +165,7 @@ jobs:
         BUILD_TESTS=no make tests
 
     - name: run cython binding test
+      if: matrix.config.enable-asan == 'OFF'
       run: |
         pip install cython
         cd bindings/python

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -36,6 +36,7 @@ jobs:
               python-arch: x64,
               python-version: '3.6',
               build-system: 'cmake',
+              enable-asan: 'OFF'
             }
           - {
               name: 'ubuntu-22.04 x64 python3.9 make',
@@ -44,6 +45,7 @@ jobs:
               python-arch: x64,
               python-version: '3.9',
               build-system: 'make',
+              enable-asan: 'OFF'
             }   
           - {
               name: 'ubuntu-22.04 x64 python3.9 cmake',
@@ -52,6 +54,7 @@ jobs:
               python-arch: x64,
               python-version: '3.9',
               build-system: 'cmake',
+              enable-asan: 'OFF'
             }     
           - {
               name: 'ubuntu-22.04 x64 python3.11 cmake',
@@ -60,6 +63,16 @@ jobs:
               python-arch: x64,
               python-version: '3.11',
               build-system: 'cmake',
+              enable-asan: 'OFF'
+            }
+          - {
+              name: 'ubuntu-22.04 x64 python3.11 ASAN',
+              os: ubuntu-22.04,
+              arch: x64,
+              python-arch: x64,
+              python-version: '3.11',
+              build-system: 'cmake',
+              enable-asan: 'ON'
             }
 
     steps:
@@ -88,13 +101,15 @@ jobs:
 
     - name: cmake
       if: startsWith(matrix.config.build-system, 'cmake')
+      env:
+        asan: ${{ matrix.config.enable-asan }}
       run: |
         mkdir build && cd build
         # build static library
         cmake -DCAPSTONE_INSTALL=1 -DCMAKE_INSTALL_PREFIX=/usr ..
         cmake --build . --config Release
         # build shared library
-        cmake -DCAPSTONE_INSTALL=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_PREFIX=/usr ..
+        cmake -DCAPSTONE_INSTALL=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_ASAN=${asan} ..
         sudo cmake --build . --config Release --target install
         cp libcapstone.* ../
         cp libcapstone.* ../tests/

--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -39,15 +39,6 @@ jobs:
               enable-asan: 'OFF'
             }
           - {
-              name: 'ubuntu-22.04 x64 python3.9 make',
-              os: ubuntu-22.04,
-              arch: x64,
-              python-arch: x64,
-              python-version: '3.9',
-              build-system: 'make',
-              enable-asan: 'OFF'
-            }   
-          - {
               name: 'ubuntu-22.04 x64 python3.9 cmake',
               os: ubuntu-22.04,
               arch: x64,
@@ -90,14 +81,6 @@ jobs:
         unzip -q corpus-libFuzzer-capstone_fuzz_disasmnext-latest.zip -d suite/fuzz
         git clone https://git.cryptomilk.org/projects/cmocka.git suite/cstest/cmocka
         chmod +x suite/cstest/build_cstest.sh
-
-    - name: make
-      if: startsWith(matrix.config.build-system, 'make')
-      run: |
-        ./make.sh
-        make check
-        sudo make install
-        cp libcapstone.so.5 libcapstone.so.5.0
 
     - name: cmake
       if: startsWith(matrix.config.build-system, 'cmake')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,13 @@ option(CAPSTONE_USE_ARCH_REGISTRATION "Use explicit architecture registration" O
 option(CAPSTONE_ARCHITECTURE_DEFAULT "Whether architectures are enabled by default" ON)
 option(CAPSTONE_DEBUG "Whether to enable extra debug assertions" OFF)
 option(CAPSTONE_INSTALL "Generate install target" ${PROJECT_IS_TOP_LEVEL})
+option(ENABLE_ASAN "Enable address sanitizer" OFF)
+
+if (ENABLE_ASAN)
+    add_definitions(-DASAN_ENABLED)
+    add_compile_options(-fsanitize=address)
+    add_link_options(-fsanitize=address)
+endif()
 
 # If building for OSX it's best to allow CMake to handle building both architectures
 if(APPLE AND NOT CAPSTONE_BUILD_MACOS_THIN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -862,16 +862,27 @@ if(CAPSTONE_BUILD_CSTOOL)
 endif()
 
 if(CAPSTONE_BUILD_CSTEST)
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(CMOCKA REQUIRED IMPORTED_TARGET cmocka)
+    include(ExternalProject)
+    ExternalProject_Add(cmocka_ext
+        PREFIX extern
+        GIT_REPOSITORY "https://git.cryptomilk.org/projects/cmocka.git"
+        CONFIGURE_COMMAND cmake -DBUILD_SHARED_LIBS=OFF ../cmocka_ext/
+        BUILD_COMMAND cmake --build . --config Release
+        INSTALL_COMMAND ""
+    )
+    set(CMOCKA_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern/src/cmocka_ext/include)
+    set(CMOCKA_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern/src/cmocka_ext-build/src/)
+    add_library(cmocka STATIC IMPORTED)
+    set_target_properties(cmocka PROPERTIES IMPORTED_LOCATION ${CMOCKA_LIB_DIR}/libcmocka.a)
 
     file(GLOB CSTEST_SRC suite/cstest/src/*.c)
     add_executable(cstest ${CSTEST_SRC})
-    target_link_libraries(cstest PUBLIC capstone PkgConfig::CMOCKA)
+    add_dependencies(cstest cmocka_ext)
+    target_link_libraries(cstest PUBLIC capstone cmocka)
     target_include_directories(cstest PRIVATE
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
             ${PROJECT_SOURCE_DIR}/suite/cstest/include
-            ${CMOCKA_INCLUDE_DIRS}
+            ${CMOCKA_INCLUDE_DIR}
             )
 
     if(CAPSTONE_INSTALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -866,6 +866,7 @@ if(CAPSTONE_BUILD_CSTEST)
     ExternalProject_Add(cmocka_ext
         PREFIX extern
         GIT_REPOSITORY "https://git.cryptomilk.org/projects/cmocka.git"
+        GIT_TAG "origin/stable-1.1"
         CONFIGURE_COMMAND cmake -DBUILD_SHARED_LIBS=OFF ../cmocka_ext/
         BUILD_COMMAND cmake --build . --config Release
         INSTALL_COMMAND ""

--- a/COMPILE_CMAKE.TXT
+++ b/COMPILE_CMAKE.TXT
@@ -56,6 +56,7 @@ Get CMake for free from http://www.cmake.org.
   - CAPSTONE_X86_REDUCE: change this to ON to make X86 binary smaller.
   - CAPSTONE_X86_ATT_DISABLE: change this to ON to disable AT&T syntax on x86.
   - CAPSTONE_DEBUG: change this to ON to enable extra debug assertions.
+  - CAPSTONE_BUILD_CSTEST: Build `cstest` in `suite/cstes/`
   - ENABLE_ASAN: Compiles Capstone with the address sanitizer.
 
   By default, Capstone use system dynamic memory management, and both DIET and X86_REDUCE

--- a/COMPILE_CMAKE.TXT
+++ b/COMPILE_CMAKE.TXT
@@ -56,7 +56,7 @@ Get CMake for free from http://www.cmake.org.
   - CAPSTONE_X86_REDUCE: change this to ON to make X86 binary smaller.
   - CAPSTONE_X86_ATT_DISABLE: change this to ON to disable AT&T syntax on x86.
   - CAPSTONE_DEBUG: change this to ON to enable extra debug assertions.
-  - CAPSTONE_BUILD_CSTEST: Build `cstest` in `suite/cstes/`
+  - CAPSTONE_BUILD_CSTEST: Build `cstest` in `suite/cstest/`
   - ENABLE_ASAN: Compiles Capstone with the address sanitizer.
 
   By default, Capstone use system dynamic memory management, and both DIET and X86_REDUCE

--- a/COMPILE_CMAKE.TXT
+++ b/COMPILE_CMAKE.TXT
@@ -56,6 +56,7 @@ Get CMake for free from http://www.cmake.org.
   - CAPSTONE_X86_REDUCE: change this to ON to make X86 binary smaller.
   - CAPSTONE_X86_ATT_DISABLE: change this to ON to disable AT&T syntax on x86.
   - CAPSTONE_DEBUG: change this to ON to enable extra debug assertions.
+  - ENABLE_ASAN: Compiles Capstone with the address sanitizer.
 
   By default, Capstone use system dynamic memory management, and both DIET and X86_REDUCE
   modes are disabled. To use your own memory allocations, turn ON both DIET &

--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -503,6 +503,14 @@ class _cs_insn(ctypes.Structure):
         ('detail', ctypes.POINTER(_cs_detail)),
     )
 
+class _cs_buffer(ctypes.Structure):
+    _fields_ = (
+        ('private', ctypes.c_void_p),
+        ('insn', ctypes.POINTER(_cs_insn)),
+        ('capacity', ctypes.c_size_t),
+        ('count', ctypes.c_size_t),
+    )
+
 # callback for SKIPDATA option
 CS_SKIPDATA_CALLBACK = ctypes.CFUNCTYPE(ctypes.c_size_t, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t, ctypes.c_size_t, ctypes.c_void_p)
 
@@ -525,11 +533,12 @@ def _setup_prototype(lib, fname, restype, *argtypes):
     getattr(lib, fname).argtypes = argtypes
 
 _setup_prototype(_cs, "cs_open", ctypes.c_int, ctypes.c_uint, ctypes.c_uint, ctypes.POINTER(ctypes.c_size_t))
+_setup_prototype(_cs, "cs_buffer_new", ctypes.POINTER(_cs_buffer), ctypes.c_size_t)
+_setup_prototype(_cs, "cs_buffer_free", None, ctypes.POINTER(_cs_buffer))
 _setup_prototype(_cs, "cs_disasm", ctypes.c_size_t, ctypes.c_size_t, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t, \
-        ctypes.c_uint64, ctypes.c_size_t, ctypes.POINTER(ctypes.POINTER(_cs_insn)))
+        ctypes.c_uint64, ctypes.c_size_t, ctypes.POINTER(_cs_buffer))
 _setup_prototype(_cs, "cs_disasm_iter", ctypes.c_bool, ctypes.c_size_t, ctypes.POINTER(ctypes.POINTER(ctypes.c_char)), ctypes.POINTER(ctypes.c_size_t), \
-                 ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(_cs_insn))
-_setup_prototype(_cs, "cs_free", None, ctypes.c_void_p, ctypes.c_size_t)
+                         ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(_cs_buffer))
 _setup_prototype(_cs, "cs_close", ctypes.c_int, ctypes.POINTER(ctypes.c_size_t))
 _setup_prototype(_cs, "cs_reg_name", ctypes.c_char_p, ctypes.c_size_t, ctypes.c_uint)
 _setup_prototype(_cs, "cs_insn_name", ctypes.c_char_p, ctypes.c_size_t, ctypes.c_uint)
@@ -599,20 +608,21 @@ def cs_disasm_quick(arch, mode, code, offset, count=0):
     if status != CS_ERR_OK:
         raise CsError(status)
 
-    all_insn = ctypes.POINTER(_cs_insn)()
-    res = _cs.cs_disasm(csh, code, len(code), offset, count, ctypes.byref(all_insn))
-    if res > 0:
-        try:
+    buffer = _cs.cs_buffer_new(0)
+    try:
+        res = _cs.cs_disasm(csh, code, len(code), offset, count, buffer)
+        all_insn = buffer.contents.insn
+        if res > 0:
             for i in range(res):
                 yield CsInsn(_dummy_cs(csh, arch), all_insn[i])
-        finally:
-            _cs.cs_free(all_insn, res)
-    else:
-        status = _cs.cs_errno(csh)
-        if status != CS_ERR_OK:
-            raise CsError(status)
-        return
-        yield
+        else:
+            status = _cs.cs_errno(csh)
+            if status != CS_ERR_OK:
+                raise CsError(status)
+            return
+            yield
+    finally:
+        _cs.cs_buffer_free(buffer)
 
     status = _cs.cs_close(ctypes.byref(csh))
     if status != CS_ERR_OK:
@@ -639,21 +649,22 @@ def cs_disasm_lite(arch, mode, code, offset, count=0):
     if status != CS_ERR_OK:
         raise CsError(status)
 
-    all_insn = ctypes.POINTER(_cs_insn)()
-    res = _cs.cs_disasm(csh, code, len(code), offset, count, ctypes.byref(all_insn))
-    if res > 0:
-        try:
+    buffer = _cs.cs_buffer_new(0)
+    res = _cs.cs_disasm(csh, code, len(code), offset, count, buffer)
+    all_insn = buffer.contents.insn
+    try:
+        if res > 0:
             for i in range(res):
                 insn = all_insn[i]
                 yield (insn.address, insn.size, insn.mnemonic.decode('ascii'), insn.op_str.decode('ascii'))
-        finally:
-            _cs.cs_free(all_insn, res)
-    else:
-        status = _cs.cs_errno(csh)
-        if status != CS_ERR_OK:
-            raise CsError(status)
-        return
-        yield
+        else:
+            status = _cs.cs_errno(csh)
+            if status != CS_ERR_OK:
+                raise CsError(status)
+            return
+            yield
+    finally:
+        _cs.cs_buffer_free(buffer)
 
     status = _cs.cs_close(ctypes.byref(csh))
     if status != CS_ERR_OK:
@@ -1214,7 +1225,6 @@ class Cs(object):
 
     # Disassemble binary & return disassembled instructions in CsInsn objects
     def disasm(self, code, offset, count=0):
-        all_insn = ctypes.POINTER(_cs_insn)()
         '''if not _python2:
             print(code)
             code = code.encode()
@@ -1226,19 +1236,21 @@ class Cs(object):
             code = ctypes.byref(ctypes.c_char.from_buffer(view))
         elif not isinstance(code, bytes):
             code = view.tobytes()
-        res = _cs.cs_disasm(self.csh, code, size, offset, count, ctypes.byref(all_insn))
-        if res > 0:
-            try:
+        buffer = _cs.cs_buffer_new(0)
+        res = _cs.cs_disasm(self.csh, code, size, offset, count, buffer)
+        all_insn = buffer.contents.insn
+        try:
+            if res > 0:
                 for i in range(res):
                     yield CsInsn(self, all_insn[i])
-            finally:
-                _cs.cs_free(all_insn, res)
-        else:
-            status = _cs.cs_errno(self.csh)
-            if status != CS_ERR_OK:
-                raise CsError(status)
-            return
-            yield
+            else:
+                status = _cs.cs_errno(self.csh)
+                if status != CS_ERR_OK:
+                    raise CsError(status)
+                return
+                yield
+        finally:
+            _cs.cs_buffer_free(buffer)
 
     # This function matches the cs_disasm_iter implementation which
     # *should* be much faster via the C API due to pre-allocating
@@ -1264,8 +1276,13 @@ class Cs(object):
         # the typical auto conversion, so we have to cast it here.
         code = ctypes.cast(code, ctypes.POINTER(ctypes.c_char))
         address = ctypes.c_uint64(offset)
-        while _cs.cs_disasm_iter(self.csh, ctypes.byref(code), ctypes.byref(size), ctypes.byref(address), ctypes.byref(insn)):
-            yield (insn.address, insn.size, insn.mnemonic.decode('ascii'), insn.op_str.decode('ascii'))
+        buffer = _cs.cs_buffer_new(0)
+        try:
+            while _cs.cs_disasm_iter(self.csh, ctypes.byref(code), ctypes.byref(size), ctypes.byref(address), buffer):
+                insn = buffer.contents.insn[0]
+                yield (insn.address, insn.size, insn.mnemonic.decode('ascii'), insn.op_str.decode('ascii'))
+        finally:
+            _cs.cs_buffer_free(buffer)
 
     # Light function to disassemble binary. This is about 20% faster than disasm() because
     # unlike disasm(), disasm_lite() only return tuples of (address, size, mnemonic, op_str),
@@ -1275,7 +1292,6 @@ class Cs(object):
             # Diet engine cannot provide @mnemonic & @op_str
             raise CsError(CS_ERR_DIET)
 
-        all_insn = ctypes.POINTER(_cs_insn)()
         size = len(code)
         # Pass a bytearray by reference
         view = memoryview(code)
@@ -1283,20 +1299,22 @@ class Cs(object):
             code = ctypes.byref(ctypes.c_char.from_buffer(view))
         elif not isinstance(code, bytes):
             code = view.tobytes()
-        res = _cs.cs_disasm(self.csh, code, size, offset, count, ctypes.byref(all_insn))
-        if res > 0:
-            try:
+        buffer = _cs.cs_buffer_new(0)
+        res = _cs.cs_disasm(self.csh, code, size, offset, count, buffer)
+        all_insn = buffer.contents.insn
+        try:
+            if res > 0:
                 for i in range(res):
                     insn = all_insn[i]
                     yield (insn.address, insn.size, insn.mnemonic.decode('ascii'), insn.op_str.decode('ascii'))
-            finally:
-                _cs.cs_free(all_insn, res)
-        else:
-            status = _cs.cs_errno(self.csh)
-            if status != CS_ERR_OK:
-                raise CsError(status)
-            return
-            yield
+            else:
+                status = _cs.cs_errno(self.csh)
+                if status != CS_ERR_OK:
+                    raise CsError(status)
+                return
+                yield
+        finally:
+            _cs.cs_buffer_free(buffer)
 
 
 # print out debugging info

--- a/bindings/python/pyx/ccapstone.pxd
+++ b/bindings/python/pyx/ccapstone.pxd
@@ -28,6 +28,12 @@ cdef extern from "<capstone/capstone.h>":
         bool usesAliasDetails;
         cs_detail *detail
 
+    ctypedef struct cs_buffer:
+        void *private_data;
+        cs_insn *insn;
+        size_t capacity;
+        size_t count;
+
     ctypedef enum cs_err:
         pass
 
@@ -44,15 +50,23 @@ cdef extern from "<capstone/capstone.h>":
 
     cs_err cs_errno(csh handle)
 
+    cs_buffer * cs_buffer_new(size_t capacity)
+
+    void cs_buffer_free(cs_buffer *buffer)
+
+    void cs_buffer_clear(cs_buffer *buffer)
+
+    bool cs_buffer_reserve_exact(cs_buffer *buffer, size_t capacity)
+
+    bool cs_buffer_reserve(cs_buffer *buffer, size_t additional)
+
     size_t cs_disasm(csh handle,
         const uint8_t *code, size_t code_size,
         uint64_t address,
         size_t count,
-        cs_insn **insn)
+        cs_buffer *buffer)
 
     cs_err cs_option(csh handle, cs_opt_type type, size_t value)
-
-    void cs_free(cs_insn *insn, size_t count)
 
     const char *cs_reg_name(csh handle, unsigned int reg_id)
 

--- a/bindings/python/pyx/ccapstone.pxd
+++ b/bindings/python/pyx/ccapstone.pxd
@@ -16,12 +16,16 @@ cdef extern from "<capstone/capstone.h>":
     ctypedef struct cs_detail:
         pass
 
+    ctypedef union cs_insn_bytes:
+        uint8_t arr[16]
+        uint8_t *ptr
+
     ctypedef struct cs_insn:
         unsigned int id
         uint64_t alias_id;
         uint64_t address
         uint16_t size
-        uint8_t bytes[24]
+        cs_insn_bytes bytes
         char mnemonic[32]
         char op_str[160]
         bool is_alias;

--- a/bindings/python/pyx/ccapstone.pyx
+++ b/bindings/python/pyx/ccapstone.pyx
@@ -108,7 +108,11 @@ cdef class CsInsn(object):
     # return instruction's machine bytes (which should have @size bytes).
     @property
     def bytes(self):
-        return bytearray(self._raw.bytes[:self._raw.size])
+        if self._raw.size > 16:
+            raw = self._raw.bytes.ptr
+        else:
+            raw = self._raw.bytes.arr
+        return bytearray(raw[:self._raw.size])
 
     # return instruction's mnemonic.
     @property

--- a/contrib/cs_driver/cs_driver/cs_driver.c
+++ b/contrib/cs_driver/cs_driver/cs_driver.c
@@ -43,6 +43,7 @@ EXTERN_C NTSTATUS DriverEntry(PDRIVER_OBJECT DriverObject,
 // Hello, Capstone!
 static NTSTATUS cs_driver_hello() {
   csh handle;
+  cs_buffer *buffer;
   cs_insn *insn;
   size_t count;
   KFLOATING_SAVE float_save;
@@ -69,16 +70,18 @@ static NTSTATUS cs_driver_hello() {
     goto exit;
   }
 
+  buffer = cs_buffer_new(0);
   count = cs_disasm(handle, (uint8_t *)&cs_driver_hello, 0x80,
-                    (uint64_t)&cs_driver_hello, 0, &insn);
+                    (uint64_t)&cs_driver_hello, 0, buffer);
   if (count > 0) {
+    cs_insn *insn = buffer->insn;
     printf("cs_driver!cs_driver_hello:\n");
     for (size_t j = 0; j < count; j++) {
       printf("0x%p\t%s\t\t%s\n", (void *)(uintptr_t)insn[j].address,
              insn[j].mnemonic, insn[j].op_str);
     }
-    cs_free(insn, count);
   }
+  cs_buffer_free(buffer);
   cs_close(&handle);
 
 exit:;

--- a/cs.c
+++ b/cs.c
@@ -697,7 +697,7 @@ CAPSTONE_EXPORT
 cs_err CAPSTONE_API cs_open(cs_arch arch, cs_mode mode, csh *handle)
 {
 	cs_err err;
-	struct cs_struct *ud;
+	struct cs_struct *ud = NULL;
 	if (!cs_mem_malloc || !cs_mem_calloc || !cs_mem_realloc || !cs_mem_free || !cs_vsnprintf)
 		// Error: before cs_open(), dynamic memory management must be initialized
 		// with cs_option(CS_OPT_MEM)
@@ -745,8 +745,8 @@ cs_err CAPSTONE_API cs_open(cs_arch arch, cs_mode mode, csh *handle)
 CAPSTONE_EXPORT
 cs_err CAPSTONE_API cs_close(csh *handle)
 {
-	struct cs_struct *ud;
-	struct insn_mnem *next, *tmp;
+	struct cs_struct *ud = NULL;
+	struct insn_mnem *next = NULL, *tmp = NULL;
 
 	if (*handle == 0)
 		// invalid handle

--- a/cs.c
+++ b/cs.c
@@ -736,6 +736,7 @@ cs_err CAPSTONE_API cs_open(cs_arch arch, cs_mode mode, csh *handle)
 
 		return CS_ERR_OK;
 	} else {
+		cs_mem_free(ud);
 		*handle = 0;
 		return CS_ERR_ARCH;
 	}

--- a/cstool/cstool.c
+++ b/cstool/cstool.c
@@ -653,13 +653,14 @@ int main(int argc, char **argv)
 	if (count > 0) {
 		cs_insn *insn = buffer->insn;
 		for (i = 0; i < count; i++) {
+			uint8_t *bytes = CS_INSN_BYTES(&insn[i]);
 			int j;
 
 			printf("%2"PRIx64"  ", insn[i].address);
 			for (j = 0; j < insn[i].size; j++) {
 				if (j > 0)
 					putchar(' ');
-				printf("%02x", insn[i].bytes[j]);
+				printf("%02x", bytes[j]);
 			}
 			// Align instruction when it varies in size.
 			// ex: x86, s390x or compressed riscv

--- a/cstool/cstool.c
+++ b/cstool/cstool.c
@@ -678,8 +678,11 @@ int main(int argc, char **argv)
 		}
 
 		cs_free(insn, count);
+		free(assembly);
 	} else {
 		printf("ERROR: invalid assembly code\n");
+		cs_close(&handle);
+		free(assembly);
 		return(-4);
 	}
 

--- a/cstool/cstool.c
+++ b/cstool/cstool.c
@@ -687,7 +687,6 @@ int main(int argc, char **argv)
 	}
 
 	cs_close(&handle);
-	free(assembly);
 
 	return 0;
 }

--- a/cstool/cstool_arm.c
+++ b/cstool/cstool_arm.c
@@ -58,6 +58,8 @@ void print_insn_detail_arm(csh handle, cs_insn *ins)
 					printf("\t\t\toperands[%u].mem.scale: %d\n", i, op->mem.scale);
 				if (op->mem.disp != 0)
 					printf("\t\t\toperands[%u].mem.disp: 0x%x\n", i, op->mem.disp);
+				if (op->mem.align != 0)
+					printf("\t\t\toperands[%u].mem.align: 0x%x\n", i, op->mem.align);
 				if (op->mem.lshift != 0)
 					printf("\t\t\toperands[%u].mem.lshift: 0x%x\n", i, op->mem.lshift);
 

--- a/docs/cs_v6_release_guide.md
+++ b/docs/cs_v6_release_guide.md
@@ -174,6 +174,7 @@ These features are only supported by `auto-sync`-enabled architectures.
 **More code quality checks**
 
 - `clang-tidy` is now run on all files changed by a PR.
+- ASAN: All tests are now run with the address sanitizer enabled. This includes checking for leaks.
 
 **Instruction formats for PPC**
 

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -464,9 +464,12 @@ typedef struct cs_insn {
 	/// This information is available even when CS_OPT_DETAIL = CS_OPT_OFF
 	uint16_t size;
 
-	/// Machine bytes of this instruction, with number of bytes indicated by @size above
-	/// This information is available even when CS_OPT_DETAIL = CS_OPT_OFF
-	uint8_t bytes[24];
+	/// Use CS_INSN_BYTES() to access instruction bytes.
+	union cs_insn_bytes {
+		// NOTE: Size is selected based on the length of x86 instructions.
+		uint8_t arr[16];
+		uint8_t *ptr;
+	} bytes;
 
 	/// Ascii text of instruction mnemonic
 	/// This information is available even when CS_OPT_DETAIL = CS_OPT_OFF
@@ -495,6 +498,10 @@ typedef struct cs_insn {
 	cs_detail *detail;
 } cs_insn;
 
+/// Machine bytes of this instruction, with number of bytes indicated by @size above
+/// This information is available even when CS_OPT_DETAIL = CS_OPT_OFF
+#define CS_INSN_BYTES(INSN) \
+	((INSN)->size > sizeof((INSN)->bytes.arr) ? (INSN)->bytes.ptr : (INSN)->bytes.arr)
 
 /// Calculate the offset of a disassembled instruction in its buffer, given its position
 /// in its array of disassembled insn

--- a/suite/arm/test_arm_regression.c
+++ b/suite/arm/test_arm_regression.c
@@ -171,7 +171,7 @@ static void test_invalids()
 	struct invalid_instructions * invalid = NULL;
 
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	int j;
 	size_t count;
@@ -205,12 +205,14 @@ static void test_invalids()
 
 			free(hex_str);
 
-			count = cs_disasm(handle,
-					invalid_code->code, invalid_code->size, address, 0, &insn
-					);
+			buffer = cs_buffer_new(0);
+			count = cs_disasm(handle, invalid_code->code, invalid_code->size,
+					address, 0, buffer);
 
 			if (count) {
 				size_t k;
+				cs_insn *insn = buffer->insn;
+
 				printf("    ERROR:\n");
 
 				for (k = 0; k < count; k++) {
@@ -218,13 +220,13 @@ static void test_invalids()
 							insn[k].address, insn[k].mnemonic, insn[k].op_str);
 					print_insn_detail(&insn[k]);
 				}
-				cs_free(insn, count);
 
 			} else {
 				printf("    SUCCESS: invalid\n");
 			}
 		}
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }
@@ -286,7 +288,7 @@ static void test_valids()
 
 	struct valid_instructions *valid = NULL;
 
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	int j;
 	size_t count;
@@ -333,15 +335,17 @@ static void test_valids()
 
 			free(hex_str);
 
+			buffer = cs_buffer_new(0);
 			count = cs_disasm(handle,
 					valid_code->code, valid_code->size, 
-					valid_code->start_addr, 0, &insn
+					valid_code->start_addr, 0, buffer
 					);
 
 			if (count) {
 				size_t k;
 				size_t max_len = 0;
 				size_t tmp_len = 0;
+				cs_insn *insn = buffer->insn;
 
 				for (k = 0; k < count; k++) {
 					_this_printf(
@@ -368,14 +372,12 @@ static void test_valids()
 				} else {
 					printf("    SUCCESS: valid\n");
 				}
-
-				cs_free(insn, count);
-
 			} else {
 				printf("ERROR: invalid\n");
 			}
 		}
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 

--- a/suite/auto-sync/c_tests/src/test_arm64_compatibility_header.c
+++ b/suite/auto-sync/c_tests/src/test_arm64_compatibility_header.c
@@ -10,6 +10,7 @@
 int main(void)
 {
 	csh handle;
+	int ret = 0;
 
 	if (cs_open(CS_ARCH_ARM64, CS_MODE_BIG_ENDIAN, &handle) != CS_ERR_OK) {
 		printf("cs_open failed\n");
@@ -18,23 +19,22 @@ int main(void)
 
 	cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-	cs_insn *insn;
+	cs_buffer *buffer = cs_buffer_new(0);
 	uint8_t bytes[] = "0x1a,0x48,0xa0,0xf8";
-	size_t count = cs_disasm(handle, bytes, sizeof(bytes), 0x1000, 1, &insn);
+	size_t count = cs_disasm(handle, bytes, sizeof(bytes), 0x1000, 1, buffer);
 	if (count > 0) {
+		cs_insn *insn = buffer->insn;
 		printf("0x%" PRIx64 ":\t%s\t\t%s\n", insn[0].address,
 		       insn[0].mnemonic, insn[0].op_str);
 		printf("A register = %s\n", cs_reg_name(handle, insn[0].detail->arm64.operands[0].reg));
 		printf("An imm = 0x%" PRIx64 "\n", insn[0].detail->arm64.operands[1].imm);
-
-		cs_free(insn, count);
 	} else {
 		printf("ERROR: Failed to disassemble given code!\n");
-		cs_close(&handle);
-		return -1;
+		ret = -1;
 	}
 
+	cs_buffer_free(buffer);
 	cs_close(&handle);
 
-	return 0;
+	return ret;
 }

--- a/suite/benchmark/test_file_benchmark.c
+++ b/suite/benchmark/test_file_benchmark.c
@@ -7,7 +7,7 @@
 int main(int argc, char* argv[])
 {
     csh handle = 0;
-    cs_insn *insn = NULL;
+    cs_buffer *buffer = NULL;
     int ret = 0;
     const uint8_t *code_iter = NULL;
     size_t code_len_iter = 0;
@@ -31,8 +31,8 @@ int main(int argc, char* argv[])
         goto leave;
     }
 
-    insn = cs_malloc(handle);
-    if (!insn)
+    buffer = cs_buffer_new(0);
+    if (!buffer)
     {
         fputs("Failed to allocate memory\n", stderr);
         ret = 1;
@@ -51,7 +51,7 @@ int main(int argc, char* argv[])
                 &code_iter,
                 &code_len_iter,
                 &ip,
-                insn
+                buffer
             ))
             {
                 ++code_iter;
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
     );
 
 leave:
-    if (insn) cs_free(insn, 1);
+    if (buffer) cs_buffer_free(buffer);
     if (handle) cs_close(&handle);
     if (code) free(code);
     return ret;

--- a/suite/benchmark/test_iter_benchmark.c
+++ b/suite/benchmark/test_iter_benchmark.c
@@ -57,7 +57,7 @@ static void test()
 
 	csh handle;
 	uint64_t address;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	cs_err err;
 	const uint8_t *code;
@@ -76,16 +76,16 @@ static void test()
 
 	start = clock();
 	int maxcount = 10000000;
-	insn = cs_malloc(handle);
+	buffer = cs_buffer_new(1);
 	for (i = 0; i < maxcount;) {
 		code = (const uint8_t *)X86_CODE32;
 		address = 0x1000;
 		size = sizeof(X86_CODE32) - 1;
-		while(cs_disasm_iter(handle, &code, &size, &address, insn)) {
+		while(cs_disasm_iter(handle, &code, &size, &address, buffer)) {
 			i++;
 		}
 	}
-	cs_free(insn, 1);
+	cs_buffer_free(buffer);
 	cs_close(&handle);
 	end = clock();
 	timeUsed = (double)(end - start) / CLOCKS_PER_SEC;

--- a/suite/cstest/Makefile
+++ b/suite/cstest/Makefile
@@ -6,7 +6,7 @@ LIBRARY = -lcmocka -lcapstone -L../..
 all:
 	rm -rf $(BUILD)
 	mkdir $(BUILD)
-	$(CC) $(SOURCE)/*.c $(INCLUDE:%=-I %) -g -o $(BUILD)/cstest $(LIBRARY)
+	$(CC) $(SOURCE)/*.c $(INCLUDE:%=-I %) ${CMAKE_C_FLAGS} -g -o $(BUILD)/cstest $(LIBRARY)
 cstest:
 	$(BUILD)/cstest -d ../MC	
 clean:

--- a/suite/cstest/README.md
+++ b/suite/cstest/README.md
@@ -13,22 +13,18 @@ brew install cmocka
 
 - Build Cmocka
 
-```
-cd cmocka_dir
-mkdir build
-cd build
-cmake ..
-make
-sudo make install
-```
-
 ## Build
 
 - Build `cstest`
 
+```sh
+./build_cstest.sh
 ```
-cd suite/cstest
-make
+
+To enable ASAN run
+
+```sh
+asan="ON" ./build_cstest.sh
 ```
 
 ## Usage

--- a/suite/cstest/README.md
+++ b/suite/cstest/README.md
@@ -15,17 +15,10 @@ brew install cmocka
 
 ## Build
 
-- Build `cstest`
+You can build `cstest` with `cmake` when building Capstone. Just pass the `CAPSTONE_BUILD_CSTEST` flag
+during configuration.
 
-```sh
-./build_cstest.sh
-```
-
-To enable ASAN run
-
-```sh
-asan="ON" ./build_cstest.sh
-```
+Alternatively you can use the `build_cstest.sh` file in this directory.
 
 ## Usage
 

--- a/suite/cstest/build_cstest.sh
+++ b/suite/cstest/build_cstest.sh
@@ -1,9 +1,21 @@
-#!/bin/sh
+#!/bin/sh -x
 
-cd cmocka && mkdir build && cd build
+cd cmocka
+mkdir build
+cd build
+
 if [ "$(uname)" = Darwin ]; then
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. && make -j2 && sudo make install
+  cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. && make -j2 && sudo make install
+elif [ "$asan" = "ON" ]; then
+  CMAKE_C_FLAGS="-fsanitize=address" CMAKE_LINK_FLAGS="-fsanitize=address" cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. && make -j2 && sudo make install
 else  # Linux
-cmake -DCMAKE_INSTALL_PREFIX=/usr .. && make -j2 && sudo make install
+  cmake -DCMAKE_INSTALL_PREFIX=/usr .. && make -j2 && sudo make install
 fi
-cd ../.. && make
+
+cd ../..
+
+if [ "$asan" = "ON" ]; then
+  CMAKE_C_FLAGS="-fsanitize=address" make
+else
+  make
+fi

--- a/suite/cstest/cstest_report.py
+++ b/suite/cstest/cstest_report.py
@@ -15,7 +15,7 @@ def Usage(s):
 	sys.exit(-1)
 
 def get_report_file(toolpath, filepath, getDetails, cmt_out):
-	cmd = [toolpath, '-f', filepath]
+	cmd = [toolpath if toolpath else "cstest", '-f', filepath]
 	process = Popen(cmd, stdout=PIPE, stderr=PIPE)
 	stdout, stderr = process.communicate()
 	if process.returncode != 0:

--- a/suite/cstest/include/helper.h
+++ b/suite/cstest/include/helper.h
@@ -17,7 +17,7 @@
 #define X86_32 1
 #define X86_64 2
 
-char **split(char *str, char *delim, int *size);
+char **split(const char *str, const char *delim, int *size);
 void print_strs(char **list_str, int size);
 void free_strs(char **list_str, int size);
 void add_str(char **src, const char *format, ...);

--- a/suite/cstest/include/helper.h
+++ b/suite/cstest/include/helper.h
@@ -17,7 +17,7 @@
 #define X86_32 1
 #define X86_64 2
 
-char **split(char *str, const char *delim, int *size);
+char **split(char *str, char *delim, int *size);
 void print_strs(char **list_str, int size);
 void free_strs(char **list_str, int size);
 void add_str(char **src, const char *format, ...);

--- a/suite/cstest/include/helper.h
+++ b/suite/cstest/include/helper.h
@@ -17,7 +17,7 @@
 #define X86_32 1
 #define X86_64 2
 
-char **split(char *str, char *delim, int *size);
+char **split(char *str, const char *delim, int *size);
 void print_strs(char **list_str, int size);
 void free_strs(char **list_str, int size);
 void add_str(char **src, const char *format, ...);

--- a/suite/cstest/src/arm_detail.c
+++ b/suite/cstest/src/arm_detail.c
@@ -52,6 +52,8 @@ char *get_detail_arm(csh *handle, cs_mode mode, cs_insn *ins)
 					add_str(&result, " ; operands[%u].mem.scale: %d", i, op->mem.scale);
 				if (op->mem.disp != 0)
 					add_str(&result, " ; operands[%u].mem.disp: 0x%x", i, op->mem.disp);
+				if (op->mem.align != 0)
+					add_str(&result, " ; operands[%u].mem.align: 0x%x", i, op->mem.align);
 				if (op->mem.lshift != 0)
 					add_str(&result, " ; operands[%u].mem.lshift: 0x%x", i, op->mem.lshift);
 

--- a/suite/cstest/src/capstone_test.c
+++ b/suite/cstest/src/capstone_test.c
@@ -243,8 +243,6 @@ void test_single_issue(csh *handle, cs_mode mode, char *line, int detail)
 	}
 
 	count = cs_disasm(*handle, code, size_byte, offset, 0, &insn);
-	free_strs(list_byte, size_byte);
-	free(code);
 	for (i = 0; i < count; ++i) {
 		tmp = (char *)malloc(strlen(insn[i].mnemonic) + strlen(insn[i].op_str) + 100);
 		strcpy(tmp, insn[i].mnemonic);
@@ -297,6 +295,7 @@ void test_single_issue(csh *handle, cs_mode mode, char *line, int detail)
 
 	cs_free(insn, count);
 	free_strs(list_part, size_part);
+	free_strs(list_byte, size_byte);
 	free(cs_result);
 	//	free_strs(list_part_cs_result, size_part_cs_result);
 	free_strs(list_part_issue_result, size_part_issue_result);

--- a/suite/cstest/src/capstone_test.c
+++ b/suite/cstest/src/capstone_test.c
@@ -236,6 +236,7 @@ void test_single_issue(csh *handle, cs_mode mode, char *line, int detail)
 		offset = 0;
 		list_byte = split(offset_opcode[0], ",", &size_byte);
 	}
+	free_strs(offset_opcode, size_offset_opcode);
 
 	code = (unsigned char *)malloc(sizeof(char) * size_byte);
 	for (i = 0; i < size_byte; ++i) {
@@ -243,6 +244,8 @@ void test_single_issue(csh *handle, cs_mode mode, char *line, int detail)
 	}
 
 	count = cs_disasm(*handle, code, size_byte, offset, 0, &insn);
+	free_strs(list_byte, size_byte);
+	free(code);
 	for (i = 0; i < count; ++i) {
 		tmp = (char *)malloc(strlen(insn[i].mnemonic) + strlen(insn[i].op_str) + 100);
 		strcpy(tmp, insn[i].mnemonic);
@@ -284,10 +287,10 @@ void test_single_issue(csh *handle, cs_mode mode, char *line, int detail)
 			fprintf(stderr, "[  ERROR   ] --- %s --- \"%s\" not in \"%s\"\n", list_part[0], list_part_issue_result[i], cs_result);
 			cs_free(insn, count);
 			free_strs(list_part, size_part);
-			free_strs(list_byte, size_byte);
 			free(cs_result);
 			//	free_strs(list_part_cs_result, size_part_cs_result);
 			free_strs(list_part_issue_result, size_part_issue_result);
+			free(tmptmp);
 			_fail(__FILE__, __LINE__);
 		}
 		free(tmptmp);
@@ -295,7 +298,6 @@ void test_single_issue(csh *handle, cs_mode mode, char *line, int detail)
 
 	cs_free(insn, count);
 	free_strs(list_part, size_part);
-	free_strs(list_byte, size_byte);
 	free(cs_result);
 	//	free_strs(list_part_cs_result, size_part_cs_result);
 	free_strs(list_part_issue_result, size_part_issue_result);

--- a/suite/cstest/src/capstone_test.c
+++ b/suite/cstest/src/capstone_test.c
@@ -243,6 +243,8 @@ void test_single_issue(csh *handle, cs_mode mode, char *line, int detail)
 	}
 
 	count = cs_disasm(*handle, code, size_byte, offset, 0, &insn);
+	free_strs(list_byte, size_byte);
+	free(code);
 	for (i = 0; i < count; ++i) {
 		tmp = (char *)malloc(strlen(insn[i].mnemonic) + strlen(insn[i].op_str) + 100);
 		strcpy(tmp, insn[i].mnemonic);
@@ -295,7 +297,6 @@ void test_single_issue(csh *handle, cs_mode mode, char *line, int detail)
 
 	cs_free(insn, count);
 	free_strs(list_part, size_part);
-	free_strs(list_byte, size_byte);
 	free(cs_result);
 	//	free_strs(list_part_cs_result, size_part_cs_result);
 	free_strs(list_part_issue_result, size_part_issue_result);

--- a/suite/cstest/src/capstone_test.c
+++ b/suite/cstest/src/capstone_test.c
@@ -85,6 +85,10 @@ void test_single_MC(csh *handle, int mc_mode, char *line)
 	// and laeds to wrong results.
 	cs_arch arch = ((struct cs_struct *)(uintptr_t)*handle)->arch;
 	if (arch != CS_ARCH_ARM) {
+		if (insn->detail) {
+			free(insn->detail);
+		}
+		free(insn);
 		cs_disasm(*handle, code, size_byte, offset, 0, &insn);
 
 		strcpy(tmp_noreg, insn[0].mnemonic);

--- a/suite/cstest/src/helper.c
+++ b/suite/cstest/src/helper.c
@@ -4,15 +4,12 @@
 
 #include "helper.h"
 
-char **split(char *str, char *delim, int *size)
+char **split(const char *str, const char *delim, int *size)
 {
-	char **result;
-	char *token, *src;
-	int cnt;
-
-	cnt = 0;
-	src = str;
-	result = NULL;
+	char **result = NULL;
+	char *token = NULL;
+	const char *src = str;
+	int cnt = 0;
 
 	while ((token = strstr(src, delim)) != NULL) {
 		result = (char **)realloc(result, sizeof(char *) * (cnt + 1));

--- a/suite/cstest/src/helper.c
+++ b/suite/cstest/src/helper.c
@@ -3,44 +3,34 @@
 
 
 #include "helper.h"
-#include <string.h>
 
-/// Splits a string into a list of strings, separated by the given delimeter.
-/// The last element in the list is always a duplicate of @str.
-/// @str is not freed.
-/// The number of elements in the list is written to @size
-char **split(char *str, const char *delim, int *size) {
-	// Count the number of delimeters in the string
-	uint32_t elem_cnt = 0;
-	uint32_t delim_len = strlen(delim);
-	char *split_at = NULL;
-	char *str_iter = str;
-	// Count delimeters
-	while ((split_at = strstr(str_iter, delim)) != NULL) {
-		str_iter = split_at + delim_len;
-		if (split_at != str && split_at == str + strlen(str) - delim_len) {
-			// Don't increment if the delimeter is at the very beginning or end of the string.
-			elem_cnt++;
-		}
-	}
-	uint32_t table_size = elem_cnt + 2; // Last element is the whole string
+char **split(char *str, char *delim, int *size)
+{
+	char **result;
+	char *token, *src;
+	int cnt;
 
-	char **list = calloc(table_size, sizeof(char*));
-	uint32_t count = 0;
-	while ((split_at = strstr(str_iter, delim)) != NULL) {
-		unsigned sub_len = (split_at - str_iter);
-		list[count] = calloc(sub_len + 1, sizeof(char));
-		memcpy(list[count], str_iter, sub_len);
-		count++;
-		str_iter += sub_len + strlen(delim);
+	cnt = 0;
+	src = str;
+	result = NULL;
+
+	while ((token = strstr(src, delim)) != NULL) {
+		result = (char **)realloc(result, sizeof(char *) * (cnt + 1));
+		result[cnt] = (char *)calloc(1, sizeof(char) * (int)(token - src + 10));
+		memcpy(result[cnt], src, token - src);
+		result[cnt][token - src] = '\0';
+		src = token + strlen(delim);
+		cnt ++;
 	}
 
-	if (strlen(str) > 0) {
-		list[count] = strdup(str);
-		count++;
+	if (strlen(src) > 0) {
+		result = (char **)realloc(result, sizeof(char *) * (cnt + 1));
+		result[cnt] = strdup(src);
+		cnt ++;
 	}
-	*size = count;
-	return list;
+
+	*size = cnt;
+	return result;
 }
 
 void print_strs(char **list_str, int size)

--- a/suite/cstest/src/helper.c
+++ b/suite/cstest/src/helper.c
@@ -3,34 +3,44 @@
 
 
 #include "helper.h"
+#include <string.h>
 
-char **split(char *str, char *delim, int *size)
-{
-	char **result;
-	char *token, *src;
-	int cnt;
+/// Splits a string into a list of strings, separated by the given delimeter.
+/// The last element in the list is always a duplicate of @str.
+/// @str is not freed.
+/// The number of elements in the list is written to @size
+char **split(char *str, const char *delim, int *size) {
+	// Count the number of delimeters in the string
+	uint32_t elem_cnt = 0;
+	uint32_t delim_len = strlen(delim);
+	char *split_at = NULL;
+	char *str_iter = str;
+	// Count delimeters
+	while ((split_at = strstr(str_iter, delim)) != NULL) {
+		str_iter = split_at + delim_len;
+		if (split_at != str && split_at == str + strlen(str) - delim_len) {
+			// Don't increment if the delimeter is at the very beginning or end of the string.
+			elem_cnt++;
+		}
+	}
+	uint32_t table_size = elem_cnt + 2; // Last element is the whole string
 
-	cnt = 0;
-	src = str;
-	result = NULL;
-
-	while ((token = strstr(src, delim)) != NULL) {
-		result = (char **)realloc(result, sizeof(char *) * (cnt + 1));
-		result[cnt] = (char *)calloc(1, sizeof(char) * (int)(token - src + 10));
-		memcpy(result[cnt], src, token - src);
-		result[cnt][token - src] = '\0';
-		src = token + strlen(delim);
-		cnt ++;
+	char **list = calloc(table_size, sizeof(char*));
+	uint32_t count = 0;
+	while ((split_at = strstr(str_iter, delim)) != NULL) {
+		unsigned sub_len = (split_at - str_iter);
+		list[count] = calloc(sub_len + 1, sizeof(char));
+		memcpy(list[count], str_iter, sub_len);
+		count++;
+		str_iter += sub_len + strlen(delim);
 	}
 
-	if (strlen(src) > 0) {
-		result = (char **)realloc(result, sizeof(char *) * (cnt + 1));
-		result[cnt] = strdup(src);
-		cnt ++;
+	if (strlen(str) > 0) {
+		list[count] = strdup(str);
+		count++;
 	}
-
-	*size = cnt;
-	return result;
+	*size = count;
+	return list;
 }
 
 void print_strs(char **list_str, int size)

--- a/suite/cstest/src/main.c
+++ b/suite/cstest/src/main.c
@@ -431,6 +431,11 @@ static void test_file(const char *filename)
 	printf("[!] Noted:\n[  ERROR   ] --- \"<capstone result>\" != \"<user result>\"\n");	
 	printf("\n\n");
 	free_strs(list_lines, size_lines);
+	for (int k = 0; tests && k < number_of_tests; k++) {
+		free((char *)tests[k].name);
+	}
+	free(tests);
+	free(content);
 }
 
 static void test_folder(const char *folder)

--- a/suite/fuzz/fuzz_diff.c
+++ b/suite/fuzz/fuzz_diff.c
@@ -179,7 +179,7 @@ int LLVMFuzzerReturnOneInput(const uint8_t *Data, size_t Size, char * AssemblyTe
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     csh handle;
-    cs_insn *insn;
+    cs_buffer *buffer;
     cs_err err;
     const uint8_t **Datap = &Data;
     size_t * Sizep = &Size;
@@ -216,11 +216,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         return 0;
     }
 
-    insn = cs_malloc(handle);
+    buffer = cs_buffer_new(1);
     Data++;
     Size--;
-    assert(insn);
-        if (cs_disasm_iter(handle, Datap, Sizep, &address, insn)) {
+    assert(buffer);
+        if (cs_disasm_iter(handle, Datap, Sizep, &address, buffer)) {
+            cs_insn *insn = buffer->insn;
             snprintf(CapstoneAssemblyText, 80, "\t%s\t%s", insn->mnemonic, insn->op_str);
             if (strcmp(CapstoneAssemblyText, LLVMAssemblyText) != 0) {
                 printf("capstone %s != llvm %s", CapstoneAssemblyText, LLVMAssemblyText);
@@ -230,7 +231,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
             printf("capstone failed with llvm %s", LLVMAssemblyText);
             abort();
         }
-    cs_free(insn, 1);
+    cs_buffer_free(buffer);
     cs_close(&handle);
 
     return 0;

--- a/suite/fuzz/fuzz_disasm.c
+++ b/suite/fuzz/fuzz_disasm.c
@@ -18,7 +18,7 @@ static FILE *outfile = NULL;
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     csh handle;
-    cs_insn *all_insn;
+    cs_buffer *buffer;
     cs_detail *detail;
     cs_err err;
     unsigned int i;
@@ -52,12 +52,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         cs_option(handle, CS_OPT_SYNTAX, CS_OPT_SYNTAX_ATT);
     }
 
+    buffer = cs_buffer_new(0);
     uint64_t address = 0x1000;
-    size_t count = cs_disasm(handle, Data+1, Size-1, address, 0, &all_insn);
+    size_t count = cs_disasm(handle, Data+1, Size-1, address, 0, buffer);
 
     if (count) {
         size_t j;
         unsigned int n;
+	cs_insn *all_insn = buffer->insn;
 
         for (j = 0; j < count; j++) {
             cs_insn *insn = &(all_insn[j]);
@@ -90,9 +92,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         }
 
         fprintf(outfile, "0x%"PRIx64":\n", all_insn[j-1].address + all_insn[j-1].size);
-        cs_free(all_insn, count);
     }
 
+    cs_buffer_free(buffer);
     cs_close(&handle);
 
     return 0;

--- a/suite/fuzz/fuzz_harness.c
+++ b/suite/fuzz/fuzz_harness.c
@@ -144,6 +144,7 @@ int main(int argc, char **argv)
 
   // Disassemble
   csh handle;
+  cs_buffer *buffer;
   cs_insn *all_insn;
   cs_detail *detail;
   cs_err err;
@@ -166,8 +167,10 @@ int main(int argc, char **argv)
 
   cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
+  buffer = cs_buffer_new(0);
   uint64_t address = 0x1000;
-  size_t count = cs_disasm(handle, buf_ptr, buf_ptr_size, address, 0, &all_insn);
+  size_t count = cs_disasm(handle, buf_ptr, buf_ptr_size, address, 0, buffer);
+  all_insn = buffer->insn;
 
   if (count) {
     size_t j;
@@ -208,7 +211,6 @@ int main(int argc, char **argv)
       }
     }
     printf("0x%"PRIx64":\n", all_insn[j-1].address + all_insn[j-1].size);
-    cs_free(all_insn, count);
   } else {
     printf("ERROR: Failed to disasm given code!\n");
   }
@@ -216,6 +218,7 @@ int main(int argc, char **argv)
   printf("\n");
 
   free(buf);
+  cs_buffer_free(buffer);
   cs_close(&handle);
 
   return 0;

--- a/suite/run_invalid_cstool.sh
+++ b/suite/run_invalid_cstool.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -x
 
 cstool -d x64 0x4 | grep "ERROR: invalid assembly code" &&
 cstool -d arm 0x1 | grep "ERROR: invalid assembly code" &&

--- a/suite/run_invalid_cstool.sh
+++ b/suite/run_invalid_cstool.sh
@@ -27,3 +27,5 @@ cstool -d riscv64 0x1 | grep "ERROR: invalid assembly code" &&
 cstool -d sh 0x1 | grep "ERROR: invalid assembly code" &&
 cstool -d tc162 0x1 | grep "ERROR: invalid assembly code"
 
+# One successful disassembly
+cstool -d x64 0xc5,0xca,0x58,0xd4

--- a/tests/cs_details/issue.cs
+++ b/tests/cs_details/issue.cs
@@ -130,7 +130,7 @@
 
 !# issue 0 ARM operand groups 0xa4,0xf9,0x6d,0x0e == vld3.16 {d0[], d2[], d4[]}, [r4]! ;
 !# CS_ARCH_ARM, CS_MODE_THUMB, CS_OPT_DETAIL
-0xa4,0xf9,0x6d,0x0e == vld3.16 {d0[], d2[], d4[]}, [r4]! ; op_count: 4 ; operands[0].type: REG = d0 ; operands[0].access: WRITE ; operands[1].type: REG = d2 ; operands[1].access: WRITE ; operands[2].type: REG = d4 ; operands[2].access: WRITE ; operands[3].type: MEM ; operands[3].mem.index: REG = r4 ; operands[3].access: READ ; Write-back: True ; Registers read: r4 ; Registers modified: r4 d0 d2 d4
+0xa4,0xf9,0x6d,0x0e == vld3.16 {d0[], d2[], d4[]}, [r4]! ; op_count: 4 ; operands[0].type: REG = d0 ; operands[0].access: WRITE ; operands[1].type: REG = d2 ; operands[1].access: WRITE ; operands[2].type: REG = d4 ; operands[2].access: WRITE ; operands[3].type: MEM ; operands[3].mem.base: REG = r4 ; operands[3].access: READ | WRITE ; Write-back: True ; Registers read: r4 ; Registers modified: r4 d0 d2 d4
 
 !# issue 0 ARM operand groups 0x0d,0x50,0x66,0xe4 == strbt r5, [r6], #-13 ;
 !# CS_ARCH_ARM, CS_MODE_ARM, CS_OPT_DETAIL
@@ -166,7 +166,7 @@
 
 !# issue 0 ARM operand groups 0xa4,0xf9,0xed,0x0b == vld4.32 {d0[1], d2[1], d4[1], d6[1]}, [r4:128]! ;
 !# CS_ARCH_ARM, CS_MODE_THUMB, CS_OPT_DETAIL
-0xa4,0xf9,0xed,0x0b == vld4.32 {d0[1], d2[1], d4[1], d6[1]}, [r4:0x80]! ; op_count: 5 ; operands[0].type: REG = d0 ; operands[0].neon_lane = 1 ; operands[0].access: READ | WRITE ; operands[1].type: REG = d2 ; operands[1].neon_lane = 1 ; operands[1].access: READ | WRITE ; operands[2].type: REG = d4 ; operands[2].neon_lane = 1 ; operands[2].access: READ | WRITE ; operands[3].type: REG = d6 ; operands[3].neon_lane = 1 ; operands[3].access: READ | WRITE ; operands[4].type: MEM ; operands[4].mem.index: REG = r4 ; operands[4].mem.disp: 0x80 ; operands[4].access: READ ; Write-back: True ; Registers read: d0 d2 d4 d6 r4 ; Registers modified: r4 d0 d2 d4 d6
+0xa4,0xf9,0xed,0x0b == vld4.32 {d0[1], d2[1], d4[1], d6[1]}, [r4:0x80]! ; op_count: 5 ; operands[0].type: REG = d0 ; operands[0].neon_lane = 1 ; operands[0].access: READ | WRITE ; operands[1].type: REG = d2 ; operands[1].neon_lane = 1 ; operands[1].access: READ | WRITE ; operands[2].type: REG = d4 ; operands[2].neon_lane = 1 ; operands[2].access: READ | WRITE ; operands[3].type: REG = d6 ; operands[3].neon_lane = 1 ; operands[3].access: READ | WRITE ; operands[4].type: MEM ; operands[4].mem.base: REG = r4 ; operands[4].mem.align: 0x80 ; operands[4].access: READ | WRITE ; Write-back: True ; Registers read: d0 d2 d4 d6 r4 ; Registers modified: r4 d0 d2 d4 d6
 
 !# issue 0 ARM operand groups 0x42,0x03,0xb0,0xf3 == aesd.8 q0, q1 ;
 !# CS_ARCH_ARM, CS_MODE_ARM | CS_MODE_V8, CS_OPT_DETAIL
@@ -202,5 +202,5 @@
 
 !# issue 0 ARM operand groups 0xef,0xf3,0x11,0x85 == ldrhi pc, [r1, #-0x3ef]
 !# CS_ARCH_ARM, CS_MODE_ARM, CS_OPT_DETAIL
-0xef,0xf3,0x11,0x85 == ldrhi pc, [r1, #-0x3ef] ; op_count: 2 ; operands[0].type: REG = r15 ; operands[0].access: WRITE ; operands[1].type: MEM ; operands[1].mem.base: REG = r1 ; operands[1].mem.disp: 0x3ef ; operands[1].access: READ ; Code condition: 8 ; Registers read: cpsr r1 ; Registers modified: r15 ; Groups: IsARM
+0xef,0xf3,0x11,0x85 == ldrhi pc, [r1, #-0x3ef] ; op_count: 2 ; operands[0].type: REG = r15 ; operands[0].access: WRITE ; operands[1].type: MEM ; operands[1].mem.base: REG = r1 ; operands[1].mem.disp: 0x3ef ; operands[1].access: READ ; Code condition: 8 ; Registers read: cpsr r1 ; Registers modified: r15 ; Groups: IsARM jump
 

--- a/tests/test_aarch64.c
+++ b/tests/test_aarch64.c
@@ -288,7 +288,7 @@ static void test()
 	};
 
 	uint64_t address = 0x2c;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -301,9 +301,11 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -315,9 +317,6 @@ static void test()
 				print_insn_detail(&insn[j]);
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -328,6 +327,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_alpha.c
+++ b/tests/test_alpha.c
@@ -85,7 +85,7 @@ static void test()
 	};
 
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -100,10 +100,12 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
+		buffer = cs_buffer_new(0);
 		count = cs_disasm(handle, platforms[i].code, platforms[i].size,
-				  address, 0, &insn);
+				  address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -119,9 +121,6 @@ static void test()
 			}
 			printf("0x%" PRIx64 ":\n",
 			       insn[j - 1].address + insn[j - 1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -132,6 +131,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_arm.c
+++ b/tests/test_arm.c
@@ -279,7 +279,7 @@ static void test()
 	};
 
 	uint64_t address = 0x80001000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -295,9 +295,12 @@ static void test()
 		if (platforms[i].syntax)
 			cs_option(handle, CS_OPT_SYNTAX, platforms[i].syntax);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
+
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
 			print_string_hex("Code:", platforms[i].code, platforms[i].size);
@@ -308,9 +311,6 @@ static void test()
 				print_insn_detail(handle, &insn[j]);
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -321,6 +321,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_basic.c
+++ b/tests/test_basic.c
@@ -424,7 +424,7 @@ static void test()
 
 	csh handle;
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 	cs_err err;
@@ -441,9 +441,11 @@ static void test()
 		if (platforms[i].opt_type)
 			cs_option(handle, platforms[i].opt_type, platforms[i].opt_value);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			print_string_hex(platforms[i].code, platforms[i].size);
 			printf("Disasm:\n");
@@ -455,9 +457,6 @@ static void test()
 
 			// print out the next offset, after the last insn
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -468,6 +467,9 @@ static void test()
 
 		printf("\n");
 
+
+		// free memory allocated by cs_buffer_new()
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_bpf.c
+++ b/tests/test_bpf.c
@@ -140,7 +140,7 @@ static void test()
 		},
 	};
 	uint64_t address = 0x0;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -153,9 +153,12 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
+
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
 			print_string_hex("Code:", platforms[i].code, platforms[i].size);
@@ -165,9 +168,6 @@ static void test()
 				printf("0x%" PRIx64 ":\t%s\t%s\n", insn[j].address, insn[j].mnemonic, insn[j].op_str);
 				print_insn_detail(handle, &insn[j]);
 			}
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -176,6 +176,7 @@ static void test()
 			abort();
 		}
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_customized_mnem.c
+++ b/tests/test_customized_mnem.c
@@ -26,19 +26,20 @@ static void print_string_hex(unsigned char *str, size_t len)
 // Print one instruction
 static void print_insn(csh handle)
 {
-	cs_insn *insn;
+	cs_buffer *buffer;
 	size_t count;
 	
-	count = cs_disasm(handle, (const uint8_t *)X86_CODE32, sizeof(X86_CODE32) - 1, 0x1000, 1, &insn);
+	buffer = cs_buffer_new(0);
+	count = cs_disasm(handle, (const uint8_t *)X86_CODE32, sizeof(X86_CODE32) - 1, 0x1000, 1, buffer);
 	if (count) {
+		cs_insn *insn = buffer->insn;
 		print_string_hex((unsigned char *)X86_CODE32, sizeof(X86_CODE32) - 1);
 		printf("\t%s\t%s\n", insn[0].mnemonic, insn[0].op_str); 
-		// Free memory allocated by cs_disasm()
-		cs_free(insn, count);
 	} else {
 		printf("ERROR: Failed to disasm given code!\n");
 		abort();
 	}
+	cs_buffer_free(buffer);
 }
 
 static void test()

--- a/tests/test_detail.c
+++ b/tests/test_detail.c
@@ -341,8 +341,7 @@ static void test()
 
 	csh handle;
 	uint64_t address = 0x1000;
-	cs_insn *all_insn;
-	cs_detail *detail;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 	cs_err err;
@@ -361,10 +360,13 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &all_insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
 			int n;
+			cs_insn *all_insn = buffer->insn;
+			cs_detail *detail;
 
 			print_string_hex(platforms[i].code, platforms[i].size);
 			printf("Disasm:\n");
@@ -407,9 +409,6 @@ static void test()
 
 			// print out the next offset, after the last insn
 			printf("0x%" PRIx64 ":\n", all_insn[j-1].address + all_insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(all_insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -420,6 +419,9 @@ static void test()
 
 		printf("\n");
 
+
+		// free memory allocated by cs_buffer_new()
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_evm.c
+++ b/tests/test_evm.c
@@ -74,7 +74,7 @@ static void test()
 	};
 
 	uint64_t address = 0x80001000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -87,9 +87,12 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
+
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
 			print_string_hex("Code:", platforms[i].code, platforms[i].size);
@@ -100,9 +103,6 @@ static void test()
 				print_insn_detail(handle, &insn[j]);
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -113,6 +113,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_hppa.c
+++ b/tests/test_hppa.c
@@ -127,7 +127,7 @@ static void test()
 	};
 
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -142,10 +142,12 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
+		buffer = cs_buffer_new(0);
 		count = cs_disasm(handle, platforms[i].code, platforms[i].size,
-				  address, 0, &insn);
+				  address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -161,9 +163,6 @@ static void test()
 			}
 			printf("0x%" PRIx64 ":\n",
 			       insn[j - 1].address + insn[j - 1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -174,6 +173,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_iter.c
+++ b/tests/test_iter.c
@@ -1,7 +1,7 @@
 /* Capstone Disassembler Engine */
 /* By Nguyen Anh Quynh <aquynh@gmail.com>, 2013-2019 */
 
-// This sample code demonstrates the APIs cs_malloc() & cs_disasm_iter().
+// This sample code demonstrates the APIs cs_buffer_new() & cs_disasm_iter().
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -324,7 +324,7 @@ struct platform platforms[] = {
 
 	csh handle;
 	uint64_t address;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	cs_detail *detail;
 	int i;
 	cs_err err;
@@ -346,7 +346,7 @@ struct platform platforms[] = {
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
 		// allocate memory for the cache to be used by cs_disasm_iter()
-		insn = cs_malloc(handle);
+		buffer = cs_buffer_new(1);
 
 		print_string_hex(platforms[i].code, platforms[i].size);
 		printf("Disasm:\n");
@@ -354,8 +354,9 @@ struct platform platforms[] = {
 		address = 0x1000;
 		code = platforms[i].code;
 		size = platforms[i].size;
-		while(cs_disasm_iter(handle, &code, &size, &address, insn)) {
+		while(cs_disasm_iter(handle, &code, &size, &address, buffer)) {
 			int n;
+			cs_insn *insn = buffer->insn;
 
 			printf("0x%" PRIx64 ":\t%s\t\t%s // insn-ID: %u, insn-mnem: %s\n",
 					insn->address, insn->mnemonic, insn->op_str,
@@ -393,9 +394,7 @@ struct platform platforms[] = {
 
 		printf("\n");
 
-		// free memory allocated by cs_malloc()
-		cs_free(insn, 1);
-
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_m680x.c
+++ b/tests/test_m680x.c
@@ -361,7 +361,7 @@ static void test()
 			for (j = 0; j < count; j++) {
 				int slen;
 				printf("0x%04x: ", (uint16_t)insn[j].address);
-				print_string_hex_short(insn[j].bytes,
+				print_string_hex_short(CS_INSN_BYTES(&insn[j]),
 					insn[j].size);
 				printf("%.*s", 1 + ((5 - insn[j].size) * 2),
 					nine_spaces);

--- a/tests/test_m680x.c
+++ b/tests/test_m680x.c
@@ -322,7 +322,7 @@ static void test()
 
 	uint64_t address = 0x1000;
 	csh handle;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 	const char *nine_spaces = "         ";
@@ -344,11 +344,13 @@ static void test()
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 #endif
 
+		buffer = cs_buffer_new(0);
 		count = cs_disasm(handle, platforms[i].code, platforms[i].size,
-				address, 0, &insn);
+				address, 0, buffer);
 
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("********************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -371,9 +373,6 @@ static void test()
 				print_insn_detail(handle, &insn[j]);
 #endif
 			}
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		}
 		else {
 			printf("********************\n");
@@ -384,6 +383,7 @@ static void test()
 			abort();
 		}
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_m68k.c
+++ b/tests/test_m68k.c
@@ -168,7 +168,7 @@ static void test()
 	};
 
 	uint64_t address = 0x01000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -181,9 +181,11 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -197,9 +199,6 @@ static void test()
 				print_insn_detail(&insn[j]);
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -210,6 +209,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_mips.c
+++ b/tests/test_mips.c
@@ -123,7 +123,7 @@ static void test()
 	};
 
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -136,9 +136,11 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -150,9 +152,6 @@ static void test()
 				print_insn_detail(&insn[j]);
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -163,6 +162,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_mos65xx.c
+++ b/tests/test_mos65xx.c
@@ -176,7 +176,7 @@ static void test()
 	};
 
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -190,10 +190,12 @@ static void test()
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 		cs_option(handle, CS_OPT_SYNTAX, CS_OPT_SYNTAX_MOTOROLA);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -206,9 +208,6 @@ static void test()
 				puts("");
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -219,6 +218,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_ppc.c
+++ b/tests/test_ppc.c
@@ -126,7 +126,7 @@ static void test()
 	};
 
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -139,9 +139,11 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -153,9 +155,6 @@ static void test()
 				print_insn_detail(&insn[j]);
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -166,6 +165,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_riscv.c
+++ b/tests/test_riscv.c
@@ -101,7 +101,7 @@ static void test()
 	};
 	
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -116,9 +116,11 @@ static void test()
 		//cs_option(handle, CS_OPT_DETAIL, CS_OPT_OFF); 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -130,9 +132,6 @@ static void test()
 				print_insn_detail(&insn[j]);
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -142,6 +141,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_sh.c
+++ b/tests/test_sh.c
@@ -188,7 +188,7 @@ static void test()
 
 	uint64_t address = 0x80000000;
 	csh handle;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -209,11 +209,13 @@ static void test()
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 #endif
 
+		buffer = cs_buffer_new(0);
 		count = cs_disasm(handle, platforms[i].code, platforms[i].size,
-				address, 0, &insn);
+				address, 0, buffer);
 
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -228,9 +230,6 @@ static void test()
 #endif
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		}
 		else {
 			printf("****************\n");
@@ -241,6 +240,7 @@ static void test()
 			abort();
 		}
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_skipdata.c
+++ b/tests/test_skipdata.c
@@ -104,7 +104,7 @@ static void test()
 
 	csh handle;
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	cs_err err;
 	int i;
 	size_t count;
@@ -125,9 +125,11 @@ static void test()
 		cs_option(handle, CS_OPT_SKIPDATA, CS_OPT_ON);
 		cs_option(handle, platforms[i].opt_skipdata, platforms[i].skipdata);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			print_string_hex(platforms[i].code, platforms[i].size);
 			printf("Disasm:\n");
@@ -139,9 +141,6 @@ static void test()
 
 			// print out the next offset, after the last insn
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -152,6 +151,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_sparc.c
+++ b/tests/test_sparc.c
@@ -100,7 +100,7 @@ static void test()
 	};
 
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -113,9 +113,11 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -127,9 +129,6 @@ static void test()
 				print_insn_detail(&insn[j]);
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -140,6 +139,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_systemz.c
+++ b/tests/test_systemz.c
@@ -93,7 +93,7 @@ static void test()
 	};
 
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -106,9 +106,11 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -120,9 +122,6 @@ static void test()
 				print_insn_detail(&insn[j]);
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -133,6 +132,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_tms320c64x.c
+++ b/tests/test_tms320c64x.c
@@ -142,7 +142,7 @@ static void test()
 	};
 
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -155,9 +155,11 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -169,9 +171,6 @@ static void test()
 				print_insn_detail(&insn[j]);
 			}
 			printf("0x%"PRIx64":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -181,6 +180,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_tricore.c
+++ b/tests/test_tricore.c
@@ -88,7 +88,7 @@ static void test()
 	};
 
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -103,10 +103,12 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
+		buffer = cs_buffer_new(0);
 		count = cs_disasm(handle, platforms[i].code, platforms[i].size,
-				  address, 0, &insn);
+				  address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -122,9 +124,6 @@ static void test()
 			}
 			printf("0x%" PRIx64 ":\n",
 			       insn[j - 1].address + insn[j - 1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -133,6 +132,7 @@ static void test()
 			printf("ERROR: Failed to disasm given code!\n");
 		}
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_wasm.c
+++ b/tests/test_wasm.c
@@ -108,7 +108,7 @@ static void test()
 	};
 
 	uint64_t address = 0xffff;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	size_t count;
 	int i;
 
@@ -121,9 +121,12 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
+
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
 			print_string_hex("Code: ", platforms[i].code, platforms[i].size);
@@ -134,9 +137,6 @@ static void test()
 				print_insn_detail(handle, &insn[j]);
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -147,6 +147,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_x86.c
+++ b/tests/test_x86.c
@@ -409,7 +409,7 @@ static void test()
 	};
 
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -425,9 +425,11 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -439,9 +441,6 @@ static void test()
 				print_insn_detail(handle, platforms[i].mode, &insn[j]);
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -452,6 +451,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }

--- a/tests/test_xcore.c
+++ b/tests/test_xcore.c
@@ -88,7 +88,7 @@ static void test()
 	};
 
 	uint64_t address = 0x1000;
-	cs_insn *insn;
+	cs_buffer *buffer;
 	int i;
 	size_t count;
 
@@ -101,9 +101,11 @@ static void test()
 
 		cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
-		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, &insn);
+		buffer = cs_buffer_new(0);
+		count = cs_disasm(handle, platforms[i].code, platforms[i].size, address, 0, buffer);
 		if (count) {
 			size_t j;
+			cs_insn *insn = buffer->insn;
 
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -115,9 +117,6 @@ static void test()
 				print_insn_detail(&insn[j]);
 			}
 			printf("0x%" PRIx64 ":\n", insn[j-1].address + insn[j-1].size);
-
-			// free memory allocated by cs_disasm()
-			cs_free(insn, count);
 		} else {
 			printf("****************\n");
 			printf("Platform: %s\n", platforms[i].comment);
@@ -128,6 +127,7 @@ static void test()
 
 		printf("\n");
 
+		cs_buffer_free(buffer);
 		cs_close(&handle);
 	}
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Using fixed size arrays for instruction bytes is very good for performance and simplicity but it has some drawbacks. It can not be used for achitectures with instructions longer than fixed size array for instruction bytes. But big arrays is not practical for architecutres with small instructions.

This patch changes `cs_insn.bytes` into an union of small fixed array for small instructions and a pointer to dynamically allocated memory for very long instructions. 

The size of the fixed array is chosen to be 16 bytes based on x86 instruction lengths.

**Benchmarks**

`old` is https://github.com/capstone-engine/capstone/pull/2367.
`libc.so` is a standard C library from my amd64 machine.

```
❯ hyperfine -N -r5 ./old/test_iter_benchmark ./new/test_iter_benchmark                                                                                                                                         
Benchmark 1: ./old/test_iter_benchmark
  Time (mean ± σ):     10.830 s ±  0.075 s    [User: 10.771 s, System: 0.004 s]
  Range (min … max):   10.706 s … 10.884 s    5 runs
 
Benchmark 2: ./new/test_iter_benchmark
  Time (mean ± σ):     10.941 s ±  0.146 s    [User: 10.927 s, System: 0.003 s]
  Range (min … max):   10.722 s … 11.060 s    5 runs
 
Summary
  './old/test_iter_benchmark' ran
    1.01 ± 0.02 times faster than './new/test_iter_benchmark'

❯ ARGS="10 0x028800 0x1517dd libc.so"; hyperfine -N "./old/test_file_benchmark $ARGS" "./new/test_file_benchmark $ARGS"                                                                                        
Benchmark 1: ./old/test_file_benchmark 10 0x028800 0x1517dd libc.so
  Time (mean ± σ):      2.392 s ±  0.091 s    [User: 2.354 s, System: 0.003 s]
  Range (min … max):    2.286 s …  2.621 s    10 runs
 
Benchmark 2: ./new/test_file_benchmark 10 0x028800 0x1517dd libc.so
  Time (mean ± σ):      2.414 s ±  0.039 s    [User: 2.404 s, System: 0.004 s]
  Range (min … max):    2.342 s …  2.467 s    10 runs
 
Summary
  './old/test_file_benchmark 10 0x028800 0x1517dd libc.so' ran
    1.01 ± 0.04 times faster than './new/test_file_benchmark 10 0x028800 0x1517dd libc.so'
```

If `bytes_arr` size is 8 bytes.

```
❯ hyperfine -N -r5 ./old/test_iter_benchmark ./new/test_iter_benchmark
Benchmark 1: ./old/test_iter_benchmark
  Time (mean ± σ):     10.745 s ±  0.132 s    [User: 10.721 s, System: 0.006 s]
  Range (min … max):   10.643 s … 10.967 s    5 runs
 
Benchmark 2: ./new/test_iter_benchmark
  Time (mean ± σ):     10.814 s ±  0.192 s    [User: 10.786 s, System: 0.007 s]
  Range (min … max):   10.566 s … 11.064 s    5 runs
 
Summary
  './old/test_iter_benchmark' ran
    1.01 ± 0.02 times faster than './new/test_iter_benchmark'

❯ ARGS="10 0x028800 0x1517dd libc.so"; hyperfine -N "./old/test_file_benchmark $ARGS" "./new/test_file_benchmark $ARGS"                                                         
Benchmark 1: ./old/test_file_benchmark 10 0x028800 0x1517dd libc.so
  Time (mean ± σ):      2.376 s ±  0.093 s    [User: 2.369 s, System: 0.004 s]
  Range (min … max):    2.301 s …  2.622 s    10 runs
 
Benchmark 2: ./new/test_file_benchmark 10 0x028800 0x1517dd libc.so
  Time (mean ± σ):      2.422 s ±  0.042 s    [User: 2.414 s, System: 0.003 s]
  Range (min … max):    2.372 s …  2.513 s    10 runs
 
Summary
  './old/test_file_benchmark 10 0x028800 0x1517dd libc.so' ran
    1.02 ± 0.04 times faster than './new/test_file_benchmark 10 0x028800 0x1517dd libc.so'
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Update bindings and user software.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
