### PR TITLE
Add flag for the SoftFail case of the LLVM disassembler.

### DIFF
--- a/MCInst.c
+++ b/MCInst.c
@@ -319,3 +319,13 @@ void MCInst_updateWithTmpMI(MCInst *MI, MCInst *TmpMI) {
 	assert(MI->size < MAX_MC_OPS);
 	memcpy(MI->Operands, TmpMI->Operands, sizeof(MI->Operands[0]) * MI->size);
 }
+
+/// @brief Sets the softfail/illegal flag in the cs_insn.
+/// Setting it indicates the instruction can be decoded, but is invalid
+/// due to not allowed operands or an illegal context.
+///
+/// @param MI The MCInst holding the cs_insn currently decoded.
+void MCInst_setSoftFail(MCInst *MI) {
+	assert(MI && MI->flat_insn);
+	MI->flat_insn->illegal = true;
+}

--- a/MCInst.h
+++ b/MCInst.h
@@ -179,4 +179,6 @@ static inline bool MCInst_isAlias(const MCInst *MI) {
 
 void MCInst_updateWithTmpMI(MCInst *MI, MCInst *TmpMI);
 
+void MCInst_setSoftFail(MCInst *MI);
+
 #endif

--- a/arch/AArch64/AArch64Mapping.c
+++ b/arch/AArch64/AArch64Mapping.c
@@ -821,11 +821,14 @@ bool AArch64_getInstruction(csh handle, const uint8_t *code, size_t code_len,
 			    void *info)
 {
 	AArch64_init_cs_detail(MI);
-	bool Result = AArch64_LLVM_getInstruction(handle, code, code_len, MI,
+	DecodeStatus Result = AArch64_LLVM_getInstruction(handle, code, code_len, MI,
 						  size, address,
-						  info) != MCDisassembler_Fail;
+						  info);
 	AArch64_set_instr_map_data(MI);
-	return Result;
+	if (Result == MCDisassembler_SoftFail) {
+		MCInst_setSoftFail(MI);
+	}
+	return Result != MCDisassembler_Fail;
 }
 
 /// Patches the register names with Capstone specific alias.

--- a/arch/ARC/ARCMapping.c
+++ b/arch/ARC/ARCMapping.c
@@ -142,12 +142,14 @@ bool ARC_getInstruction(csh handle, const uint8_t *code, size_t code_len,
 {
 	uint64_t temp_size;
 	ARC_init_cs_detail(instr);
-	bool Result = ARC_LLVM_getInstruction(instr, &temp_size, code,
-						    code_len, address, info) !=
-		      MCDisassembler_Fail;
+	DecodeStatus Result = ARC_LLVM_getInstruction(instr, &temp_size, code,
+						    code_len, address, info);
 	ARC_set_instr_map_data(instr);
 	*size = temp_size;
-	return Result;
+	if (Result == MCDisassembler_SoftFail) {
+		MCInst_setSoftFail(instr);
+	}
+	return Result != MCDisassembler_Fail;
 }
 
 void ARC_printer(MCInst *MI, SStream *O,

--- a/arch/ARM/ARMMapping.c
+++ b/arch/ARM/ARMMapping.c
@@ -816,11 +816,14 @@ bool ARM_getInstruction(csh handle, const uint8_t *code, size_t code_len,
 			void *info)
 {
 	ARM_init_cs_detail(instr);
-	bool Result = ARM_LLVM_getInstruction(handle, code, code_len, instr,
+	DecodeStatus Result = ARM_LLVM_getInstruction(handle, code, code_len, instr,
 					      size, address,
-					      info) != MCDisassembler_Fail;
+					      info);
 	ARM_set_instr_map_data(instr);
-	return Result;
+	if (Result == MCDisassembler_SoftFail) {
+		MCInst_setSoftFail(instr);
+	}
+	return Result != MCDisassembler_Fail;
 }
 
 #define GET_REGINFO_MC_DESC

--- a/arch/Alpha/AlphaMapping.c
+++ b/arch/Alpha/AlphaMapping.c
@@ -173,10 +173,13 @@ bool Alpha_getInstruction(csh handle, const uint8_t *code,
 								  uint16_t *size, uint64_t address, void *info)
 {
 	Alpha_init_cs_detail(instr);
-	bool Result = Alpha_LLVM_getInstruction(handle, code, code_len, instr, size,
+	DecodeStatus Result = Alpha_LLVM_getInstruction(handle, code, code_len, instr, size,
 									 address, info);
 	Alpha_set_instr_map_data(instr);
-	return Result;
+	if (Result == MCDisassembler_SoftFail) {
+		MCInst_setSoftFail(instr);
+	}
+	return Result != MCDisassembler_Fail;
 }
 
 #endif

--- a/arch/LoongArch/LoongArchMapping.c
+++ b/arch/LoongArch/LoongArchMapping.c
@@ -386,12 +386,14 @@ bool LoongArch_getInstruction(csh handle, const uint8_t *code, size_t code_len,
 {
 	uint64_t temp_size;
 	LoongArch_init_cs_detail(instr);
-	bool Result = LoongArch_LLVM_getInstruction(instr, &temp_size, code,
-						    code_len, address, info) !=
-		      MCDisassembler_Fail;
+	DecodeStatus Result = LoongArch_LLVM_getInstruction(instr, &temp_size, code,
+						    code_len, address, info);
 	LoongArch_set_instr_map_data(instr);
 	*size = temp_size;
-	return Result;
+	if (Result == MCDisassembler_SoftFail) {
+		MCInst_setSoftFail(instr);
+	}
+	return Result != MCDisassembler_Fail;
 }
 
 /// Adds group to the instruction which are not defined in LLVM.

--- a/arch/Mips/MipsMapping.c
+++ b/arch/Mips/MipsMapping.c
@@ -197,14 +197,17 @@ bool Mips_getInstruction(csh handle, const uint8_t *code, size_t code_len,
 	instr->MRI = (MCRegisterInfo *)info;
 	map_set_fill_detail_ops(instr, true);
 
-	bool result = Mips_LLVM_getInstruction(instr, &size64, code, code_len,
+	DecodeStatus Result = Mips_LLVM_getInstruction(instr, &size64, code, code_len,
 					       address,
-					       info) != MCDisassembler_Fail;
-	if (result) {
+					       info);
+	*size = size64;
+	if (Result != MCDisassembler_Fail) {
 		Mips_set_instr_map_data(instr);
 	}
-	*size = size64;
-	return result;
+	if (Result == MCDisassembler_SoftFail) {
+		MCInst_setSoftFail(instr);
+	}
+	return Result != MCDisassembler_Fail;
 }
 
 void Mips_printer(MCInst *MI, SStream *O, void * /* MCRegisterInfo* */ info)

--- a/arch/RISCV/RISCVDisassembler.c
+++ b/arch/RISCV/RISCVDisassembler.c
@@ -421,11 +421,15 @@ bool RISCV_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 {
   	cs_struct *handle = (cs_struct *)(uintptr_t)ud;
 
-  	return MCDisassembler_Success == 
+		DecodeStatus Result =
 	   	RISCVDisassembler_getInstruction(handle->mode, instr,
 				            	 code, code_len,
 			                    	 size, address,
 			                    	 (MCRegisterInfo *)info);
+	if (Result == MCDisassembler_SoftFail) {
+		MCInst_setSoftFail(instr);
+	}
+	return Result != MCDisassembler_Fail;
 
 }
 

--- a/arch/SystemZ/SystemZMapping.c
+++ b/arch/SystemZ/SystemZMapping.c
@@ -94,10 +94,13 @@ bool SystemZ_getInstruction(csh handle, const uint8_t *bytes, size_t bytes_len,
 {
 	SystemZ_init_cs_detail(MI);
 	MI->MRI = (MCRegisterInfo *)info;
-	DecodeStatus result = SystemZ_LLVM_getInstruction(
+	DecodeStatus Result = SystemZ_LLVM_getInstruction(
 		handle, bytes, bytes_len, MI, size, address, info);
 	SystemZ_set_instr_map_data(MI, bytes, bytes_len);
-	return result != MCDisassembler_Fail;
+	if (Result == MCDisassembler_SoftFail) {
+		MCInst_setSoftFail(MI);
+	}
+	return Result != MCDisassembler_Fail;
 }
 
 // given internal insn id, return public instruction info

--- a/arch/XCore/XCoreDisassembler.c
+++ b/arch/XCore/XCoreDisassembler.c
@@ -747,6 +747,9 @@ bool XCore_getInstruction(csh ud, const uint8_t *code, size_t code_len, MCInst *
 	// Calling the auto-generated decoder function.
 	Result = decodeInstruction_2(DecoderTable16, MI, insn16, address, info, 0);
 	if (Result != MCDisassembler_Fail) {
+		if (Result == MCDisassembler_SoftFail) {
+			MCInst_setSoftFail(MI);
+		}
 		*size = 2;
 		return true;
 	}
@@ -758,6 +761,9 @@ bool XCore_getInstruction(csh ud, const uint8_t *code, size_t code_len, MCInst *
 	// Calling the auto-generated decoder function.
 	Result = decodeInstruction_4(DecoderTable32, MI, insn32, address, info, 0);
 	if (Result != MCDisassembler_Fail) {
+		if (Result == MCDisassembler_SoftFail) {
+			MCInst_setSoftFail(MI);
+		}
 		*size = 4;
 		return true;
 	}

--- a/arch/Xtensa/XtensaMapping.c
+++ b/arch/Xtensa/XtensaMapping.c
@@ -73,10 +73,13 @@ bool Xtensa_disasm(csh handle, const uint8_t *code, size_t code_len,
 {
 	DecodeStatus res = Xtensa_LLVM_getInstruction(instr, size, code,
 						      code_len, address);
-	if (res == MCDisassembler_Success) {
+	if (res != MCDisassembler_Fail) {
 		set_instr_map_data(instr);
 	}
-	return res == MCDisassembler_Success;
+	if (res == MCDisassembler_SoftFail) {
+		MCInst_setSoftFail(instr);
+	}
+	return res != MCDisassembler_Fail;
 }
 
 const char *Xtensa_reg_name(csh handle, unsigned int id)

--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -625,6 +625,7 @@ class _cs_insn(ctypes.Structure):
         ('op_str', ctypes.c_char * 160),
         ('is_alias', ctypes.c_bool),
         ('usesAliasDetails', ctypes.c_bool),
+        ('illegal', ctypes.c_bool),
         ('detail', ctypes.POINTER(_cs_detail)),
     )
 
@@ -832,6 +833,13 @@ class CsInsn(object):
     @property
     def is_alias(self):
         return self._raw.is_alias
+
+    # return instruction's illegal flag
+    # Set if instruction can be decoded but is invalid
+    # due to context or illegal operands.
+    @property
+    def illegal(self):
+        return self._raw.illegal
 
     # return instruction's alias_id
     @property

--- a/bindings/python/cstest_py/src/cstest_py/cstest.py
+++ b/bindings/python/cstest_py/src/cstest_py/cstest.py
@@ -253,6 +253,9 @@ class TestExpected:
             if not compare_tbool(a_insn.is_alias, e_insn.get("is_alias"), "is_alias"):
                 return TestResult.FAILED
 
+            if not compare_tbool(a_insn.illegal, e_insn.get("illegal"), "illegal"):
+                return TestResult.FAILED
+
             if not compare_enum(a_insn.alias_id, e_insn.get("alias_id"), "alias_id"):
                 return TestResult.FAILED
 

--- a/cstool/cstool.c
+++ b/cstool/cstool.c
@@ -768,7 +768,8 @@ int main(int argc, char **argv)
 				}
 			}
 
-			printf("  %s\t%s\n", insn[i].mnemonic, insn[i].op_str);
+			printf("  %s\t%s%s\n", insn[i].mnemonic, insn[i].op_str,
+			       insn[i].illegal ? "\t; Illegal instruction" : "");
 
 			if (detail_flag) {
 				print_details(handle, arch, mode, &insn[i]);

--- a/docs/cs_v6_release_guide.md
+++ b/docs/cs_v6_release_guide.md
@@ -79,7 +79,12 @@ For `v7` we can then focus on other big features, like [SAIL](https://github.com
 
 ## New features
 
-These features are only supported by `auto-sync`-enabled architectures.
+**LLVM disassembler based modules**
+
+- The `cs_insn.illegal` flag was added. If it is set the instruction is decoded correctly but is considered illegal.
+  This happens for instructions which use invalid operands or are in an illegal context.
+
+**Auto-Sync-enabled modules**
 
 **More code quality checks**
 

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -510,6 +510,13 @@ typedef struct cs_insn {
 	/// False: The detail operands are from the real instruction.
 	bool usesAliasDetails;
 
+	/// True: The bytes disassemble to a valid instruction, but it is illegal by ISA definitions.
+	/// For example the instruction uses a register which is not allowed or it appears in
+	/// an invalid context.
+	///
+	/// False: The instruction decoded correctly and is valid.
+	bool illegal;
+
 	/// Pointer to cs_detail.
 	/// NOTE: detail pointer is only valid when both requirements below are met:
 	/// (1) CS_OP_DETAIL = CS_OPT_ON

--- a/suite/cstest/include/test_case.h
+++ b/suite/cstest/include/test_case.h
@@ -62,6 +62,7 @@ typedef struct {
 	char *asm_text;	  // mandatory
 	char *op_str;
 	int32_t is_alias; ///< 0 == not given, >0 == true, <0 == false
+	int32_t illegal; ///< 0 == not given, >0 == true, <0 == false
 	char *alias_id;
 	char *mnemonic;
 	TestDetail *details;
@@ -81,6 +82,8 @@ static const cyaml_schema_field_t test_insn_data_mapping_schema[] = {
 		TestInsnData, op_str, 0, CYAML_UNLIMITED),
 	CYAML_FIELD_INT("is_alias", CYAML_FLAG_OPTIONAL, TestInsnData,
 			 is_alias),
+	CYAML_FIELD_INT("illegal", CYAML_FLAG_OPTIONAL, TestInsnData,
+			 illegal),
 	CYAML_FIELD_STRING_PTR("alias_id",
 			CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
 			TestInsnData, alias_id, 0, CYAML_UNLIMITED),

--- a/suite/cstest/src/test_case.c
+++ b/suite/cstest/src/test_case.c
@@ -115,6 +115,7 @@ TestInsnData *test_insn_data_clone(TestInsnData *test_insn_data)
 				cs_strdup(test_insn_data->id) :
 				NULL;
 	tid->is_alias = test_insn_data->is_alias;
+	tid->illegal = test_insn_data->illegal;
 	tid->mnemonic = test_insn_data->mnemonic ?
 				cs_strdup(test_insn_data->mnemonic) :
 				NULL;
@@ -246,6 +247,13 @@ void test_expected_compare(csh *handle, TestExpected *expected, cs_insn *insns,
 				assert_true(insns[i].is_alias);
 			} else {
 				assert_false(insns[i].is_alias);
+			}
+		}
+		if (expec_data->illegal != 0) {
+			if (expec_data->illegal > 0) {
+				assert_true(insns[i].illegal);
+			} else {
+				assert_false(insns[i].illegal);
 			}
 		}
 		if (expec_data->alias_id) {

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6101,3 +6101,118 @@ test_cases:
     expected:
       insns:
       - asm_text: "jalrc $ra, $t0"
+
+  - input:
+      name: "Add flag for softfail case - #2703 and #1991."
+      bytes: [ 0x07, 0xB0, 0xBD, 0xE8 ]
+      arch: "CS_ARCH_ARM"
+      options: [ CS_MODE_LITTLE_ENDIAN ]
+      address: 0x0
+    expected:
+      insns:
+      - asm_text: "pop	{r0, r1, r2, r12, sp, pc}"
+        illegal: 1
+
+  - input:
+      name: "Add flag for softfail case - #2703 and #1991."
+      bytes: [ 0xf0, 0x00, 0xf0, 0xe7, 0x07, 0xB0, 0xBD, 0xE8, 0xf0, 0x00, 0xf0, 0xe7 ]
+      arch: "CS_ARCH_ARM"
+      options: [ CS_MODE_LITTLE_ENDIAN ]
+      address: 0x0
+    expected:
+      insns:
+      - asm_text: "udf #0"
+        illegal: -1
+      - asm_text: "pop	{r0, r1, r2, r12, sp, pc}"
+        illegal: 1
+      - asm_text: "udf #0"
+        illegal: -1
+  -
+    input:
+      name: "Add flag for softfail case - #2703 and #1991."
+      bytes: [ 0x21, 0x04, 0x03, 0x5e ]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_MODE_LITTLE_ENDIAN ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "mov b1, v1.b[1]"
+        illegal: -1
+  -
+    input:
+      name: "Add flag for softfail case - #2703 and #1991."
+      bytes: [ 0x04, 0x11, 0x00, 0x00 ]
+      arch: "CS_ARCH_ARC"
+      options: [ CS_MODE_LITTLE_ENDIAN ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "ld %r0, [%r1,4]"
+        illegal: -1
+  -
+    input:
+      name: "Add flag for softfail case - #2703 and #1991."
+      bytes: [ 0x63, 0xb8, 0xb5, 0x2c ]
+      arch: "CS_ARCH_LOONGARCH"
+      options: [ "CS_MODE_LOONGARCH64" ]
+    expected:
+      insns:
+        -
+          asm_text: "xvld $xr3, $sp, -0x292"
+          illegal: -1
+  -
+    input:
+      name: "Add flag for softfail case - #2703 and #1991."
+      bytes: [ 0x03, 0x00, 0x22, 0x40 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "addl $1,$2,$3"
+          illegal: -1
+  -
+    input:
+      name: "Add flag for softfail case - #2703 and #1991."
+      bytes: [ 0x41, 0x60, 0x0b, 0xc1 ]
+      arch: "CS_ARCH_MIPS"
+      options: [ "CS_OPT_SYNTAX_NOREGNAME", "CS_MODE_BIG_ENDIAN", "CS_MODE_MIPS32R2" ]
+    expected:
+      insns:
+        -
+          asm_text: "dmt"
+          illegal: -1
+  -
+    input:
+      name: "Add flag for softfail case - #2703 and #1991."
+      bytes: [ 0x37, 0x34, 0x00, 0x00 ]
+      arch: "CS_ARCH_RISCV"
+      options: [ "CS_MODE_RISCV32" ]
+    expected:
+      insns:
+        -
+          asm_text: "lui s0, 3"
+          illegal: -1
+  -
+    input:
+      name: "Add flag for softfail case - #2703 and #1991."
+      bytes: [ 0xfe, 0x0f ]
+      arch: "xcore"
+      options: [ CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+        -
+          asm_text: "get r11, ed"
+          illegal: -1
+  - input:
+      name: "Add flag for softfail case - #2703 and #1991."
+      bytes: [ 0x18, 0x23 ]
+      arch: "CS_ARCH_XTENSA"
+      options: [ ]
+    expected:
+      insns:
+        - asm_text: "l32i.n a1, a3, 8"
+          illegal: -1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The LLVM disassembler returns SoftFail if the instruction can be decoded, but it is illegal due to other reasons.

E.g. because it uses operands it is not allowed to use or the instructions is invalid in a given context.

New `cstool` output:
```
cstool arm "0xf0, 0x00, 0xf0, 0xe7, 0x07, 0xB0, 0xBD, 0xE8, 0xf0, 0x00, 0xf0, 0xe7"
 0  f0 00 f0 e7  udf	#0
 4  07 b0 bd e8  pop	{r0, r1, r2, r12, sp, pc}	; Illegal instruction
 8  f0 00 f0 e7  udf	#0
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Added.

I didn't went through the trouble looking up a SoftFail case for each architecture.
But added the instructions from the issues and null-hypothesis test cases.

Can't reproduce the instruction sequence from #1991. No idea what I did there. But it is not added as use case.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes https://github.com/capstone-engine/capstone/issues/2703
closes https://github.com/capstone-engine/capstone/issues/1991
