### PR TITLE
[v5] Wheel build fixes: manylinux1, trigger upload on release, Linux AArch64

### DIFF
--- a/.github/workflows/python-publish-release.yml
+++ b/.github/workflows/python-publish-release.yml
@@ -1,6 +1,6 @@
 name: RELEASE BUILD - PyPI 📦 Distribution
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request, release, workflow_dispatch]
 
 jobs:
   build_wheels:
@@ -26,7 +26,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_ARCHS_LINUX: "x86_64 i686" # ppc64le s390x really slow
+          CIBW_ARCHS_LINUX: "x86_64 i686 aarch64" # ppc64le s390x really slow
           CIBW_ARCHS_WINDOWS: "AMD64" # ARM64  Seems ARM64 will rebuild amd64 wheel for unknow reason.
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-*"
           CIBW_SKIP: ""
@@ -69,12 +69,13 @@ jobs:
   publish:
     needs: [build_wheels]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'release' && github.event.prerelease == false && github.event.action == 'published'
     permissions:
       id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
+          merge-multiple: true
           path: dist
 
       - name: Show downloaded artifacts

--- a/.github/workflows/python-publish-release.yml
+++ b/.github/workflows/python-publish-release.yml
@@ -77,6 +77,9 @@ jobs:
         with:
           path: dist
 
+      - name: Show downloaded artifacts
+        run: ls -laR dist
+
       - name: Publish distribution 📦 to PyPI
         if: ${{ success() }}
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-publish-release.yml
+++ b/.github/workflows/python-publish-release.yml
@@ -81,5 +81,6 @@ jobs:
         if: ${{ success() }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          verbose: true
           user: __token__
           password: ${{ secrets.pypi_pass }}

--- a/suite/check_wheel_bin_arch.py
+++ b/suite/check_wheel_bin_arch.py
@@ -33,6 +33,7 @@ archs = {
 filename = {
     "macosx": "libcapstone.dylib",
     "manylinux": "libcapstone.so",
+    "musllinux": "libcapstone.so",
     "win": "capstone.dll",
 }
 
@@ -45,7 +46,7 @@ for root, dir, files in os.walk(sys.argv[1]):
             continue
         wheel_seen = True
         target = re.search(r"py3-none-(.+).whl", f"{f}").group(1)
-        platform = re.search("^(win|manylinux|macosx)", target).group(1)
+        platform = re.search("^(win|manylinux|musllinux|macosx)", target).group(1)
 
         arch = re.search(
             "(universal2|x86_64|arm64|aarch64|i686|win32|amd64)$", target


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Fixes several issues:

- Remove hard-coded wheel package name manipulation which adds `manylinux1`
- Enable `AArch64` binaries for Linux again, because the wheel has no longer the undefined name `manylinux1_aarch64`.
- Add `musllinux` package to test script.
- Trigger upload only on full releases.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->


Only one attempted upload (failing job `published`):
https://github.com/Rot127/capstone/actions

Lists correct wheels in: https://github.com/Rot127/capstone/actions/runs/10448403223

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
