### PR TITLE
Add jump group for generic jirl

### DIFF
--- a/arch/LoongArch/LoongArchMapping.c
+++ b/arch/LoongArch/LoongArchMapping.c
@@ -375,6 +375,9 @@ static void LoongArch_add_cs_groups(MCInst *MI)
 		} else if (loongarch->op_count == 1) {
 			// jr rj
 			add_group(MI, LOONGARCH_GRP_JUMP);
+		} else if (loongarch->op_count == 3) {
+			// none of the above, generic jirl
+			add_group(MI, LOONGARCH_GRP_JUMP);
 		}
 		break;
 	case LOONGARCH_INS_B:

--- a/tests/details/loongarch.yaml
+++ b/tests/details/loongarch.yaml
@@ -34,7 +34,7 @@ test_cases:
                 imm: -1
   -
     input:
-      bytes: [ 0x80, 0x80, 0x00, 0x40, 0x63, 0x80, 0xff, 0x02, 0x78, 0x20, 0xc0, 0x29, 0x00, 0x84, 0x00, 0x01, 0x00, 0xa4, 0x14, 0x01  ]
+      bytes: [ 0x80, 0x80, 0x00, 0x40, 0x63, 0x80, 0xff, 0x02, 0x78, 0x20, 0xc0, 0x29, 0x00, 0x84, 0x00, 0x01, 0x00, 0xa4, 0x14, 0x01, 0xed, 0x01, 0x00, 0x4c  ]
       arch: "loongarch"
       options: [ CS_OPT_DETAIL, CS_MODE_LOONGARCH64]
       address: 0x0
@@ -105,3 +105,18 @@ test_cases:
               -
                 type: LOONGARCH_OP_REG
                 reg: zero
+      -
+        asm_text: "jirl	$t1, $t3, 0"
+        details:
+          loongarch:
+            operands:
+              -
+                type: LOONGARCH_OP_REG
+                reg: t1
+              -
+                type: LOONGARCH_OP_REG
+                reg: t3
+              -
+                type: LOONGARCH_OP_IMM
+                imm: 0x0
+          groups: [ LOONGARCH_GRP_JUMP ]


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Add jump group when jirl has three operands. Fixes #2690.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

`./build/suite/cstest/cstest tests/details/loongarch.yaml` passes:

```shell
Test files found: 1
[==========] All test cases: Running 2 test(s).
[ RUN      ] /loongarch.yaml - TC #0: TestInput { arch: loongarch, options: [CS_OPT_DETAIL, CS_MODE_LOONGARCH32], addr: 0x0, bytes: 0x0c, 0x00, 0x08, 0x14, 0x8c, 0xfd, 0xbf, 0x02 }
[       OK ] /loongarch.yaml - TC #0: TestInput { arch: loongarch, options: [CS_OPT_DETAIL, CS_MODE_LOONGARCH32], addr: 0x0, bytes: 0x0c, 0x00, 0x08, 0x14, 0x8c, 0xfd, 0xbf, 0x02 }
[ RUN      ] /loongarch.yaml - TC #1: TestInput { arch: loongarch, options: [CS_OPT_DETAIL, CS_MODE_LOONGARCH64], addr: 0x0, bytes: 0x80, 0x80, 0x00, 0x40, 0x63, 0x80, 0xff, 0x02, 0x78, 0x20, 0xc0, 0x29, 0x00, 0x84, 0x00, 0x01, 0x00, 0xa4, 0x14, 0x01, 0xed, 0x01, 0x00, 0x4c }
[       OK ] /loongarch.yaml - TC #1: TestInput { arch: loongarch, options: [CS_OPT_DETAIL, CS_MODE_LOONGARCH64], addr: 0x0, bytes: 0x80, 0x80, 0x00, 0x40, 0x63, 0x80, 0xff, 0x02, 0x78, 0x20, 0xc0, 0x29, 0x00, 0x84, 0x00, 0x01, 0x00, 0xa4, 0x14, 0x01, 0xed, 0x01, 0x00, 0x4c }
[==========] All test cases: 2 test(s) run.
[  PASSED  ] 2 test(s).

-----------------------------------------
Test run statistics

Valid files: 1
Invalid files: 0
Errors: 0

Test cases:
        Total: 2
        Successful: 2
        Skipped: 0
        Failed: 0

        Decoded instructions: 8
-----------------------------------------

[o] All tests succeeded.
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

#2690 
