### PR TITLE
cmake: Fix building capstone as sub-project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -988,5 +988,5 @@ if(CAPSTONE_BUILD_CSTEST)
 endif()
 
 # Include CPack
-set(CPACK_PROJECT_CONFIG_FILE "${CMAKE_SOURCE_DIR}/CPackConfig.cmake")
+set(CPACK_PROJECT_CONFIG_FILE "${PROJECT_SOURCE_DIR}/CPackConfig.cmake")
 include(CPackConfig.txt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -988,5 +988,7 @@ if(CAPSTONE_BUILD_CSTEST)
 endif()
 
 # Include CPack
-set(CPACK_PROJECT_CONFIG_FILE "${PROJECT_SOURCE_DIR}/CPackConfig.cmake")
-include(CPackConfig.txt)
+if(PROJECT_IS_TOP_LEVEL)
+    set(CPACK_PROJECT_CONFIG_FILE "${PROJECT_SOURCE_DIR}/CPackConfig.cmake")
+    include(CPackConfig.txt)
+endif()

--- a/CPackConfig.txt
+++ b/CPackConfig.txt
@@ -9,7 +9,7 @@ set(CPACK_PACKAGE_DESCRIPTION "Capstone is a lightweight multi-platform, multi-a
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Lightweight multi-architecture disassembly framework - devel files")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://www.capstone-engine.org/")
 set(CPACK_STRIP_FILES false)
-set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSES/LICENSE.TXT")
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSES/LICENSE.TXT")
 
 # Set Debian-specific package variables
 set(CPACK_DEBIAN_PACKAGE_NAME "libcapstone-dev")
@@ -37,7 +37,7 @@ else()
 endif()
 
 # Include additional file to run 'ldconfig' after install
-set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/packages/deb/triggers")
+set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${PROJECT_SOURCE_DIR}/packages/deb/triggers")
 
 # RPM package settings
 set(CPACK_RPM_PACKAGE_NAME "capstone-devel")
@@ -45,9 +45,9 @@ set(CPACK_RPM_PACKAGE_VERSION "${PROJECT_VERSION}")
 set(CPACK_RPM_PACKAGE_ARCHITECTURE ${CMAKE_SYSTEM_PROCESSOR})
 set(CPACK_RPM_PACKAGE_GROUP "Development/Libraries")
 set(CPACK_RPM_PACKAGE_REQUIRES "glibc >= 2.2.5")
-set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/packages/rpm/postinstall.sh")
-set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/packages/rpm/postinstall.sh")
-set(CPACK_RPM_CHANGELOG_FILE "${CMAKE_SOURCE_DIR}/ChangeLog")
+set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${PROJECT_SOURCE_DIR}/packages/rpm/postinstall.sh")
+set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${PROJECT_SOURCE_DIR}/packages/rpm/postinstall.sh")
+set(CPACK_RPM_CHANGELOG_FILE "${PROJECT_SOURCE_DIR}/ChangeLog")
 set(CPACK_RPM_PACKAGE_LICENSE "BSD3, LLVM")
 set(CPACK_RPM_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION}")
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

capstone can be built as sub-project through cmake's fetch_content
mechanism. In this case, `CMAKE_SOURCE_DIR` refers to the parent project
(that has nothing to do with capstone), while `PROJECT_SOURCE_DIR` refers
to the root of the capstone source tree.

Recently introduced changes to enable CPack (#2590) are using the wrong
variable and are hence breaking builds that use capstone through
fetch_content. Use the correct variable to fix this issue. 

Additionally, harden the setup even further by only including cpack whenever capstone is a top-level project. In theory, either commit is sufficient, but it seems more correct to do both things. (For reference, a look at the fmt library, which is often used through fetch_content, does something similar at https://github.com/fmtlib/fmt/blob/0c9fce2ffefecfdce794e1859584e25877b7b592/CMakeLists.txt#L503).

(Regression from 6.0.0-alpha2, where using capstone with fetch_content still worked.)