### PR TITLE
Fix cmake error when build with capstone as submodule

### DIFF
--- a/CPackConfig.txt
+++ b/CPackConfig.txt
@@ -9,7 +9,7 @@ set(CPACK_PACKAGE_DESCRIPTION "Capstone is a lightweight multi-platform, multi-a
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Lightweight multi-architecture disassembly framework - devel files")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://www.capstone-engine.org/")
 set(CPACK_STRIP_FILES false)
-set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.TXT")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.TXT")
 
 # Set Debian-specific package variables
 set(CPACK_DEBIAN_PACKAGE_NAME "libcapstone-dev")


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've documented or updated the documentation of every API function and struct this PR changes.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Hey, really simple change making sure that cpack doesn't try to look for a LICENSE.TXT file in the main project root but in the current project root. This fixes the usecase where capstone is being included as a submodule and loaded using `add_subdirectory` in a cmake project. Previously it would look for LICENSE.TXT in the main project root directory, now it's looking for it in the capstone subdirectory.

**Test plan**

- Create a sample cmake project, put capstone into a subfolder and include it in the main cmake script using `add_subdirectory`. Previously this would fail with a cpack error. Now it doesn't anymore.

**Closing issues**

- None