### PR TITLE
Fix #2509.

### DIFF
--- a/include/capstone/arm64.h
+++ b/include/capstone/arm64.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include <capstone/aarch64.h>
+#include "aarch64.h"
 #include "cs_operand.h"
 #include "platform.h"
 

--- a/include/capstone/systemz_compatibility.h
+++ b/include/capstone/systemz_compatibility.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-#include <capstone/systemz.h>
+#include "systemz.h"
 #include "platform.h"
 #include "cs_operand.h"
 

--- a/suite/auto-sync/src/autosync/HeaderPatcher.py
+++ b/suite/auto-sync/src/autosync/HeaderPatcher.py
@@ -254,7 +254,7 @@ class CompatHeaderBuilder:
         for line in v6_lines:
             if re.search(r"^#include", line):
                 if not header_inserted:
-                    output.append(f"#include <capstone/{self.v6_lower}.h>\n")
+                    output.append(f'#include "{self.v6_lower}.h"\n')
                     header_inserted = True
             output.append(line)
         return output


### PR DESCRIPTION
Compatibility headers should always include the header in the same dir.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The comparability header should not include the system headers.
It breaks on one side `capstone.pc` and also is not very intuitive. Because (I would say) the header is always assumed to be the compatibility header within its directory. Not within another. 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes https://github.com/capstone-engine/capstone/issues/2509
