### PR TITLE
Update libcyaml dependency in cstest to 1.4.2

### DIFF
--- a/suite/cstest/CMakeLists.txt
+++ b/suite/cstest/CMakeLists.txt
@@ -22,8 +22,8 @@ endif()
 
 ExternalProject_Add(libcyaml_ext
     PREFIX extern
-    URL "https://github.com/tlsa/libcyaml/archive/refs/tags/v1.4.1.tar.gz"
-    URL_HASH SHA256=8dbd216e1fce90f9f7cca341e5178710adc76ee360a7793ef867edb28f3e4130
+    URL "https://github.com/tlsa/libcyaml/archive/refs/tags/v1.4.2.tar.gz"
+    URL_HASH SHA256=3211b2a0589ebfe02c563c96adce9246c0787be2af30353becbbd362998d16dc
     DOWNLOAD_EXTRACT_TIMESTAMP true
     CONFIGURE_COMMAND ""
     BUILD_COMMAND make VARIANT=${LIBCYAML_VARIANT} PKG_CONFIG=pkg-config


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

1.4.2 contains a fix to replace static_assert calls by a more portable variant. This is relevant for building on e.g. Mac OS X 10.5.

**Test plan**

Build with MacPorts gcc 7.5.0 on Mac OS X 10.5 and `-DCAPSTONE_BUILD_CSTEST=1`. (Hint: there are other issues in the cstest code, but those can be addressed separately)