### PR TITLE
Python bindings: Switch to ubuntu-24.04-arm runner image

### DIFF
--- a/.github/workflows/build-wheels-publish.yml
+++ b/.github/workflows/build-wheels-publish.yml
@@ -52,19 +52,17 @@ jobs:
           # x86_64 - musllinux
           - { os: ubuntu-latest, arch: x86_64, cibw_build: 'cp38-musllinux* cp313-musllinux*', cibw_skip: '' }
           # aarch64 - manylinux
-          # Disabled for now due to: https://github.com/capstone-engine/capstone/issues/2615
-          # - { os: ubuntu-latest, arch: aarch64, cibw_build: 'cp38-manylinux* cp313-manylinux*', cibw_skip: '' }
+          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp38-manylinux* cp313-manylinux*', cibw_skip: '' }
           # aarch64 - musllinux
-          # Disabled for now due to: https://github.com/capstone-engine/capstone/issues/2615
-          # - { os: ubuntu-latest, arch: aarch64, cibw_build: 'cp38-musllinux* cp313-musllinux*', cibw_skip: '' }
+          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp38-musllinux* cp313-musllinux*', cibw_skip: '' }
           # macos - x86_64
           - { os: macos-13, arch: x86_64, cibw_build: 'cp38* cp313*', cibw_skip: '' }
           # macos - arm64
           - { os: macos-latest, arch: arm64, cibw_build: 'cp38* cp313*', cibw_skip: '' }
           - { os: macos-latest, arch: universal2, cibw_build: 'cp38* cp313*', cibw_skip: '' }
-          # windows - x86_64
-          - { os: windows-latest, arch: AMD64, cibw_build: 'cp38* cp313*', cibw_skip: '' }
           # windows - amd64
+          - { os: windows-latest, arch: AMD64, cibw_build: 'cp38* cp313*', cibw_skip: '' }
+          # windows - x86
           # - { os: windows-latest, arch: x86, cibw_build: 'cp38* cp313*', cibw_skip: '' }
           # windows - arm64
           - { os: windows-latest, arch: ARM64, cibw_build: 'cp39* cp313*', cibw_skip: '' }
@@ -106,7 +104,7 @@ jobs:
           arch: amd64_arm64
 
       - name: '🛠️ Set up QEMU'
-        if: runner.os == 'Linux' && matrix.arch != 'x86_64'
+        if: runner.os == 'Linux' && matrix.arch == 'i686'
         uses: docker/setup-qemu-action@v3
 
       - name: '🚧 cibuildwheel run'
@@ -164,17 +162,15 @@ jobs:
           - { os: ubuntu-latest, arch: x86_64, cibw_build: 'cp311-musllinux*', cibw_skip: '' }
           - { os: ubuntu-latest, arch: x86_64, cibw_build: 'cp312-musllinux*', cibw_skip: '' }
           # aarch64 - manylinux
-          # Disabled for now due to: https://github.com/capstone-engine/capstone/issues/2615
-          # - { os: ubuntu-latest, arch: aarch64, cibw_build: 'cp39-manylinux*', cibw_skip: '' }
-          # - { os: ubuntu-latest, arch: aarch64, cibw_build: 'cp310-manylinux*', cibw_skip: '' }
-          # - { os: ubuntu-latest, arch: aarch64, cibw_build: 'cp311-manylinux*', cibw_skip: '' }
-          # - { os: ubuntu-latest, arch: aarch64, cibw_build: 'cp312-manylinux*', cibw_skip: '' }
+          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp39-manylinux*', cibw_skip: '' }
+          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp310-manylinux*', cibw_skip: '' }
+          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp311-manylinux*', cibw_skip: '' }
+          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp312-manylinux*', cibw_skip: '' }
           # aarch64 - musllinux
-          # Disabled for now due to: https://github.com/capstone-engine/capstone/issues/2615
-          # - { os: ubuntu-latest, arch: aarch64, cibw_build: 'cp39-musllinux*', cibw_skip: '' }
-          # - { os: ubuntu-latest, arch: aarch64, cibw_build: 'cp310-musllinux*', cibw_skip: '' }
-          # - { os: ubuntu-latest, arch: aarch64, cibw_build: 'cp311-musllinux*', cibw_skip: '' }
-          # - { os: ubuntu-latest, arch: aarch64, cibw_build: 'cp312-musllinux*', cibw_skip: '' }
+          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp39-musllinux*', cibw_skip: '' }
+          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp310-musllinux*', cibw_skip: '' }
+          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp311-musllinux*', cibw_skip: '' }
+          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp312-musllinux*', cibw_skip: '' }
           # macos - x86_64
           - { os: macos-13, arch: x86_64, cibw_build: 'cp*', cibw_skip: '*36* *37* *38* *313*' }
           # macos - arm64
@@ -218,7 +214,7 @@ jobs:
           arch: amd64_arm64
 
       - name: '🛠️ Set up QEMU'
-        if: runner.os == 'Linux' && matrix.arch != 'x86_64'
+        if: runner.os == 'Linux' && matrix.arch == 'i686'
         uses: docker/setup-qemu-action@v3
 
       - name: '🚧 cibuildwheel run'


### PR DESCRIPTION
**Your checklist for this pull request**
- [x ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

I have switched the runner image for aarch64 jobs. This means we don't need anymore the qemu emulation resulting in speeding up the whole run by 10x

Sort of take over from: https://github.com/capstone-engine/capstone/pull/2622

**Test plan**

Existing ones still valid

**Closing issues**

https://github.com/capstone-engine/capstone/issues/2615
