### PR TITLE
Fix missing operand for smstart, due to space replaced by tab

### DIFF
--- a/arch/AArch64/AArch64Mapping.c
+++ b/arch/AArch64/AArch64Mapping.c
@@ -670,7 +670,7 @@ static void AArch64_add_not_defined_ops(MCInst *MI, const SStream *OS)
 	case AARCH64_INS_ALIAS_SMSTART:
 	case AARCH64_INS_ALIAS_SMSTOP: {
 		const char *disp_off = NULL;
-		disp_off = strstr(OS->buffer, " za");
+		disp_off = strstr(OS->buffer, "smstart\tza");
 		if (disp_off) {
 			aarch64_sysop sysop = { 0 };
 			sysop.alias.svcr = AARCH64_SVCR_SVCRZA;
@@ -679,7 +679,7 @@ static void AArch64_add_not_defined_ops(MCInst *MI, const SStream *OS)
 						  AARCH64_OP_SYSALIAS);
 			return;
 		}
-		disp_off = strstr(OS->buffer, " sm");
+		disp_off = strstr(OS->buffer, "smstart\tsm");
 		if (disp_off) {
 			aarch64_sysop sysop = { 0 };
 			sysop.alias.svcr = AARCH64_SVCR_SVCRSM;

--- a/tests/details/aarch64.yaml
+++ b/tests/details/aarch64.yaml
@@ -1505,3 +1505,40 @@ test_cases:
               access: CS_AC_READ
           regs_read: []
           regs_write: []
+  -
+    input:
+      bytes: [0x7f, 0x43, 0x03, 0xd5, 0x7f, 0x45, 0x03, 0xd5, 0x7f, 0x47, 0x03, 0xd5]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "smstart sm"
+        details:
+          aarch64:
+            operands:
+            -
+              type: AARCH64_OP_SYSALIAS
+              sub_type: AARCH64_OP_SVCR
+              sys_raw_val: 0x1
+          regs_read: []
+          regs_write: []
+      -
+        asm_text: "smstart za"
+        details:
+          aarch64:
+            operands:
+            -
+              type: AARCH64_OP_SYSALIAS
+              sub_type: AARCH64_OP_SVCR
+              sys_raw_val: 0x2
+          regs_read: []
+          regs_write: []
+      -
+        asm_text: "smstart"
+        details:
+          aarch64:
+            operands: []
+          regs_read: []
+          regs_write: []


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Fix missing operand for smstart, due to space replaced by tab in assembly: `smstart sm` -> `smstart\tsm`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

`./suite/cstest/cstest ../tests/details/aarch64.yaml`

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #2715
