### PR TITLE
[v5][SuperH] Fix missing setting detail->sh

### DIFF
--- a/arch/SH/SHDisassembler.c
+++ b/arch/SH/SHDisassembler.c
@@ -2192,6 +2192,8 @@ bool SH_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 		*size = 0;
 		return MCDisassembler_Fail;
 	} else {
+		if (detail)
+			detail->sh = info->op;
 		return MCDisassembler_Success;
 	}		
 }

--- a/suite/cstest/issues.cs
+++ b/suite/cstest/issues.cs
@@ -1062,3 +1062,7 @@
 !# issue 2418
 !# CS_ARCH_ARM, CS_MODE_THUMB, CS_OPT_DETAIL
 0x0: 0x86,0xf3,0x00,0x89 == msr cpsr_fc, r6 ; operands[0].type: SYSREG = 144
+
+!# issue 2424
+!# CS_ARCH_SH, CS_MODE_SH2A | CS_MODE_BIG_ENDIAN, CS_OPT_DETAIL
+0x0: 0x32,0x11,0x92,0x00 == movu.w @(1024,r1),r2 ; operands[0].type: MEM ; operands[0].mem.reg: REG = r1 ; operands[0].mem.disp: 0x400 ; address mode: Register Indirect with Predecrement ; operands[1].type: REG = r2


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

`detail->sh` is never set. Which makes the detailed output related to operands is always missing.

**Test plan**

`issues.cs`, the newly added case passes/fails with/without the change.

...

**Closing issues**

closes #2424 

...
