### PR TITLE
Print immediate only memory operands for AArch64.

### DIFF
--- a/cstool/cstool_aarch64.c
+++ b/cstool/cstool_aarch64.c
@@ -53,7 +53,7 @@ void print_insn_detail_aarch64(csh handle, cs_insn *ins)
 				printf("\t\t\toperands[%u].mem.base: REG = %s\n", i, cs_reg_name(handle, op->mem.base));
 			if (op->mem.index != AARCH64_REG_INVALID)
 				printf("\t\t\toperands[%u].mem.index: REG = %s\n", i, cs_reg_name(handle, op->mem.index));
-			if (op->mem.disp != 0)
+			if (op->mem.disp != 0 || op->mem.base == AARCH64_REG_INVALID)
 				printf("\t\t\toperands[%u].mem.disp: 0x%x\n", i, op->mem.disp);
 			if (ins->detail->aarch64.post_index)
 				printf("\t\t\tpost-indexed: true\n");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

`cstool` prints a disponent only if it is not 0. But there are some memory operands which can be immediate only and can be 0. This fixes it.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Manually:
```
cstool -d aarch64 00000098
 0  00 00 00 98  ldrsw	x0, 0
	ID: 638 (ldrsw)
	op_count: 2
		operands[0].type: REG = x0
		operands[0].access: WRITE
		operands[1].type: MEM
			operands[1].mem.disp: 0x0
		operands[1].access: READ
	Registers modified: x0
```


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
