### PR TITLE
Fix cstest build with Ninja

### DIFF
--- a/suite/cstest/CMakeLists.txt
+++ b/suite/cstest/CMakeLists.txt
@@ -4,6 +4,7 @@ include(ExternalProject)
 find_library(libyaml
     NAMES libyaml yaml
     REQUIRED)
+set(CMOCKA_LIB_FILE "${CMAKE_CURRENT_BINARY_DIR}/extern/src/cmocka_ext-build/src/libcmocka.a")
 ExternalProject_Add(cmocka_ext
     PREFIX extern
     URL "https://cmocka.org/files/1.1/cmocka-1.1.7.tar.xz"
@@ -11,6 +12,7 @@ ExternalProject_Add(cmocka_ext
     DOWNLOAD_EXTRACT_TIMESTAMP true
     CONFIGURE_COMMAND cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ../cmocka_ext/
     BUILD_COMMAND cmake --build . --config Release
+    BUILD_BYPRODUCTS "${CMOCKA_LIB_FILE}"
     INSTALL_COMMAND ""
 )
 
@@ -20,6 +22,7 @@ else()
     set(LIBCYAML_VARIANT "release")
 endif()
 
+set(LIBCYAML_LIB_FILE "${CMAKE_CURRENT_BINARY_DIR}/extern/src/libcyaml_ext/build/${LIBCYAML_VARIANT}/libcyaml.a")
 ExternalProject_Add(libcyaml_ext
     PREFIX extern
     URL "https://github.com/tlsa/libcyaml/archive/refs/tags/v1.4.1.tar.gz"
@@ -27,17 +30,16 @@ ExternalProject_Add(libcyaml_ext
     DOWNLOAD_EXTRACT_TIMESTAMP true
     CONFIGURE_COMMAND ""
     BUILD_COMMAND make VARIANT=${LIBCYAML_VARIANT} PKG_CONFIG=pkg-config
+    BUILD_BYPRODUCTS "${LIBCYAML_LIB_FILE}"
     BUILD_IN_SOURCE true
     INSTALL_COMMAND ""
 )
 set(CMOCKA_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern/src/cmocka_ext/include)
-set(CMOCKA_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern/src/cmocka_ext-build/src/)
 set(LIBCYAML_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern/src/libcyaml_ext/include)
-set(LIBCYAML_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern/src/libcyaml_ext/build/${LIBCYAML_VARIANT}/)
 add_library(cmocka STATIC IMPORTED)
 add_library(libcyaml STATIC IMPORTED)
-set_target_properties(cmocka PROPERTIES IMPORTED_LOCATION ${CMOCKA_LIB_DIR}/libcmocka.a)
-set_target_properties(libcyaml PROPERTIES IMPORTED_LOCATION ${LIBCYAML_LIB_DIR}/libcyaml.a)
+set_target_properties(cmocka PROPERTIES IMPORTED_LOCATION "${CMOCKA_LIB_FILE}")
+set_target_properties(libcyaml PROPERTIES IMPORTED_LOCATION "${LIBCYAML_LIB_FILE}")
 
 set(CSTEST_INCLUDE_DIR ${CSTEST_DIR}/include)
 file(GLOB CSTEST_SRC ${CSTEST_DIR}/src/*.c)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

When building with Ninja, it is necessary to explicitly declare that the libcmocka.a and libcyaml.a files are built by their respective ExternalProject targets, otherwise it will refuse to build.

See also the documentation of BUILD_BYPRODUCTS in https://cmake.org/cmake/help/v3.31/module/ExternalProject.html#id13

**Test plan**

The following should not error:

```
florian-macbook:capstone florian$ cmake -Bbuild -GNinja -DCAPSTONE_BUILD_CSTEST=ON
-- The C compiler identification is AppleClang 16.0.0.16000026
-- The CXX compiler identification is AppleClang 16.0.0.16000026
(...)
-- Configuring done (0.6s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/florian/dev/capstone/build
florian-macbook:capstone florian$ ninja -Cbuild
ninja: Entering directory `build'
ninja: error: 'suite/cstest/extern/src/cmocka_ext-build/src/libcmocka.a', needed by 'suite/cstest/cstest', missing and no known rule to make it
```