### PR TITLE
Stringify BH fields when printing ppc details

### DIFF
--- a/cstool/cstool_powerpc.c
+++ b/cstool/cstool_powerpc.c
@@ -142,15 +142,23 @@ void print_insn_detail_ppc(csh handle, cs_insn *ins)
 		printf("\t\tbi: %u\n", ppc->bc.bi);
 		printf("\t\tbo: %u\n", ppc->bc.bo);
 		if (ppc->bc.bh != PPC_BH_INVALID) {
-			int bh=-1;
+			char const* msg = NULL;
 			switch(ppc->bc.bh) {
-				case PPC_BH_SUBROUTINE_RET: bh=0; break;
-				case PPC_BH_NO_SUBROUTINE_RET: bh=1; break;
-				case PPC_BH_NOT_PREDICTABLE: bh=3; break;
-				case PPC_BH_RESERVED: bh=2; break;
+				case PPC_BH_SUBROUTINE_RET:
+					msg = "subroutine return";
+					break;
+				case PPC_BH_NO_SUBROUTINE_RET:
+					msg = "not a subroutine return";
+					break;
+				case PPC_BH_NOT_PREDICTABLE:
+					msg = "unpredictable";
+					break;
+				case PPC_BH_RESERVED:
+					msg = "reserved";
+					break;
 				case PPC_BH_INVALID: break;
 			}
-			printf("\t\tbh: %u\n", bh);
+			printf("\t\tbh: %s\n", msg);
     }
 		if (ppc->bc.pred_cr != PPC_PRED_INVALID) {
 			printf("\t\tcrX: %s\n", cs_reg_name(handle, ppc->bc.crX));

--- a/cstool/cstool_powerpc.c
+++ b/cstool/cstool_powerpc.c
@@ -171,7 +171,7 @@ void print_insn_detail_ppc(csh handle, cs_insn *ins)
 	}
 
 	if (ppc->bc.hint != PPC_BR_NOT_GIVEN)
-		printf("\tBranch hint: %u\n", ppc->bc.hint);
+		printf("\tBranch hint (at bits): %u\n", ppc->bc.hint);
 
 	if (ppc->update_cr0)
 		printf("\tUpdate-CR0: True\n");

--- a/include/capstone/ppc.h
+++ b/include/capstone/ppc.h
@@ -884,9 +884,10 @@ typedef struct {
 	uint8_t bi; ///< BI field of branch condition. UINT8_MAX if invalid.
 	ppc_cr_bit crX_bit; ///< CR field bit to test.
 	ppc_reg crX;	    ///< The CR field accessed.
-	ppc_br_hint hint;   ///< This is the hint encoded into the 'at' bits \
-                           of the BO field. Not to be confused with \
+	ppc_br_hint hint;   /** This is the hint encoded into the 'at' bits
+                           of the BO field. Not to be confused with
                            the BH field.
+                      */
 	ppc_pred pred_cr;   ///< CR-bit branch predicate
 	ppc_pred pred_ctr;  ///< CTR branch predicate
 	ppc_bh bh;	    ///< The BH field hint if any is present.

--- a/include/capstone/ppc.h
+++ b/include/capstone/ppc.h
@@ -884,7 +884,9 @@ typedef struct {
 	uint8_t bi; ///< BI field of branch condition. UINT8_MAX if invalid.
 	ppc_cr_bit crX_bit; ///< CR field bit to test.
 	ppc_reg crX;	    ///< The CR field accessed.
-	ppc_br_hint hint;   ///< The encoded hint.
+	ppc_br_hint hint;   ///< This is the hint encoded into the 'at' bits \
+                           of the BO field. Not to be confused with \
+                           the BH field.
 	ppc_pred pred_cr;   ///< CR-bit branch predicate
 	ppc_pred pred_ctr;  ///< CTR branch predicate
 	ppc_bh bh;	    ///< The BH field hint if any is present.


### PR DESCRIPTION
This extends #2662.

@Rot127

- [x] string descriptions are meaningful
- [x] update documentation
