### PR TITLE
Fix 'make check' for python tests

### DIFF
--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -41,7 +41,7 @@ TESTS += test_lite.py test_iter.py test_customized_mnem.py test_alpha.py
 check:
 	@for t in $(TESTS); do \
 		echo Check $$t ... ; \
-		./$$t > /dev/null; \
+		./tests/$$t > /dev/null; \
 		if [ $$? -eq 0 ]; then echo OK; else echo FAILED; exit 1; fi \
 	done
 


### PR DESCRIPTION


**Your checklist for this pull request**
- not applicable --> I've documented or updated the documentation of every API function and struct this PR changes.
- not applicable --> I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

The python tests were relocated to a subdirectory, but the `check` target in the `Makefile` wasn't changed accordingly. This PR changes the `Makefile` to execute the checks from the subdirectory.

**Test plan**

* Build Capstone with Python bindings
* Run `make check`

**Closing issues**

N/A
