### PR TITLE
Tricore EA calculation

### DIFF
--- a/arch/TriCore/TriCoreInstPrinter.c
+++ b/arch/TriCore/TriCoreInstPrinter.c
@@ -277,8 +277,7 @@ static void printDisp24Imm(MCInst *MI, int OpNum, SStream *O)
 		case TRICORE_JA_b:
 		case TRICORE_JLA_b:
 			// = {disp24[23:20], 7’b0000000, disp24[19:0], 1’b0};
-			res = ((wrapping_u32(disp) & 0xf00000ULL) << 28) |
-			      ((wrapping_u32(disp) & 0xfffffULL) << 1);
+			res = disp << 1;
 			break;
 		case TRICORE_J_b:
 		case TRICORE_JL_b:

--- a/tests/MC/TriCore/ADC_Queued_Scan_1_KIT_TC397_TFT.s.yaml
+++ b/tests/MC/TriCore/ADC_Queued_Scan_1_KIT_TC397_TFT.s.yaml
@@ -574,7 +574,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "call #0x7023e8"
+          asm_text: "call #0xff7023e8"
   -
     input:
       bytes: [ 0x91, 0x00, 0x03, 0xfa ]
@@ -1114,7 +1114,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "call #0x702300"
+          asm_text: "call #0xff702300"
   -
     input:
       bytes: [ 0x15, 0xd0, 0xc0, 0xeb ]
@@ -1420,7 +1420,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "call #0x402300"
+          asm_text: "call #0xff402300"
   -
     input:
       bytes: [ 0x3b, 0x00, 0x00, 0xf3 ]
@@ -5047,7 +5047,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "call #0x4023e8"
+          asm_text: "call #0xff4023e8"
   -
     input:
       bytes: [ 0x49, 0xff, 0x0c, 0x0a ]
@@ -7972,7 +7972,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "call #0x102300"
+          asm_text: "call #0xff102300"
   -
     input:
       bytes: [ 0xda, 0x05 ]

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -5438,3 +5438,71 @@ test_cases:
           writeback: 1
           regs_read: [ x0 ]
           regs_write: [ x0, x1 ]
+  -
+    input:
+      name: "TriCore EA calculation with disponent - #2504"
+      bytes: [ 0xfd,0xc0,0xe2,0x48,
+               0xdd,0x8a,0x2b,0x53,
+               0xdd,0x97,0x3e,0x94,
+               0xdd,0xd6,0x4d,0x85,
+               0x9d,0xcb,0x01,0x42,
+               0x9d,0x56,0xce,0x04,
+               0x9d,0xce,0x71,0x03,
+               0xe1,0xec,0xe3,0xb1,
+               0xe1,0x23,0xf7,0x37,
+               0xe1,0xa1,0x33,0xf7,
+               0xed,0xec,0xe3,0xb1,
+               0xed,0x23,0xf7,0x37,
+               0x6d,0x90,0xa7,0x8e,
+               0xed,0xa1,0x33,0xf7,
+               0x6d,0xb7,0xe0,0xba,
+               0x1b,0x00,0x30,0x00,
+               0x5c,0x56,
+               0x5c,0x97,
+               0x5c,0xc4,
+               0x5c,0xcd ]
+      arch: "CS_ARCH_TRICORE"
+      options: [ CS_OPT_DETAIL, CS_MODE_TRICORE_162 ]
+      address: 0x80000000
+    expected:
+      insns:
+        -
+          asm_text: "loop a12, #0x7fff91c4"
+        -
+          asm_text: "jla #0x8014a656"
+        -
+          asm_text: "jla #0x900f287c"
+        -
+          asm_text: "jla #0xd00d0a9a"
+        -
+          asm_text: "ja #0xc0168402"
+        -
+          asm_text: "ja #0x500c099c"
+        -
+          asm_text: "ja #0xc01c06e2"
+        -
+          asm_text: "fcalla #0xe01963c6"
+        -
+          asm_text: "fcalla #0x20066fee"
+        -
+          asm_text: "fcalla #0xa003ee66"
+        -
+          asm_text: "calla #0xe01963c6"
+        -
+          asm_text: "calla #0x20066fee"
+        -
+          asm_text: "call #0x7f211d7e"
+        -
+          asm_text: "calla #0xa003ee66"
+        -
+          asm_text: "call #0x7f6f75f8"
+        -
+          asm_text: "addi d0, d0, #0x300"
+        -
+          asm_text: "call #0x800000ec"
+        -
+          asm_text: "call #0x7fffff70"
+        -
+          asm_text: "call #0x7fffffcc"
+        -
+          asm_text: "call #0x7fffffe0"


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Fixes two issues with address calculation:

[Fix absolute address calculations.](https://github.com/capstone-engine/capstone/commit/0dc6d70620131a003552e9ef51f0aa420d706b79)

Absolute effective addresses are decoded by DecodeBInstruction().
Because they are encoded as normal disp24 value.
To form the EA:
The lower 20bits are shifted by one, and the upper 4bits by 1 (jumps) or 7 (calls).

[Fix PC relative disponents.](https://github.com/capstone-engine/capstone/commit/3eccb1340249d04c8232cd5cb61c85ca33f83ee5)

The ISA sign extends disponents values of 8, 15 and 24 bits.
For address disponents it also shifts the results by 1 for alignment.

The ISA has two writing styles for this though:
sign_ext(dispXX * 2) and sign_ext(dispXX) * 2.

Assuming that sign_ext() always works on the MSB of the value
they are eqivalent. Because:
sign_ext(disp8 * 2) = sign_ext(disp8 * 2 = disp9) = sign_ext(disp9) = sign_ext(disp8) * 2.

This let to confusion before and for the sign_ext(dispXX * 2) case,
and the wrong bit was checked for sign extension (e.g bit 8 for an effective disp9 value).

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Not yet added.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
