### PR TITLE
[next] Fix typo in AArch64 Python binding

### DIFF
--- a/bindings/python/capstone/aarch64.py
+++ b/bindings/python/capstone/aarch64.py
@@ -25,7 +25,7 @@ class AArch64SMESliceOffset(ctypes.Union):
     )
 
 class AArch64OpSme(ctypes.Structure):
-    _fileds_ = (
+    _fields_ = (
         ('type', ctypes.c_uint),
         ('tile', ctypes.c_uint),
         ('slice_reg', ctypes.c_uint),
@@ -35,7 +35,7 @@ class AArch64OpSme(ctypes.Structure):
     )
 
 class AArch64OpPred(ctypes.Structure):
-    _fileds_ = (
+    _fields_ = (
         ('reg', ctypes.c_uint),
         ('vec_select', ctypes.c_uint),
         ('imm_index', ctypes.c_int),


### PR DESCRIPTION
**Your checklist for this pull request**

- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Replace typo "fileds" with "fields" in Python binding aarch64.py.
...

**Test plan**

No need?

...

**Closing issues**

(Along with #2412) Closes issue #2411 

...