### PR TITLE
Decode BH field in print_insn_detail_ppc

### DIFF
--- a/cstool/cstool_powerpc.c
+++ b/cstool/cstool_powerpc.c
@@ -141,8 +141,17 @@ void print_insn_detail_ppc(csh handle, cs_insn *ins)
 		printf("\tBranch:\n");
 		printf("\t\tbi: %u\n", ppc->bc.bi);
 		printf("\t\tbo: %u\n", ppc->bc.bo);
-		if (ppc->bc.bh != PPC_BH_INVALID)
-			printf("\t\tbh: %u\n", ppc->bc.bh);
+		if (ppc->bc.bh != PPC_BH_INVALID) {
+			int bh=-1;
+			switch(ppc->bc.bh) {
+				case PPC_BH_SUBROUTINE_RET: bh=0; break;
+				case PPC_BH_NO_SUBROUTINE_RET: bh=1; break;
+				case PPC_BH_NOT_PREDICTABLE: bh=3; break;
+				case PPC_BH_RESERVED: bh=2; break;
+				case PPC_BH_INVALID: break;
+			}
+			printf("\t\tbh: %u\n", bh);
+    }
 		if (ppc->bc.pred_cr != PPC_PRED_INVALID) {
 			printf("\t\tcrX: %s\n", cs_reg_name(handle, ppc->bc.crX));
 			printf("\t\tpred CR-bit: %s\n", get_pred_name(ppc->bc.pred_cr));


### PR DESCRIPTION
The enumeration value does not match the value in the BH field encoding table (Figure 2.7, OpenPOWER ISA v3.1C May 2024). There is a note about this in capstone/ppc.h where ppc_bh is declared.

**before**

```
/cstool -d ppc64 "0x2000824c"
 0  20 00 82 4c  bflr	eq
	ID: 1712 (bclr)
	Is alias: 1955 (bflr) with ALIAS operand set
	op_count: 1
		operands[0].type: REG = 2
		operands[0].access: READ
	Branch:
		bi: 2
		bo: 4
		bh: 1   <---
		crX: cr0
		pred CR-bit: ne
	Implicit registers read: ctr lr **ROUNDING MODE**
	Implicit registers modified: ctr
	Groups: jump 
```

**after**

```
./cstool -d ppc64 "0x2000824c"
 0  20 00 82 4c  bflr	eq
	ID: 1712 (bclr)
	Is alias: 1955 (bflr) with ALIAS operand set
	op_count: 1
		operands[0].type: REG = 2
		operands[0].access: READ
	Branch:
		bi: 2
		bo: 4
		bh: 0   <---
		crX: cr0
		pred CR-bit: ne
	Implicit registers read: ctr lr **ROUNDING MODE**
	Implicit registers modified: ctr
	Groups: jump
```