### PR TITLE
Constify three ARM and AArch64 variables

### DIFF
--- a/arch/AArch64/AArch64Mapping.c
+++ b/arch/AArch64/AArch64Mapping.c
@@ -20,11 +20,11 @@
 #include "AArch64Mapping.h"
 
 #ifndef CAPSTONE_DIET
-static aarch64_reg aarch64_flag_regs[] = {
+static const aarch64_reg aarch64_flag_regs[] = {
 	AARCH64_REG_NZCV,
 };
 
-static aarch64_sysreg aarch64_flag_sys_regs[] = {
+static const aarch64_sysreg aarch64_flag_sys_regs[] = {
 	AARCH64_SYSREG_NZCV, AARCH64_SYSREG_PMOVSCLR_EL0,
 	AARCH64_SYSREG_PMOVSSET_EL0, AARCH64_SYSREG_SPMOVSCLR_EL0,
 	AARCH64_SYSREG_SPMOVSSET_EL0

--- a/arch/ARM/ARMMapping.c
+++ b/arch/ARM/ARMMapping.c
@@ -618,7 +618,7 @@ static const char *const insn_name_maps[] = {
 #endif
 
 #ifndef CAPSTONE_DIET
-static arm_reg arm_flag_regs[] = {
+static const arm_reg arm_flag_regs[] = {
 	ARM_REG_APSR,	      ARM_REG_APSR_NZCV, ARM_REG_CPSR,
 	ARM_REG_FPCXTNS,      ARM_REG_FPCXTS,	 ARM_REG_FPEXC,
 	ARM_REG_FPINST,	      ARM_REG_FPSCR,	 ARM_REG_FPSCR_NZCV,


### PR DESCRIPTION
Three variables have crept into .data that should be read-only.
Fix them.