### PR TITLE
[v5][arm] Consider SpecRegRBit on setting SYSREG

### DIFF
--- a/arch/ARM/ARMInstPrinter.c
+++ b/arch/ARM/ARMInstPrinter.c
@@ -1805,22 +1805,22 @@ static void printMSRMaskOperand(MCInst *MI, unsigned OpNum, SStream *O)
 
 		if (Mask & 8) {
 			SStream_concat0(O, "f");
-			reg += ARM_SYSREG_SPSR_F;
+			reg += SpecRegRBit ? ARM_SYSREG_SPSR_F : ARM_SYSREG_CPSR_F;
 		}
 
 		if (Mask & 4) {
 			SStream_concat0(O, "s");
-			reg += ARM_SYSREG_SPSR_S;
+			reg += SpecRegRBit ? ARM_SYSREG_SPSR_S : ARM_SYSREG_CPSR_S;
 		}
 
 		if (Mask & 2) {
 			SStream_concat0(O, "x");
-			reg += ARM_SYSREG_SPSR_X;
+			reg += SpecRegRBit ? ARM_SYSREG_SPSR_X : ARM_SYSREG_CPSR_X;
 		}
 
 		if (Mask & 1) {
 			SStream_concat0(O, "c");
-			reg += ARM_SYSREG_SPSR_C;
+			reg += SpecRegRBit ? ARM_SYSREG_SPSR_C : ARM_SYSREG_CPSR_C;
 		}
 
 		ARM_addSysReg(MI, reg);

--- a/suite/cstest/issues.cs
+++ b/suite/cstest/issues.cs
@@ -1058,3 +1058,7 @@
 !# issue 2419
 !# CS_ARCH_SPARC, CS_MODE_BIG_ENDIAN, CS_OPT_DETAIL
 0x0: 0x12,0xbf,0xff,0xff == bne -4 ; Code condition: 265
+
+!# issue 2418
+!# CS_ARCH_ARM, CS_MODE_THUMB, CS_OPT_DETAIL
+0x0: 0x86,0xf3,0x00,0x89 == msr cpsr_fc, r6 ; operands[0].type: SYSREG = 144


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

In ARMInstPrinter#printMSRMaskOperand, setting the type of SYSREG does not consider the SpecRegRBit, which causes the reported SYSREG value is always for SPSR even the instruction is using CPSR.

...

**Test plan**

Added a test case in suite/cs_test/issues.cs

...

**Closing issues**

closes #2418 

...
