### PR TITLE
This time actually fix big endian issue.

### DIFF
--- a/bindings/python/capstone/aarch64.py
+++ b/bindings/python/capstone/aarch64.py
@@ -52,14 +52,14 @@ class AArch64SysOpSysReg(ctypes.Union):
         ('sysreg', ctypes.c_uint),
         ('tlbi', ctypes.c_uint),
         ('ic', ctypes.c_uint),
-        ('raw_val', ctypes.c_uint64),
+        ('raw_val', ctypes.c_int),
     )
 
 class AArch64SysOpSysImm(ctypes.Union):
     _fields_ = (
         ('dbnxs', ctypes.c_uint),
         ('exactfpimm', ctypes.c_uint),
-        ('raw_val', ctypes.c_uint64),
+        ('raw_val', ctypes.c_int),
     )
 
 class AArch64SysOpSysAlias(ctypes.Union):
@@ -79,7 +79,7 @@ class AArch64SysOpSysAlias(ctypes.Union):
         ('bti', ctypes.c_uint),
         ('svepredpat', ctypes.c_uint),
         ('sveveclenspecifier', ctypes.c_uint),
-        ('raw_val', ctypes.c_uint64),
+        ('raw_val', ctypes.c_int),
     )
 class AArch64SysOp(ctypes.Structure):
     _fields_ = (

--- a/bindings/python/cstest_py/src/cstest_py/details.py
+++ b/bindings/python/cstest_py/src/cstest_py/details.py
@@ -755,7 +755,7 @@ def test_expected_aarch64(actual: CsInsn, expected: dict) -> bool:
                 aop.sysop.sub_type, eop.get("sub_type"), "sub_type"
             ):
                 return False
-            if not compare_uint64(
+            if not compare_int32(
                 aop.sysop.reg.raw_val, eop.get("sys_raw_val"), "sys_raw_val"
             ):
                 return False
@@ -764,7 +764,7 @@ def test_expected_aarch64(actual: CsInsn, expected: dict) -> bool:
                 aop.sysop.sub_type, eop.get("sub_type"), "sub_type"
             ):
                 return False
-            if not compare_uint64(
+            if not compare_int32(
                 aop.sysop.imm.raw_val, eop.get("sys_raw_val"), "sys_raw_val"
             ):
                 return False
@@ -778,7 +778,7 @@ def test_expected_aarch64(actual: CsInsn, expected: dict) -> bool:
                 aop.sysop.sub_type, eop.get("sub_type"), "sub_type"
             ):
                 return False
-            if not compare_uint64(
+            if not compare_int32(
                 aop.sysop.alias.raw_val, eop.get("sys_raw_val"), "sys_raw_val"
             ):
                 return False

--- a/include/capstone/aarch64.h
+++ b/include/capstone/aarch64.h
@@ -1972,13 +1972,13 @@ typedef union {
 	aarch64_sysreg sysreg;
 	aarch64_tlbi tlbi;
 	aarch64_ic ic;
-	uint64_t raw_val;
+	int raw_val;
 } aarch64_sysop_reg;
 
 typedef union {
 	aarch64_dbnxs dbnxs;
 	aarch64_exactfpimm exactfpimm;
-	uint64_t raw_val;
+	int raw_val;
 } aarch64_sysop_imm;
 
 typedef union {
@@ -1997,7 +1997,7 @@ typedef union {
 	aarch64_bti bti;
 	aarch64_svepredpat svepredpat;
 	aarch64_sveveclenspecifier sveveclenspecifier;
-	uint64_t raw_val;
+	int raw_val;
 } aarch64_sysop_alias;
 
 /// Operand type for instruction's operands

--- a/suite/cstest/include/test_detail_aarch64.h
+++ b/suite/cstest/include/test_detail_aarch64.h
@@ -58,7 +58,7 @@ typedef struct {
 	int8_t imm_range_offset;
 	double fp;
 	bool fp_set; /// Only relevant for SysOps with EXACTFPIMM
-	uint64_t sys_raw_val;
+	int sys_raw_val;
 
 	TestDetailAArch64SME *sme;
 

--- a/suite/cstest/src/test_detail_aarch64.c
+++ b/suite/cstest/src/test_detail_aarch64.c
@@ -180,13 +180,13 @@ bool test_expected_aarch64(csh *handle, cs_aarch64 *actual,
 		case AARCH64_OP_SYSREG:
 			compare_enum_ret(op->sysop.sub_type, eop->sub_type,
 					 false);
-			compare_uint64_ret(op->sysop.reg.raw_val,
+			compare_int_ret(op->sysop.reg.raw_val,
 					   eop->sys_raw_val, false);
 			break;
 		case AARCH64_OP_SYSIMM:
 			compare_enum_ret(op->sysop.sub_type, eop->sub_type,
 					 false);
-			compare_uint64_ret(op->sysop.imm.raw_val,
+			compare_int_ret(op->sysop.imm.raw_val,
 					   eop->sys_raw_val, false);
 			if (eop->fp_set) {
 				compare_fp_ret(op->fp, eop->fp, false);
@@ -195,7 +195,7 @@ bool test_expected_aarch64(csh *handle, cs_aarch64 *actual,
 		case AARCH64_OP_SYSALIAS:
 			compare_enum_ret(op->sysop.sub_type, eop->sub_type,
 					 false);
-			compare_uint64_ret(op->sysop.alias.raw_val,
+			compare_int_ret(op->sysop.alias.raw_val,
 					   eop->sys_raw_val, false);
 			break;
 		case AARCH64_OP_MEM:


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Of course an enum value has the width of an int.
If it is 64bits long and on a big endian machine,
the enum value gets assigned to the upper bits.
Not the lower ones.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

```
QEMU_LD_PREFIX=/usr/s390x-redhat-linux/sys-root/fc40/usr/ qemu-s390x-static ./build-s390x/cstool -d aarch64 01421bd501423bd5
 0  01 42 1b d5  msr	NZCV, x1
	ID: 734 (msr)
	op_count: 2
		operands[0].type: SYS REG:
		operands[0].subtype: REG_MSR = 0xda10
		operands[1].type: REG = x1
		operands[1].access: READ
	Update-flags: True
	Registers read: x1
	Groups: privilege 

 4  01 42 3b d5  mrs	x1, NZCV
	ID: 732 (mrs)
	op_count: 2
		operands[0].type: REG = x1
		operands[0].access: WRITE
		operands[1].type: SYS REG:
		operands[1].subtype: REG_MRS = 0xda10
	Registers modified: x1
	Groups: privilege 
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
