### PR TITLE
[v5] Fix typo in AArch64 Python binding

### DIFF
--- a/bindings/python/capstone/arm64.py
+++ b/bindings/python/capstone/arm64.py
@@ -13,7 +13,7 @@ class Arm64OpMem(ctypes.Structure):
     )
 
 class Arm64OpSmeIndex(ctypes.Structure):
-    _fileds_ = (
+    _fields_ = (
         ('reg', ctypes.c_uint),
         ('base', ctypes.c_uint),
         ('disp', ctypes.c_int32),


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Replace typo "fileds" with "fields" in Python binding arm64.py.
...

**Test plan**

No need?

...

**Closing issues**

Closes issue #2411

...
