### PR TITLE
Build PDB for debugging on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -825,6 +825,12 @@ if(CAPSTONE_BUILD_SHARED_LIBS)
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     )
     target_compile_definitions(capstone PUBLIC CAPSTONE_SHARED)
+    # Build pdb file for dll on Windows
+    if(WIN32)
+        message("Enabling PDB for Windows")
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
+        set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
+    endif()
 endif()
 
 # Fuzzer if this is moved to it's own CMakeLists.txt (as it should be)
@@ -950,6 +956,14 @@ if(CAPSTONE_INSTALL)
             NAMESPACE capstone::
             DESTINATION ${CAPSTONE_CMAKE_CONFIG_INSTALL_DIR}
     )
+
+    if (WIN32 AND CAPSTONE_BUILD_SHARED_LIBS)
+        install(FILES
+            $<TARGET_PDB_FILE:capstone_shared>
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
+            OPTIONAL
+        )
+    endif()
 
     # uninstall target
     if(NOT TARGET UNINSTALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -826,10 +826,10 @@ if(CAPSTONE_BUILD_SHARED_LIBS)
     )
     target_compile_definitions(capstone PUBLIC CAPSTONE_SHARED)
     # Build pdb file for dll on Windows
-    if(WIN32)
+    if(MSVC)
         message("Enabling PDB for Windows")
         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
-        set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
+        set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG")
     endif()
 endif()
 
@@ -957,7 +957,7 @@ if(CAPSTONE_INSTALL)
             DESTINATION ${CAPSTONE_CMAKE_CONFIG_INSTALL_DIR}
     )
 
-    if (WIN32 AND CAPSTONE_BUILD_SHARED_LIBS)
+    if (MSVC AND CAPSTONE_BUILD_SHARED_LIBS)
         install(FILES
             $<TARGET_PDB_FILE:capstone_shared>
             DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

See https://github.com/capstone-engine/capstone/issues/2642
Currently, using CMake can compile Capstone on Windows using Clang or MSVC toolchain to generate .lib static libraries and .dll dynamic libraries. However, the .pdb file corresponding to the dynamic library is not being installed. To facilitate debugging, this pull request adds support for generating and installing the .pdb file.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

On Windows:
```cmd
git clone https://github.com/stevenjoezhang/capstone.git -b windows
cd capstone
call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
cmake -B build -T "ClangCL,host=x64" -A x64 -DCAPSTONE_BUILD_SHARED_LIBS=ON
cmake --build build --config Release --target install --clean-first
:: Then check "C:\Program Files\capstone\bin\capstone.pdb"
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->


