### PR TITLE
Add back support for relocatable packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -837,10 +837,26 @@ source_group("Include\\LoongArch" FILES ${HEADERS_LOONGARCH})
 
 ## installation
 if(CAPSTONE_INSTALL)
-    include("GNUInstallDirs")
+    include(GNUInstallDirs)
 
     install(FILES ${HEADERS_COMMON} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/capstone)
     install(FILES ${HEADERS_INC} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/capstone/inc)
+
+    # Support absolute installation paths (discussion: https://github.com/NixOS/nixpkgs/issues/144170)
+    if(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
+        set(CAPSTONE_PKGCONFIG_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
+        set(CAPSTONE_CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
+    else()
+        set(CAPSTONE_PKGCONFIG_INSTALL_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+        set(CAPSTONE_CMAKE_INSTALL_LIBDIR "\${PACKAGE_PREFIX_DIR}/${CMAKE_INSTALL_LIBDIR}")
+    endif()
+    if(IS_ABSOLUTE ${CMAKE_INSTALL_INCLUDEDIR})
+        set(CAPSTONE_PKGCONFIG_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
+        set(CAPSTONE_CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
+    else()
+        set(CAPSTONE_PKGCONFIG_INSTALL_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+        set(CAPSTONE_CMAKE_INSTALL_INCLUDEDIR "\${PACKAGE_PREFIX_DIR}/${CMAKE_INSTALL_INCLUDEDIR}")
+    endif()
 
     configure_file(capstone.pc.in ${CMAKE_BINARY_DIR}/capstone.pc @ONLY)
     install(FILES ${CMAKE_BINARY_DIR}/capstone.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/capstone-config.cmake.in
+++ b/capstone-config.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-set_and_check(capstone_INCLUDE_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
-set_and_check(capstone_LIB_DIR "@CMAKE_INSTALL_FULL_LIBDIR@")
+set_and_check(capstone_INCLUDE_DIR "@CAPSTONE_CMAKE_INSTALL_INCLUDEDIR@")
+set_and_check(capstone_LIB_DIR "@CAPSTONE_CMAKE_INSTALL_LIBDIR@")
 
 include("${CMAKE_CURRENT_LIST_DIR}/capstone-targets.cmake")

--- a/capstone.pc.in
+++ b/capstone.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+libdir=@CAPSTONE_PKGCONFIG_INSTALL_LIBDIR@
+includedir=@CAPSTONE_PKGCONFIG_INSTALL_INCLUDEDIR@
 
 Name: capstone
 Description: Capstone disassembly engine

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -13,8 +13,8 @@ foreach(file ${files})
   endif()
 endforeach()
 
-message(STATUS "Uninstalling @CMAKE_INSTALL_FULL_INCLUDEDIR@/capstone")
-file(REMOVE_RECURSE @CMAKE_INSTALL_FULL_INCLUDEDIR@/capstone)
+message(STATUS "Uninstalling @CAPSTONE_CMAKE_INSTALL_INCLUDEDIR@/capstone")
+file(REMOVE_RECURSE @CAPSTONE_CMAKE_INSTALL_INCLUDEDIR@/capstone)
 
-message(STATUS "Uninstalling @CMAKE_INSTALL_FULL_LIBDIR@/cmake/capstone")
-file(REMOVE_RECURSE @CMAKE_INSTALL_FULL_LIBDIR@/cmake/capstone)
+message(STATUS "Uninstalling @CAPSTONE_CMAKE_INSTALL_LIBDIR@/cmake/capstone")
+file(REMOVE_RECURSE @CAPSTONE_CMAKE_INSTALL_LIBDIR@/cmake/capstone)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

The previous PR https://github.com/capstone-engine/capstone/pull/2134 not only 'allowed' an absolute `CMAKE_INSTALL_LIBDIR`/`CMAKE_INSTALL_INCLUDEDIR`, it also broke support for relocatable packages if the path was not absolute.

These changes should also be cherry-picked in `v5`.

Discussion: https://github.com/NixOS/nixpkgs/issues/144170