### PR TITLE
[next] Fix unintended zero set in Sparc printInst

### DIFF
--- a/arch/Sparc/SparcInstPrinter.c
+++ b/arch/Sparc/SparcInstPrinter.c
@@ -354,9 +354,9 @@ void Sparc_printInst(MCInst *MI, SStream *O, void *Info)
 	mnem = printAliasInstr(MI, O, Info);
 	if (mnem) {
 		// fixup instruction id due to the change in alias instruction
-		unsigned cpy_len = sizeof(instr) < strlen(mnem) ? sizeof(instr) : strlen(mnem);
+		unsigned cpy_len = sizeof(instr) - 1 < strlen(mnem) ? sizeof(instr) - 1 : strlen(mnem);
 		memcpy(instr, mnem, cpy_len);
-		instr[cpy_len - 1] = '\0';
+		instr[cpy_len] = '\0';
 		// does this contains hint with a coma?
 		p = strchr(instr, ',');
 		if (p)

--- a/suite/cstest/issues.cs
+++ b/suite/cstest/issues.cs
@@ -1126,3 +1126,7 @@
 !# issue 2268
 !# CS_ARCH_AARCH64, CS_MODE_ARM, CS_OPT_DETAIL
 0x0: 0x6a,0xd9,0xf8,0x7e == fcmle h10, h11, #0.0 ; operands[2].subtype EXACTFPIMM = 0
+
+!# issue 2419
+!# CS_ARCH_SPARC, CS_MODE_BIG_ENDIAN, CS_OPT_DETAIL
+0x0: 0x12,0xbf,0xff,0xff == bne -4 ; Code condition: 265


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

The null byte should be set after the mnemonic string instead of overwriting the last byte of it.

...

**Test plan**

Updated `suite/cs_test/issues.cs` with a Sparc jump with condition instruction and confirmed `./build/cstest -f ./issues.cs` failed without the fix.

...

**Closing issues**

Fixes #2419 (along with #2420)

...
