### PR TITLE
fix coverity

### DIFF
--- a/arch/LoongArch/LoongArchMapping.c
+++ b/arch/LoongArch/LoongArchMapping.c
@@ -180,6 +180,9 @@ void LoongArch_rewrite_memory_operand(MCInst *MI)
 
 	const loongarch_suppl_info *suppl_info =
 		map_get_suppl_info(MI, loongarch_insns);
+	if (!suppl_info)
+		return;
+
 	if (suppl_info->memory_access == CS_AC_INVALID) {
 		// not memory instruction
 		return;

--- a/arch/Xtensa/XtensaDisassembler.c
+++ b/arch/Xtensa/XtensaDisassembler.c
@@ -211,7 +211,7 @@ static DecodeStatus DecodeMR01RegisterClass(MCInst *Inst, uint64_t RegNo,
 					    uint64_t Address,
 					    const void *Decoder)
 {
-	if (RegNo > 2)
+	if (RegNo >= ARR_SIZE(MR01DecoderTable))
 		return MCDisassembler_Fail;
 
 	unsigned Reg = MR01DecoderTable[RegNo];
@@ -970,7 +970,7 @@ static DecodeStatus readInstructionN(const uint8_t *Bytes, size_t BytesLen,
 
 	*Insn = 0;
 	for (unsigned i = 0; i < InstSize; i++)
-		*Insn |= (Bytes[i] << 8 * i);
+		*Insn |= (uint64_t)(Bytes[i]) << (8 * i);
 
 	*Size = InstSize;
 	return MCDisassembler_Success;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

fix coverity

- cid 514642

- cid 514643

- cid 514644

- cid 514645

```

** CID 514645:  Null pointer dereferences  (NULL_RETURNS)
/arch/LoongArch/LoongArchMapping.c: 183 in LoongArch_rewrite_memory_operand()


________________________________________________________________________________________________________
*** CID 514645:  Null pointer dereferences  (NULL_RETURNS)
/arch/LoongArch/LoongArchMapping.c: 183 in LoongArch_rewrite_memory_operand()
177     
178         if (!detail_is_set(MI))
179             return;
180     
181         const loongarch_suppl_info *suppl_info =
182             map_get_suppl_info(MI, loongarch_insns);
>>>     CID 514645:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing "suppl_info", which is known to be "NULL".
183         if (suppl_info->memory_access == CS_AC_INVALID) {
184             // not memory instruction
185             return;
186         }
187     
188         // handle special cases

** CID 514644:  Memory - illegal accesses  (OVERRUN)
/arch/Xtensa/XtensaDisassembler.c: 217 in DecodeMR01RegisterClass()


________________________________________________________________________________________________________
*** CID 514644:  Memory - illegal accesses  (OVERRUN)
/arch/Xtensa/XtensaDisassembler.c: 217 in DecodeMR01RegisterClass()
211                             uint64_t Address,
212                             const void *Decoder)
213     {
214         if (RegNo > 2)
215             return MCDisassembler_Fail;
216     
>>>     CID 514644:  Memory - illegal accesses  (OVERRUN)
>>>     Overrunning array "MR01DecoderTable" of 2 4-byte elements at element index 2 (byte offset 11) using index "RegNo" (which evaluates to 2).
217         unsigned Reg = MR01DecoderTable[RegNo];
218         MCOperand_CreateReg0(Inst, (Reg));
219         return MCDisassembler_Success;
220     }
221     
222     static const unsigned MR23DecoderTable[] = { Xtensa_M2, Xtensa_M3 };

** CID 514643:  Integer handling issues  (SIGN_EXTENSION)
/arch/Xtensa/XtensaDisassembler.c: 973 in readInstructionN()


________________________________________________________________________________________________________
*** CID 514643:  Integer handling issues  (SIGN_EXTENSION)
/arch/Xtensa/XtensaDisassembler.c: 973 in readInstructionN()
967             *Size = 0;
968             return MCDisassembler_Fail;
969         }
970     
971         *Insn = 0;
972         for (unsigned i = 0; i < InstSize; i++)
>>>     CID 514643:  Integer handling issues  (SIGN_EXTENSION)
>>>     Suspicious implicit sign extension: "Bytes[i]" with type "uint8_t const" (8 bits, unsigned) is promoted in "Bytes[i] << 8U * i" to type "int" (32 bits, signed), then sign-extended to type "unsigned long" (64 bits, unsigned).  If "Bytes[i] << 8U * i" is greater than 0x7FFFFFFF, the upper bits of the result will all be 1.
973             *Insn |= (Bytes[i] << 8 * i);
974     
975         *Size = InstSize;
976         return MCDisassembler_Success;
977     }
978     

** CID 514642:  Integer handling issues  (OVERFLOW_BEFORE_WIDEN)
/arch/Xtensa/XtensaDisassembler.c: 973 in readInstructionN()


________________________________________________________________________________________________________
*** CID 514642:  Integer handling issues  (OVERFLOW_BEFORE_WIDEN)
/arch/Xtensa/XtensaDisassembler.c: 973 in readInstructionN()
967             *Size = 0;
968             return MCDisassembler_Fail;
969         }
970     
971         *Insn = 0;
972         for (unsigned i = 0; i < InstSize; i++)
>>>     CID 514642:  Integer handling issues  (OVERFLOW_BEFORE_WIDEN)
>>>     Potentially overflowing expression "Bytes[i] << 8U * i" with type "int" (32 bits, signed) is evaluated using 32-bit arithmetic, and then used in a context that expects an expression of type "uint64_t" (64 bits, unsigned).
973             *Insn |= (Bytes[i] << 8 * i);
974     
975         *Size = InstSize;
976         return MCDisassembler_Success;
977     }
978     
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
