### PR TITLE
Use cs_ac_type for operand access mode in all arches and use cs_xtensa_op_type for Xtensa operand type

### DIFF
--- a/arch/M680X/M680XDisassembler.c
+++ b/arch/M680X/M680XDisassembler.c
@@ -103,12 +103,11 @@ typedef enum e_access_mode {
 } e_access_mode;
 
 // Access type values are compatible with enum cs_ac_type:
-typedef enum e_access {
-	UNCHANGED = CS_AC_INVALID,
-	READ = CS_AC_READ,
-	WRITE = CS_AC_WRITE,
-	MODIFY = (CS_AC_READ | CS_AC_WRITE),
-} e_access;
+typedef cs_ac_type e_access;
+#define UNCHANGED CS_AC_INVALID
+#define READ CS_AC_READ
+#define WRITE CS_AC_WRITE
+#define MODIFY CS_AC_READ_WRITE
 
 /* Properties of one instruction in PAGE1 (without prefix) */
 typedef struct inst_page1 {

--- a/bindings/python/capstone/aarch64.py
+++ b/bindings/python/capstone/aarch64.py
@@ -110,7 +110,7 @@ class AArch64Op(ctypes.Structure):
         ('is_vreg', ctypes.c_bool),
         ('value', AArch64OpValue),
         ('sysop', AArch64SysOp),
-        ('access', ctypes.c_uint8),
+        ('access', ctypes.c_uint),
         ('is_list_member', ctypes.c_bool),
     )
 

--- a/bindings/python/capstone/alpha.py
+++ b/bindings/python/capstone/alpha.py
@@ -20,7 +20,7 @@ class AlphaOp(ctypes.Structure):
     _fields_ = (
         ('type', ctypes.c_uint),
         ('value', AlphaOpValue),
-        ('access', ctypes.c_uint8)
+        ('access', ctypes.c_uint)
     )
 
     @property

--- a/bindings/python/capstone/arm.py
+++ b/bindings/python/capstone/arm.py
@@ -53,7 +53,7 @@ class ArmOp(ctypes.Structure):
         ('type', ctypes.c_uint),
         ('value', ArmOpValue),
         ('subtracted', ctypes.c_bool),
-        ('access', ctypes.c_uint8),
+        ('access', ctypes.c_uint),
         ('neon_lane', ctypes.c_int8),
     )
 

--- a/bindings/python/capstone/bpf.py
+++ b/bindings/python/capstone/bpf.py
@@ -28,7 +28,7 @@ class BPFOp(ctypes.Structure):
         ('value', BPFOpValue),
         ('is_signed', ctypes.c_bool),
         ('is_pkt', ctypes.c_bool),
-        ('access', ctypes.c_uint8),
+        ('access', ctypes.c_uint),
     )
 
     @property

--- a/bindings/python/capstone/hppa.py
+++ b/bindings/python/capstone/hppa.py
@@ -45,7 +45,7 @@ class HPPAOp(ctypes.Structure):
     _fields_ = (
         ('type', ctypes.c_uint8),
         ('value', HPPAOpValue),
-        ('access', ctypes.c_uint8)
+        ('access', ctypes.c_uint)
     )
 
     @property

--- a/bindings/python/capstone/m680x.py
+++ b/bindings/python/capstone/m680x.py
@@ -44,7 +44,7 @@ class M680xOp(ctypes.Structure):
         ('type', ctypes.c_uint),
         ('value', M680xOpValue),
         ('size', ctypes.c_uint8),
-        ('access', ctypes.c_uint8),
+        ('access', ctypes.c_uint),
     )
 
     @property

--- a/bindings/python/capstone/mips.py
+++ b/bindings/python/capstone/mips.py
@@ -25,7 +25,7 @@ class MipsOp(ctypes.Structure):
         ('value', MipsOpValue),
         ('is_reglist', ctypes.c_bool),
         ('is_unsigned', ctypes.c_bool),
-        ('access', ctypes.c_uint8),
+        ('access', ctypes.c_uint),
     )
 
     @property

--- a/bindings/python/capstone/riscv.py
+++ b/bindings/python/capstone/riscv.py
@@ -22,7 +22,7 @@ class RISCVOp(ctypes.Structure):
     _fields_ = (
         ('type', ctypes.c_uint),
         ('value', RISCVOpValue),
-        ('access', ctypes.c_uint8),
+        ('access', ctypes.c_uint),
     )
 
     @property

--- a/bindings/python/capstone/systemz.py
+++ b/bindings/python/capstone/systemz.py
@@ -25,7 +25,7 @@ class SystemZOp(ctypes.Structure):
     _fields_ = (
         ('type', ctypes.c_uint),
         ('value', SystemZOpValue),
-        ('access', ctypes.c_int),
+        ('access', ctypes.c_uint),
         ('imm_width', ctypes.c_uint8),
     )
 

--- a/bindings/python/capstone/tricore.py
+++ b/bindings/python/capstone/tricore.py
@@ -23,7 +23,7 @@ class TriCoreOp(ctypes.Structure):
     _fields_ = (
         ('type', ctypes.c_uint),
         ('value', TriCoreOpValue),
-        ('access', ctypes.c_uint8)
+        ('access', ctypes.c_uint)
     )
 
     @property

--- a/bindings/python/capstone/x86.py
+++ b/bindings/python/capstone/x86.py
@@ -26,7 +26,7 @@ class X86Op(ctypes.Structure):
         ('type', ctypes.c_uint),
         ('value', X86OpValue),
         ('size', ctypes.c_uint8),
-        ('access', ctypes.c_uint8),
+        ('access', ctypes.c_uint),
         ('avx_bcast', ctypes.c_uint),
         ('avx_zero_opmask', ctypes.c_bool),
     )

--- a/cstool/cstool_xtensa.c
+++ b/cstool/cstool_xtensa.c
@@ -42,13 +42,13 @@ void print_insn_detail_xtensa(csh handle, cs_insn *ins)
 
 	for (i = 0; i < detail->op_count; i++) {
 		cs_xtensa_op *op = &(detail->operands[i]);
-		if (op->type == CS_OP_REG)
+		if (op->type == XTENSA_OP_REG)
 			printf("\t\toperands[%u].type: REG = %s\n", i,
 			       cs_reg_name(handle, op->reg));
-		else if (op->type == CS_OP_IMM)
+		else if (op->type == XTENSA_OP_IMM)
 			printf("\t\toperands[%u].type: IMM = 0x%" PRIx32 "\n",
 			       i, op->imm);
-		else if (op->type == CS_OP_MEM)
+		else if (op->type == XTENSA_OP_MEM)
 			printf("\t\toperands[%u].type: MEM\n"
 			       "\t\t\t.mem.base: REG = %s\n"
 			       "\t\t\t.mem.disp: 0x%" PRIx32 "\n",

--- a/docs/cs_v6_release_guide.md
+++ b/docs/cs_v6_release_guide.md
@@ -307,6 +307,7 @@ Such an instruction is ill-defined in LLVM and should be fixed upstream.
 | Immediate | Immediate values (`arm_op.imm`) type changed to `int64_t` | Prevent loss of precision in some cases. | None. |
 | `mem.lshift` | The `mem.lshift` field was removed. It was not set properly before and just duplicates information in `shift` | Remove faulty and duplicate code. | None. |
 | Instr. alias | Capstone now clearly separates real instructions and their aliases. Previously many aliases were treated as real instructions. See above for details. | This became a simple necessity because CS operates with a copy of the LLVMs decoder without changes to the decoder logic. |
+| Operand access type | Previously, operand access type is stored in the `uint8_t access;` field within operand details. However its possible values are stored in `enum cs_ac_type`. Now, the field has `enum cs_ac_type` type instead. | The user can find the connection between the field and the enum directly. | None |
 
 **ARM**
 

--- a/include/capstone/aarch64.h
+++ b/include/capstone/aarch64.h
@@ -2847,7 +2847,7 @@ typedef struct cs_aarch64_op {
   /// How is this operand accessed? (READ, WRITE or READ|WRITE)
   /// This field is combined of cs_ac_type.
   /// NOTE: this field is irrelevant if engine is compiled in DIET mode.
-  uint8_t access;
+  cs_ac_type access;
   bool is_list_member; ///< True if this operand is part of a register or vector list.
 } cs_aarch64_op;
 

--- a/include/capstone/arm.h
+++ b/include/capstone/arm.h
@@ -889,7 +889,7 @@ typedef struct cs_arm_op {
 	/// How is this operand accessed? (READ, WRITE or READ|WRITE)
 	/// This field is combined of cs_ac_type.
 	/// NOTE: this field is irrelevant if engine is compiled in DIET mode.
-	uint8_t access;
+	cs_ac_type access;
 
 	/// Neon lane index for NEON instructions (or -1 if irrelevant)
 	int8_t neon_lane;

--- a/include/capstone/bpf.h
+++ b/include/capstone/bpf.h
@@ -86,7 +86,7 @@ typedef struct cs_bpf_op {
 	/// How is this operand accessed? (READ, WRITE or READ|WRITE)
 	/// This field is combined of cs_ac_type.
 	/// NOTE: this field is irrelevant if engine is compiled in DIET mode.
-	uint8_t access;
+	cs_ac_type access;
 } cs_bpf_op;
 
 /// Instruction structure

--- a/include/capstone/loongarch.h
+++ b/include/capstone/loongarch.h
@@ -43,7 +43,7 @@ typedef struct cs_loongarch_op {
 
 	/// How is this operand accessed? (READ, WRITE or READ|WRITE)
 	/// NOTE: this field is irrelevant if engine is compiled in DIET mode.
-	uint8_t access;
+	cs_ac_type access;
 } cs_loongarch_op;
 
 /// LoongArch instruction formats. To get details about them please

--- a/include/capstone/m680x.h
+++ b/include/capstone/m680x.h
@@ -127,7 +127,7 @@ typedef struct cs_m680x_op {
 	/// How is this operand accessed? (READ, WRITE or READ|WRITE)
 	/// This field is combined of cs_ac_type.
 	/// NOTE: this field is irrelevant if engine is compiled in DIET 
-	uint8_t access;
+	cs_ac_type access;
 } cs_m680x_op;
 
 /// Group of M680X instructions

--- a/include/capstone/mips.h
+++ b/include/capstone/mips.h
@@ -694,7 +694,7 @@ typedef struct cs_mips_op {
 
 	/// How is this operand accessed? (READ, WRITE or READ|WRITE)
 	/// NOTE: this field is irrelevant if engine is compiled in DIET mode.
-	uint8_t access;
+	cs_ac_type access;
 } cs_mips_op;
 
 #define NUM_MIPS_OPS 10

--- a/include/capstone/riscv.h
+++ b/include/capstone/riscv.h
@@ -47,7 +47,7 @@ typedef struct cs_riscv_op {
 		int64_t imm;		// immediate value for IMM operand
 		riscv_op_mem mem;	// base/disp value for MEM operand
 	};
-	uint8_t access; ///< How is this operand accessed? (READ, WRITE or READ|WRITE)
+	cs_ac_type access; ///< How is this operand accessed? (READ, WRITE or READ|WRITE)
 } cs_riscv_op;
 
 #define NUM_RISCV_OPS 8

--- a/include/capstone/tricore.h
+++ b/include/capstone/tricore.h
@@ -44,7 +44,7 @@ typedef struct cs_tricore_op {
 	};
 	/// This field is combined of cs_ac_type.
 	/// NOTE: this field is irrelevant if engine is compiled in DIET mode.
-	uint8_t access; ///< How is this operand accessed? (READ, WRITE or READ|WRITE)
+	cs_ac_type access; ///< How is this operand accessed? (READ, WRITE or READ|WRITE)
 } cs_tricore_op;
 
 #define NUM_TRICORE_OPS 8

--- a/include/capstone/x86.h
+++ b/include/capstone/x86.h
@@ -289,7 +289,7 @@ typedef struct cs_x86_op {
 	/// How is this operand accessed? (READ, WRITE or READ|WRITE)
 	/// This field is combined of cs_ac_type.
 	/// NOTE: this field is irrelevant if engine is compiled in DIET mode.
-	uint8_t access;
+	cs_ac_type access;
 
 	/// AVX broadcast type, or 0 if irrelevant
 	x86_avx_bcast avx_bcast;

--- a/include/capstone/xtensa.h
+++ b/include/capstone/xtensa.h
@@ -1691,24 +1691,27 @@ typedef enum cs_xtensa_op_type {
 	XTENSA_OP_REG = CS_OP_REG,	   ///< = (Register operand).
 	XTENSA_OP_IMM = CS_OP_IMM,	   ///< = (Immediate operand).
 	XTENSA_OP_MEM = CS_OP_MEM,	   ///< = (Memory operand).
-	XTENSA_OP_MEM_REG = CS_OP_MEM_REG, ///< = (Memory Register operand).
-	XTENSA_OP_MEM_IMM = CS_OP_MEM_IMM, ///< = (Memory Immediate operand).
 	XTENSA_OP_L32R = CS_OP_SPECIAL + 0,			   ///< = (L32R Target)
 } cs_xtensa_op_type;
 
+/// Instruction's operand referring to memory
+/// This is associated with XTENSA_OP_MEM operand type above
 typedef struct cs_xtensa_op_mem {
-	uint8_t base;
-	int32_t disp;
+	uint8_t base;  ///< base register
+	int32_t disp;  ///< displacement/offset value
 } cs_xtensa_op_mem;
 
-typedef struct cs_xtensa_operand {
-	uint8_t type;
-	uint8_t access;
+/// Instruction operand
+typedef struct cs_xtensa_op {
+	cs_xtensa_op_type type;   //< operand type
+	/// How is this operand accessed? (READ, WRITE or READ|WRITE)
+	/// NOTE: this field is irrelevant if engine is compiled in DIET mode.
+	cs_ac_type access;
 
 	union {
-		uint8_t reg;
-		int32_t imm;
-		cs_xtensa_op_mem mem;
+		uint8_t reg;          /// register value for REG operand
+		int32_t imm;          /// immediate value for IMM operand
+		cs_xtensa_op_mem mem; /// base/disp value for MEM operand
 	};
 } cs_xtensa_op;
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Currently, some arches use uint8_t for operand access mode, while others
use cs_ac_type. Use cs_ac_type uniformly across all archs.

Additionally, use cs_xtensa_op_type for Xtensa operand types. Drop the unused XTENSA_OP_MEM_REG and XTENSA_OP_MEM_IMM.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Existing CI tests.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None
