### PR TITLE
Correct a comment in x86.h

### DIFF
--- a/include/capstone/x86.h
+++ b/include/capstone/x86.h
@@ -360,7 +360,7 @@ typedef struct cs_x86 {
 	/// AVX Suppress all Exception
 	bool avx_sae;
 
-	/// AVX static rounding mode
+	/// AVX embedded rounding mode
 	x86_avx_rm avx_rm;
 
 	


### PR DESCRIPTION
# This is just a simple fix for a misleading comment.

The `avx_rm` attribute in `cs_x86` structure should be the flag of embedded rounding mode, instead of static rounding mode of the instruction.