### PR TITLE
MIPS: Fix MIPS16 decoding, wrong flags and ghost registers

### DIFF
--- a/arch/Mips/MipsDisassembler.c
+++ b/arch/Mips/MipsDisassembler.c
@@ -1457,6 +1457,7 @@ static DecodeStatus getInstruction(MCInst *Instr, uint64_t *Size, const uint8_t 
 	bool IsNanoMips = Mips_getFeatureBits(mode, Mips_FeatureNanoMips);
 	bool IsMips32r6 = Mips_getFeatureBits(mode, Mips_FeatureMips32r6);
 	bool IsMips2 = Mips_getFeatureBits(mode, Mips_FeatureMips2);
+	bool IsMips16 = Mips_getFeatureBits(mode, Mips_FeatureMips16);
 	bool IsCnMips = Mips_getFeatureBits(mode, Mips_FeatureCnMips);
 	bool IsCnMipsP = Mips_getFeatureBits(mode, Mips_FeatureCnMipsP);
 	bool IsFP64 = Mips_getFeatureBits(mode, Mips_FeatureFP64Bit);
@@ -1496,6 +1497,14 @@ static DecodeStatus getInstruction(MCInst *Instr, uint64_t *Size, const uint8_t 
 		Result = readInstruction16(Bytes, BytesLen, Address, Size,
 						&Insn, IsBigEndian);
 		if (Result != MCDisassembler_Fail) {
+			Result = decodeInstruction_2(DecoderTableNanoMips_Conflict_Space16,
+						     Instr, Insn, Address,
+						     NULL);
+			if (Result != MCDisassembler_Fail) {
+				*Size = 2;
+				return Result;
+			}
+
 			// Calling the auto-generated decoder function for NanoMips
 			// 16-bit instructions.
 			Result = decodeInstruction_2(DecoderTableNanoMips16,
@@ -1548,6 +1557,14 @@ static DecodeStatus getInstruction(MCInst *Instr, uint64_t *Size, const uint8_t 
 
 		if (IsMips32r6) {
 			// Calling the auto-generated decoder function.
+			Result = decodeInstruction_4(DecoderTableMicroMipsR6_Ambiguous32,
+						     Instr, Insn, Address,
+						     NULL);
+			if (Result != MCDisassembler_Fail) {
+				*Size = 4;
+				return Result;
+			}
+
 			Result = decodeInstruction_4(DecoderTableMicroMipsR632,
 						     Instr, Insn, Address,
 						     NULL);
@@ -1559,6 +1576,13 @@ static DecodeStatus getInstruction(MCInst *Instr, uint64_t *Size, const uint8_t 
 
 		// Calling the auto-generated decoder function.
 		Result = decodeInstruction_4(DecoderTableMicroMips32, Instr,
+					     Insn, Address, NULL);
+		if (Result != MCDisassembler_Fail) {
+			*Size = 4;
+			return Result;
+		}
+
+		Result = decodeInstruction_4(DecoderTableMicroMipsDSP32, Instr,
 					     Insn, Address, NULL);
 		if (Result != MCDisassembler_Fail) {
 			*Size = 4;
@@ -1582,6 +1606,28 @@ static DecodeStatus getInstruction(MCInst *Instr, uint64_t *Size, const uint8_t 
 		// unconditionally branched over.
 		*Size = 2;
 		return MCDisassembler_Fail;
+	}
+
+	if (IsMips16) {
+		Result = readInstruction32(Bytes, BytesLen, Address, Size,
+					   &Insn, IsBigEndian, IsMicroMips);
+		if (Result != MCDisassembler_Fail) {
+			Result = decodeInstruction_4(DecoderTable32, Instr, Insn, Address,
+						     NULL);
+			if (Result != MCDisassembler_Fail) {
+				*Size = 4;
+				return Result;
+			}
+		}
+
+		Result = readInstruction16(Bytes, BytesLen, Address, Size,
+					   &Insn, IsBigEndian);
+		if (Result == MCDisassembler_Fail) {
+			return MCDisassembler_Fail;
+		}
+
+		*Size = 2;
+		return decodeInstruction_2(DecoderTable16, Instr, Insn, Address, NULL);
 	}
 
 	// Attempt to read the instruction so that we can attempt to decode it. If
@@ -1617,6 +1663,16 @@ static DecodeStatus getInstruction(MCInst *Instr, uint64_t *Size, const uint8_t 
 	}
 
 	if (IsMips32r6) {
+		Result = decodeInstruction_4(DecoderTableMips32r6_64r6_Ambiguous32, Instr,
+					     Insn, Address, NULL);
+		if (Result != MCDisassembler_Fail)
+			return Result;
+
+		Result = decodeInstruction_4(DecoderTableMips32r6_64r6_BranchZero32, Instr,
+					     Insn, Address, NULL);
+		if (Result != MCDisassembler_Fail)
+			return Result;
+
 		Result = decodeInstruction_4(DecoderTableMips32r6_64r632, Instr,
 					     Insn, Address, NULL);
 		if (Result != MCDisassembler_Fail)
@@ -1658,6 +1714,11 @@ static DecodeStatus getInstruction(MCInst *Instr, uint64_t *Size, const uint8_t 
 			return Result;
 	}
 
+	Result = decodeInstruction_4(DecoderTableMipsDSP32, Instr, Insn,
+				     Address, NULL);
+	if (Result != MCDisassembler_Fail)
+		return Result;
+
 	// Calling the auto-generated decoder function.
 	Result = decodeInstruction_4(DecoderTableMips32, Instr, Insn, Address,
 				     NULL);
@@ -1671,7 +1732,15 @@ static DecodeStatus DecodeCPU16RegsRegisterClass(MCInst *Inst, unsigned RegNo,
 						 uint64_t Address,
 						 const void *Decoder)
 {
-	return MCDisassembler_Fail;
+	if (RegNo > 7)
+		return MCDisassembler_Fail;
+
+	if (RegNo < 2)
+		RegNo += 16;
+
+	unsigned Reg = getReg(Inst, Mips_GPR32RegClassID, RegNo);
+	MCOperand_CreateReg0(Inst, (Reg));
+	return MCDisassembler_Success;
 }
 
 static DecodeStatus DecodeGPR64RegisterClass(MCInst *Inst, unsigned RegNo,

--- a/arch/Mips/MipsDisassembler.c
+++ b/arch/Mips/MipsDisassembler.c
@@ -236,8 +236,6 @@ bool Mips_getFeatureBits(unsigned int mode, unsigned int feature)
 		}
 		return true;
 	}
-	case Mips_FeatureUseIndirectJumpsHazard:
-		return true;
 	default:
 		return false;
 	}

--- a/arch/Mips/MipsGenDisassemblerTables.inc
+++ b/arch/Mips/MipsGenDisassemblerTables.inc
@@ -101,7 +101,7 @@ static const uint8_t DecoderTable16[] = {
 /* 299 */     MCD_OPC_CheckPredicate, 0, 57, 1, 0, // Skip to: 617
 /* 304 */     MCD_OPC_CheckField, 8, 3, 0, 50, 1, 0, // Skip to: 617
 /* 311 */     MCD_OPC_Decode, 150, 15, 10, // Opcode: JrcRx16
-/* 315 */     MCD_OPC_FilterValue, 7, 41, 1, 0, // Skip to: 617
+/* 315 */     MCD_OPC_FilterValue, 5, 41, 1, 0, // Skip to: 617
 /* 320 */     MCD_OPC_CheckPredicate, 0, 36, 1, 0, // Skip to: 617
 /* 325 */     MCD_OPC_CheckField, 8, 3, 0, 29, 1, 0, // Skip to: 617
 /* 332 */     MCD_OPC_Decode, 149, 15, 10, // Opcode: JrcRa16
@@ -190,7 +190,7 @@ static const uint8_t DecoderTable32[] = {
 /* 97 */      MCD_OPC_CheckField, 27, 5, 30, 167, 1, 0, // Skip to: 527
 /* 104 */     MCD_OPC_CheckField, 5, 3, 0, 160, 1, 0, // Skip to: 527
 /* 111 */     MCD_OPC_Decode, 240, 8, 16, // Opcode: BnezRxImmX16
-/* 115 */     MCD_OPC_FilterValue, 6, 106, 0, 0, // Skip to: 226
+/* 115 */     MCD_OPC_FilterValue, 12, 106, 0, 0, // Skip to: 226
 /* 120 */     MCD_OPC_ExtractField, 27, 5,  // Inst{31-27} ...
 /* 123 */     MCD_OPC_FilterValue, 30, 143, 1, 0, // Skip to: 527
 /* 128 */     MCD_OPC_ExtractField, 16, 5,  // Inst{20-16} ...

--- a/arch/Mips/MipsInstPrinter.c
+++ b/arch/Mips/MipsInstPrinter.c
@@ -145,6 +145,9 @@ static void patch_cs_detail_operand_reg(cs_mips_op *Op, unsigned Reg, unsigned A
 }
 
 static void patch_cs_details(MCInst *MI) {
+	if (!detail_is_set(MI))
+		return;
+
 	cs_mips_op *op0 = NULL, *op1 = NULL, *op2 = NULL;
 	unsigned opcode = MCInst_getOpcode(MI);
 	unsigned n_ops = MCInst_getNumOperands(MI);

--- a/arch/Mips/MipsInstPrinter.c
+++ b/arch/Mips/MipsInstPrinter.c
@@ -121,6 +121,98 @@ static void printRegName(MCInst *MI, SStream *OS, MCRegister Reg)
 	SStream_concat0(OS, Mips_LLVM_getRegisterName(Reg, syntax_opt & CS_OPT_SYNTAX_NOREGNAME));
 }
 
+static void patch_cs_printer_no_dollar(SStream *O) {
+	char *dollar = strchr(O->buffer, '$');
+	if (!dollar) {
+		return;
+	}
+	size_t dollar_len = strlen(dollar + 1);
+	// to include `\0`
+	memmove(dollar, dollar + 1, dollar_len + 1);
+}
+
+static void patch_cs_detail_operand_reg(cs_mips_op *Op, unsigned Reg, unsigned Access) {
+	Op->type = MIPS_OP_REG;
+	Op->reg = Reg;
+	Op->is_reglist = false;
+	Op->access = Access;
+}
+
+static void patch_cs_details(MCInst *MI) {
+	cs_mips_op *op0 = NULL, *op1 = NULL, *op2 = NULL;
+	unsigned opcode = MCInst_getOpcode(MI);
+	unsigned n_ops = MCInst_getNumOperands(MI);
+
+	switch(opcode) {
+	/* mips r2 to r5 only 64bit */
+	case Mips_DSDIV: /// ddiv $$zero, $rs, $rt
+		/* fall-thru */
+	case Mips_DUDIV: /// ddivu $$zero, $rs, $rt
+		if (n_ops == 2) {
+			Mips_inc_op_count(MI);
+			op0 = Mips_get_detail_op(MI, -3);
+			op1 = Mips_get_detail_op(MI, -2);
+			op2 = Mips_get_detail_op(MI, -1);
+			// move all details by one and add $zero reg
+			*op2 = *op1;
+			*op1 = *op0;
+			patch_cs_detail_operand_reg(op0, MIPS_REG_ZERO_64, CS_AC_WRITE);
+		}
+		return;
+
+	/* mips r2 to r5 only */
+	case Mips_SDIV: /// div $$zero, $rs, $rt
+		/* fall-thru */
+	case Mips_UDIV: /// divu $$zero, $rs, $rt
+		/* fall-thru */
+	/* microMIPS only */
+	case Mips_SDIV_MM: /// div $$zero, $rs, $rt
+		/* fall-thru */
+	case Mips_UDIV_MM: /// divu $$zero, $rs, $rt
+		/* fall-thru */
+
+	/* MIPS16 only */
+	case Mips_DivRxRy16: /// div $$zero, $rx, $ry
+		/* fall-thru */
+	case Mips_DivuRxRy16: /// divu $$zero, $rx, $ry
+		if (n_ops == 2) {
+			Mips_inc_op_count(MI);
+			op0 = Mips_get_detail_op(MI, -3);
+			op1 = Mips_get_detail_op(MI, -2);
+			op2 = Mips_get_detail_op(MI, -1);
+			// move all details by one and add $zero reg
+			*op2 = *op1;
+			*op1 = *op0;
+			patch_cs_detail_operand_reg(op0, MIPS_REG_ZERO, CS_AC_WRITE);
+		}
+		return;
+	case Mips_AddiuSpImm16:
+		/* fall-thru */
+	case Mips_AddiuSpImmX16:
+		/// addiu $sp, imm8
+		if (n_ops == 1) {
+			Mips_inc_op_count(MI);
+			op0 = Mips_get_detail_op(MI, -2);
+			op1 = Mips_get_detail_op(MI, -1);
+			// move all details by one and add $sp reg
+			*op1 = *op0;
+			patch_cs_detail_operand_reg(op0, MIPS_REG_SP, CS_AC_WRITE);
+		}
+		return;
+	case Mips_JrcRa16: /// jrc $ra
+		/* fall-thru */
+	case Mips_JrRa16: /// jr $ra
+		if (n_ops < 1) {
+			Mips_inc_op_count(MI);
+			op0 = Mips_get_detail_op(MI, -1);
+			patch_cs_detail_operand_reg(op0, MIPS_REG_RA, CS_AC_READ);
+		}
+		return;
+	default:
+		return;
+	}
+}
+
 void Mips_LLVM_printInst(MCInst *MI, uint64_t Address, SStream *O) {
 	bool useAliasDetails = map_use_alias_details(MI);
 	if (!useAliasDetails) {
@@ -136,6 +228,11 @@ void Mips_LLVM_printInst(MCInst *MI, uint64_t Address, SStream *O) {
 	} else {
 		printInstruction(MI, Address, O);
 	}
+
+	if (MI->csh->syntax & CS_OPT_SYNTAX_NO_DOLLAR) {
+		patch_cs_printer_no_dollar(O);
+	}
+	patch_cs_details(MI);
 
 	if (!useAliasDetails) {
 		map_set_fill_detail_ops(MI, true);

--- a/arch/Mips/MipsInstPrinter.c
+++ b/arch/Mips/MipsInstPrinter.c
@@ -121,14 +121,20 @@ static void printRegName(MCInst *MI, SStream *OS, MCRegister Reg)
 	SStream_concat0(OS, Mips_LLVM_getRegisterName(Reg, syntax_opt & CS_OPT_SYNTAX_NOREGNAME));
 }
 
-static void patch_cs_printer_no_dollar(SStream *O) {
-	char *dollar = strchr(O->buffer, '$');
-	if (!dollar) {
-		return;
+static void patch_cs_printer(MCInst *MI, SStream *O) {
+	if (MI->csh->syntax & CS_OPT_SYNTAX_NO_DOLLAR) {
+		char *dollar = strchr(O->buffer, '$');
+		if (!dollar) {
+			return;
+		}
+		size_t dollar_len = strlen(dollar + 1);
+		// to include `\0`
+		memmove(dollar, dollar + 1, dollar_len + 1);
 	}
-	size_t dollar_len = strlen(dollar + 1);
-	// to include `\0`
-	memmove(dollar, dollar + 1, dollar_len + 1);
+
+	// replace '# 16 bit inst' to empty.
+	SStream_replc(O, '#', 0);
+	SStream_trimls(O);
 }
 
 static void patch_cs_detail_operand_reg(cs_mips_op *Op, unsigned Reg, unsigned Access) {
@@ -186,17 +192,16 @@ static void patch_cs_details(MCInst *MI) {
 			patch_cs_detail_operand_reg(op0, MIPS_REG_ZERO, CS_AC_WRITE);
 		}
 		return;
-	case Mips_AddiuSpImm16:
+	case Mips_AddiuSpImm16: /// addiu $$sp, imm8
 		/* fall-thru */
-	case Mips_AddiuSpImmX16:
-		/// addiu $sp, imm8
+	case Mips_AddiuSpImmX16: /// addiu $$sp, imm8
 		if (n_ops == 1) {
 			Mips_inc_op_count(MI);
 			op0 = Mips_get_detail_op(MI, -2);
 			op1 = Mips_get_detail_op(MI, -1);
 			// move all details by one and add $sp reg
 			*op1 = *op0;
-			patch_cs_detail_operand_reg(op0, MIPS_REG_SP, CS_AC_WRITE);
+			patch_cs_detail_operand_reg(op0, MIPS_REG_SP, CS_AC_READ_WRITE);
 		}
 		return;
 	case Mips_JrcRa16: /// jrc $ra
@@ -229,9 +234,7 @@ void Mips_LLVM_printInst(MCInst *MI, uint64_t Address, SStream *O) {
 		printInstruction(MI, Address, O);
 	}
 
-	if (MI->csh->syntax & CS_OPT_SYNTAX_NO_DOLLAR) {
-		patch_cs_printer_no_dollar(O);
-	}
+	patch_cs_printer(MI, O);
 	patch_cs_details(MI);
 
 	if (!useAliasDetails) {

--- a/arch/Mips/MipsInstPrinter.c
+++ b/arch/Mips/MipsInstPrinter.c
@@ -122,6 +122,10 @@ static void printRegName(MCInst *MI, SStream *OS, MCRegister Reg)
 }
 
 static void patch_cs_printer(MCInst *MI, SStream *O) {
+	// replace '# 16 bit inst' to empty.
+	SStream_replc(O, '#', 0);
+	SStream_trimls(O);
+
 	if (MI->csh->syntax & CS_OPT_SYNTAX_NO_DOLLAR) {
 		char *dollar = strchr(O->buffer, '$');
 		if (!dollar) {
@@ -131,17 +135,13 @@ static void patch_cs_printer(MCInst *MI, SStream *O) {
 		// to include `\0`
 		memmove(dollar, dollar + 1, dollar_len + 1);
 	}
-
-	// replace '# 16 bit inst' to empty.
-	SStream_replc(O, '#', 0);
-	SStream_trimls(O);
 }
 
-static void patch_cs_detail_operand_reg(cs_mips_op *Op, unsigned Reg, unsigned Access) {
-	Op->type = MIPS_OP_REG;
-	Op->reg = Reg;
-	Op->is_reglist = false;
-	Op->access = Access;
+static void patch_cs_detail_operand_reg(cs_mips_op *op, unsigned reg, unsigned access) {
+	op->type = MIPS_OP_REG;
+	op->reg = reg;
+	op->is_reglist = false;
+	op->access = access;
 }
 
 static void patch_cs_details(MCInst *MI) {
@@ -157,16 +157,17 @@ static void patch_cs_details(MCInst *MI) {
 	case Mips_DSDIV: /// ddiv $$zero, $rs, $rt
 		/* fall-thru */
 	case Mips_DUDIV: /// ddivu $$zero, $rs, $rt
-		if (n_ops == 2) {
-			Mips_inc_op_count(MI);
-			op0 = Mips_get_detail_op(MI, -3);
-			op1 = Mips_get_detail_op(MI, -2);
-			op2 = Mips_get_detail_op(MI, -1);
-			// move all details by one and add $zero reg
-			*op2 = *op1;
-			*op1 = *op0;
-			patch_cs_detail_operand_reg(op0, MIPS_REG_ZERO_64, CS_AC_WRITE);
+		if (n_ops != 2) {
+			return;
 		}
+		Mips_inc_op_count(MI);
+		op0 = Mips_get_detail_op(MI, -3);
+		op1 = Mips_get_detail_op(MI, -2);
+		op2 = Mips_get_detail_op(MI, -1);
+		// move all details by one and add $zero reg
+		*op2 = *op1;
+		*op1 = *op0;
+		patch_cs_detail_operand_reg(op0, MIPS_REG_ZERO_64, CS_AC_WRITE);
 		return;
 
 	/* mips r2 to r5 only */
@@ -184,37 +185,40 @@ static void patch_cs_details(MCInst *MI) {
 	case Mips_DivRxRy16: /// div $$zero, $rx, $ry
 		/* fall-thru */
 	case Mips_DivuRxRy16: /// divu $$zero, $rx, $ry
-		if (n_ops == 2) {
-			Mips_inc_op_count(MI);
-			op0 = Mips_get_detail_op(MI, -3);
-			op1 = Mips_get_detail_op(MI, -2);
-			op2 = Mips_get_detail_op(MI, -1);
-			// move all details by one and add $zero reg
-			*op2 = *op1;
-			*op1 = *op0;
-			patch_cs_detail_operand_reg(op0, MIPS_REG_ZERO, CS_AC_WRITE);
+		if (n_ops != 2) {
+			return;
 		}
+		Mips_inc_op_count(MI);
+		op0 = Mips_get_detail_op(MI, -3);
+		op1 = Mips_get_detail_op(MI, -2);
+		op2 = Mips_get_detail_op(MI, -1);
+		// move all details by one and add $zero reg
+		*op2 = *op1;
+		*op1 = *op0;
+		patch_cs_detail_operand_reg(op0, MIPS_REG_ZERO, CS_AC_WRITE);
 		return;
 	case Mips_AddiuSpImm16: /// addiu $$sp, imm8
 		/* fall-thru */
 	case Mips_AddiuSpImmX16: /// addiu $$sp, imm8
-		if (n_ops == 1) {
-			Mips_inc_op_count(MI);
-			op0 = Mips_get_detail_op(MI, -2);
-			op1 = Mips_get_detail_op(MI, -1);
-			// move all details by one and add $sp reg
-			*op1 = *op0;
-			patch_cs_detail_operand_reg(op0, MIPS_REG_SP, CS_AC_READ_WRITE);
+		if (n_ops != 1) {
+			return;
 		}
+		Mips_inc_op_count(MI);
+		op0 = Mips_get_detail_op(MI, -2);
+		op1 = Mips_get_detail_op(MI, -1);
+		// move all details by one and add $sp reg
+		*op1 = *op0;
+		patch_cs_detail_operand_reg(op0, MIPS_REG_SP, CS_AC_READ_WRITE);
 		return;
 	case Mips_JrcRa16: /// jrc $ra
 		/* fall-thru */
 	case Mips_JrRa16: /// jr $ra
-		if (n_ops < 1) {
-			Mips_inc_op_count(MI);
-			op0 = Mips_get_detail_op(MI, -1);
-			patch_cs_detail_operand_reg(op0, MIPS_REG_RA, CS_AC_READ);
+		if (n_ops > 0) {
+			return;
 		}
+		Mips_inc_op_count(MI);
+		op0 = Mips_get_detail_op(MI, -1);
+		patch_cs_detail_operand_reg(op0, MIPS_REG_RA, CS_AC_READ);
 		return;
 	default:
 		return;

--- a/suite/cstest/include/test_mapping.h
+++ b/suite/cstest/include/test_mapping.h
@@ -213,6 +213,8 @@ static const TestOptionMapEntry test_option_map[] = {
 	  .opt = { .type = CS_OPT_SYNTAX, .val = CS_OPT_SYNTAX_CS_REG_ALIAS } },
 	{ .str = "CS_OPT_SYNTAX_PERCENT",
 	  .opt = { .type = CS_OPT_SYNTAX, .val = CS_OPT_SYNTAX_PERCENT } },
+	{ .str = "CS_OPT_SYNTAX_NO_DOLLAR",
+	  .opt = { .type = CS_OPT_SYNTAX, .val = CS_OPT_SYNTAX_NO_DOLLAR } },
 };
 
 static const cs_enum_id_map cs_enum_map[] = {

--- a/tests/MC/Mips/valid-mips32r6-el.txt.yaml
+++ b/tests/MC/Mips/valid-mips32r6-el.txt.yaml
@@ -207,7 +207,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "beqzalc $2, 1340"
+          asm_text: "bnezalc $2, 1340"
 
   -
     input:
@@ -547,7 +547,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "bovc $zero, $zero, 12"
+          asm_text: "bnvc $zero, $zero, 12"
 
   -
     input:

--- a/tests/MC/Mips/valid-mips32r6.txt.yaml
+++ b/tests/MC/Mips/valid-mips32r6.txt.yaml
@@ -507,7 +507,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "bovc $zero, $zero, 12"
+          asm_text: "bnvc $zero, $zero, 12"
 
   -
     input:
@@ -517,7 +517,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "beqzalc $2, 1340"
+          asm_text: "bnezalc $2, 1340"
 
   -
     input:

--- a/tests/details/cs_common_details.yaml
+++ b/tests/details/cs_common_details.yaml
@@ -422,7 +422,7 @@ test_cases:
           mnemonic: "lw"
           op_str: "$v0, 0($sp)"
           details:
-            groups: [ HasStdEnc, NotInMicroMips, NotNanoMips ]
+            groups: [ NotInMips16Mode, HasDSP ]
         -
           asm_text: "ori $at, $at, 0x3456"
           mnemonic: "ori"

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6003,3 +6003,13 @@ test_cases:
       - asm_text: "addq_s.w    $v1, $a0, $a1"
       - asm_text: "dpaq_s.w.ph $ac1, $a1, $v1"
       - asm_text: "dpaq_sa.l.w $ac2, $a0, $v1"
+
+  - input:
+      name: "Test nanomips BNEC[16] (not available in NMS) - Conflict_Space16"
+      bytes: [ 0xd8, 0xf6 ]
+      arch: "CS_ARCH_MIPS"
+      options: [ CS_MODE_NANOMIPS, CS_MODE_BIG_ENDIAN ]
+      address: 0x0
+    expected:
+      insns:
+      - asm_text: "bnec $a3, $s1, 14"

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -5978,3 +5978,15 @@ test_cases:
                 reg: sp
               - type: MIPS_OP_IMM
                 imm: 0x2065
+  - input:
+      name: "Test mips32 DSP"
+      bytes: [ 0x7e,0x32,0x83,0x11,0x7e,0x53,0x8d,0x11,0x7e,0x74,0x95,0x51,0x7e,0x95,0x9b,0xd1 ]
+      arch: "CS_ARCH_MIPS"
+      options: [ CS_MODE_MIPS32, CS_MODE_BIG_ENDIAN ]
+      address: 0x0
+    expected:
+      insns:
+      - asm_text: "precrq.qb.ph    $s0, $s1, $s2"
+      - asm_text: "precrq.ph.w     $s1, $s2, $s3"
+      - asm_text: "precrq_rs.ph.w  $s2, $s3, $s4"
+      - asm_text: "precrqu_s.qb.ph $s3, $s4, $s5"

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -5891,3 +5891,15 @@ test_cases:
       insns:
       -
         asm_text: "jalr $t9"
+
+  -
+    input:
+      name: "ddiv on mips64r2"
+      bytes: [ 0x01, 0x11, 0x00, 0x1e ]
+      arch: "CS_ARCH_MIPS"
+      options: [ CS_MODE_MIPS64R2, CS_MODE_BIG_ENDIAN, CS_OPT_SYNTAX_NO_DOLLAR ] #, CS_OPT_DETAIL, CS_OPT_DETAIL_REAL ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "ddiv $zero, t0, s1"

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -5990,3 +5990,16 @@ test_cases:
       - asm_text: "precrq.ph.w     $s1, $s2, $s3"
       - asm_text: "precrq_rs.ph.w  $s2, $s3, $s4"
       - asm_text: "precrqu_s.qb.ph $s3, $s4, $s5"
+
+  - input:
+      name: "Test microMips32r3 DSP"
+      bytes: [ 0x00,0xa4,0x1c,0x0d,0x00,0xa4,0x1b,0x05,0x00,0x65,0x42,0xbc,0x00,0x64,0x92,0xbc ]
+      arch: "CS_ARCH_MIPS"
+      options: [ CS_MODE_MICRO32R3, CS_MODE_BIG_ENDIAN ]
+      address: 0x0
+    expected:
+      insns:
+      - asm_text: "addq_s.ph   $v1, $a0, $a1"
+      - asm_text: "addq_s.w    $v1, $a0, $a1"
+      - asm_text: "dpaq_s.w.ph $ac1, $a1, $v1"
+      - asm_text: "dpaq_sa.l.w $ac2, $a0, $v1"

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6013,3 +6013,16 @@ test_cases:
     expected:
       insns:
       - asm_text: "bnec $a3, $s1, 14"
+
+  - input:
+      name: "Test mips32r6 - Conflict_Space16"
+      bytes: [ 0x58, 0x63, 0x00, 0x00, 0x5C, 0x63, 0x00, 0x00 ]
+      arch: "CS_ARCH_MIPS"
+      options: [ CS_MODE_MIPS32R6, CS_MODE_BIG_ENDIAN ]
+      address: 0x0
+    expected:
+      insns:
+      - asm_text: "bgezc  $v1, 4"
+      - asm_text: "bltzc  $v1, 8"
+
+

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -5880,3 +5880,14 @@ test_cases:
         asm_text: "svc #0x8"
         details:
           groups: [ call, int ]
+  -
+    input:
+      name: "jalr on mips32r2"
+      bytes: [ 0x09, 0xf8, 0x20, 0x03 ]
+      arch: "CS_ARCH_MIPS"
+      options: [ CS_MODE_MIPS32R2, CS_MODE_LITTLE_ENDIAN ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "jalr $t9"

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -5895,11 +5895,29 @@ test_cases:
   -
     input:
       name: "ddiv on mips64r2"
-      bytes: [ 0x01, 0x11, 0x00, 0x1e ]
+      bytes: [ 0x01, 0x11, 0x00, 0x1e, 0x01, 0x65, 0x00, 0x1a ]
       arch: "CS_ARCH_MIPS"
-      options: [ CS_MODE_MIPS64R2, CS_MODE_BIG_ENDIAN, CS_OPT_SYNTAX_NO_DOLLAR ] #, CS_OPT_DETAIL, CS_OPT_DETAIL_REAL ]
+      options: [ CS_MODE_MIPS64R2, CS_MODE_BIG_ENDIAN, CS_OPT_SYNTAX_NO_DOLLAR, CS_OPT_DETAIL ]
       address: 0x0
     expected:
       insns:
-      -
-        asm_text: "ddiv $zero, t0, s1"
+      - asm_text: "ddiv zero, t0, s1"
+        details:
+          mips:
+            operands:
+              - type: MIPS_OP_REG
+                reg: zero
+              - type: MIPS_OP_REG
+                reg: t0
+              - type: MIPS_OP_REG
+                reg: s1
+      - asm_text: "div zero, t3, a1"
+        details:
+          mips:
+            operands:
+              - type: MIPS_OP_REG
+                reg: zero
+              - type: MIPS_OP_REG
+                reg: t3
+              - type: MIPS_OP_REG
+                reg: a1

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -5921,3 +5921,60 @@ test_cases:
                 reg: t3
               - type: MIPS_OP_REG
                 reg: a1
+
+  - input:
+      name: "jr/jrc/ ra & div/divu zero on mips16"
+      bytes: [ 0xe8, 0x20,  0xe8, 0xa0,  0xeb, 0x5a,  0xeb, 0x5b,  0x63, 0x1e,  0xf0, 0x64, 0x63, 0x05 ]
+      arch: "CS_ARCH_MIPS"
+      options: [ CS_MODE_MIPS16, CS_MODE_BIG_ENDIAN, CS_OPT_SYNTAX_NO_DOLLAR, CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+      - asm_text: "jr ra"
+        details:
+          mips:
+            operands:
+              - type: MIPS_OP_REG
+                reg: ra
+      - asm_text: "jrc ra"
+        details:
+          mips:
+            operands:
+              - type: MIPS_OP_REG
+                reg: ra
+      - asm_text: "div zero, v1, v0"
+        details:
+          mips:
+            operands:
+              - type: MIPS_OP_REG
+                reg: zero
+              - type: MIPS_OP_REG
+                reg: v1
+              - type: MIPS_OP_REG
+                reg: v0
+      - asm_text: "divu zero, v1, v0"
+        details:
+          mips:
+            operands:
+              - type: MIPS_OP_REG
+                reg: zero
+              - type: MIPS_OP_REG
+                reg: v1
+              - type: MIPS_OP_REG
+                reg: v0
+      - asm_text: "addiu sp, 0x1e"
+        details:
+          mips:
+            operands:
+              - type: MIPS_OP_REG
+                reg: sp
+              - type: MIPS_OP_IMM
+                imm: 0x1e
+      - asm_text: "addiu sp, 0x2065"
+        details:
+          mips:
+            operands:
+              - type: MIPS_OP_REG
+                reg: sp
+              - type: MIPS_OP_IMM
+                imm: 0x2065


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Disables Mips_FeatureUseIndirectJumpsHazard
- Mips_FeatureUseIndirectJumpsHazard is only used for enabling/disabling `jalr` in mips32 configs.

Adds missing mips decoding tables:
- DecoderTableNanoMips_Conflict_Space16
- DecoderTableMicroMipsR6_Ambiguous32
- DecoderTableMicroMipsDSP32
- DecoderTable16 (mips16 only)
- DecoderTable32 (mips16 only)
- DecoderTableMips32r6_64r6_Ambiguous32
- DecoderTableMips32r6_64r6_BranchZero32
- DecoderTableMipsDSP32

Fixes for mips16
- decoding of JrcRa16 & AddiuSpImmX16 was expecting the wrong bits.
- DecodeCPU16RegsRegisterClass was not implemented.


**Test plan**

Added test to verify the correctness

**Closing issues**

Fix #2652