### PR TITLE
[PPC] Fix #2401 - incorrect operands in disassembled instructions

### DIFF
--- a/arch/PowerPC/PPCMapping.c
+++ b/arch/PowerPC/PPCMapping.c
@@ -639,7 +639,7 @@ void PPC_insert_detail_op_imm_at(MCInst *MI, unsigned index, int64_t Val,
 
 	cs_ppc_op *ops = PPC_get_detail(MI)->operands;
 	int i = PPC_get_detail(MI)->op_count - 1;
-	for (; i >= 0; --i) {
+	for (; i >= index; --i) {
 		ops[i + 1] = ops[i];
 		if (i == index)
 			break;

--- a/tests/cs_details/issue.cs
+++ b/tests/cs_details/issue.cs
@@ -204,6 +204,18 @@
 !# CS_ARCH_ARM, CS_MODE_ARM, CS_OPT_DETAIL
 0xef,0xf3,0x11,0x85 == ldrhi pc, [r1, #-0x3ef] ; op_count: 2 ; operands[0].type: REG = r15 ; operands[0].access: WRITE ; operands[1].type: MEM ; operands[1].mem.base: REG = r1 ; operands[1].mem.disp: 0x3ef ; operands[1].access: READ ; Code condition: 8 ; Registers read: cpsr r1 ; Registers modified: r15 ; Groups: IsARM jump
 
+!# issue 0 PPC operand groups 0x54,0x22,0xe0,0x06 == slwi r2, r1, 0x1c
+!# CS_ARCH_PPC, CS_MODE_32 | CS_MODE_BIG_ENDIAN, CS_OPT_DETAIL
+0x54,0x22,0xe0,0x06 == slwi r2, r1, 0x1c ; op_count: 3 ; operands[0].type: REG = r2 ; operands[1].type: REG = r1 ; operands[2].type: IMM = 0x1c
+
+!# issue 0 PPC operand groups 0x54,0x66,0xf0,0xbe == srwi r6, r3, 2
+!# CS_ARCH_PPC, CS_MODE_32 | CS_MODE_BIG_ENDIAN, CS_OPT_DETAIL
+0x54,0x66,0xf0,0xbe == srwi r6, r3, 2 ; op_count: 3 ; operands[0].type: REG = r6 ; operands[1].type: REG = r3 ; operands[2].type: IMM = 0x2
+
+!# issue 0 PPC operand groups 0x78,0x62,0x26,0xe4 == sldi r2, r3, 4
+!# CS_ARCH_PPC, CS_MODE_32 | CS_MODE_BIG_ENDIAN, CS_OPT_DETAIL
+0x78,0x62,0x26,0xe4 == sldi r2, r3, 4 ; op_count: 3 ; operands[0].type: REG = r2 ; operands[1].type: REG = r3 ; operands[2].type: IMM = 0x4
+
 !# issue 0 RISCV operand groups 0x37,0x34,0x00,0x00 == lui s0, 3
 !# CS_ARCH_RISCV, CS_MODE_RISCV32, CS_OPT_DETAIL
 0x37,0x34,0x00,0x00 == lui s0, 3 ; op_count: 2 ; operands[0].type: REG = s0 ; operands[0].access: WRITE ; operands[1].type: IMM = 0x3 ; operands[1].access: READ


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Disassembling the "slwi", "srwi" and "rldicr" PowerPC instructions with the "-d" option displays the wrong operands in detailed information. This is due to an incorrect break condition in [PPC_insert_detail_op_imm_at()](https://github.com/capstone-engine/capstone/blob/next/arch/PowerPC/PPCMapping.c#L642)

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan**

- Before applying the fix:
```sh
$ cstool -d ppc32be 786226e4
 0  78 62 26 e4  sldi   r2, r3, 4
        ID: 868 (rldicr)
        Is alias: 2329 (sldi) with ALIAS operand set
        op_count: 3
                operands[0].type: REG = r2
                operands[0].access: WRITE
                operands[1].type: REG = r2
                operands[1].access: WRITE
                operands[2].type: IMM = 0x4
                operands[2].access: READ
```

- After applying the fix:
```sh
$ cstool -d ppc32be 786226e4
 0  78 62 26 e4  sldi   r2, r3, 4
        ID: 868 (rldicr)
        Is alias: 2329 (sldi) with ALIAS operand set
        op_count: 3
                operands[0].type: REG = r2
                operands[0].access: WRITE
                operands[1].type: REG = r3
                operands[1].access: READ
                operands[2].type: IMM = 0x4
                operands[2].access: READ
```

Please let me know if this should be added in the testsuite too. I am not sure how one does that.

**Closing issues**

closes #2401 