### PR TITLE
Handle zero case of R1 operand field

### DIFF
--- a/arch/SystemZ/SystemZMapping.c
+++ b/arch/SystemZ/SystemZMapping.c
@@ -321,6 +321,21 @@ void SystemZ_set_detail_op_reg(MCInst *MI, unsigned op_num, systemz_reg Reg)
 	if (!detail_is_set(MI))
 		return;
 	CS_ASSERT((map_get_op_type(MI, op_num) & ~CS_OP_MEM) == CS_OP_REG);
+	if (Reg == SYSTEMZ_REG_INVALID) {
+		// This case is legal. The ISA says:
+		// "
+		// When the R1 field is not zero, bits 8-15 of the instruction designated
+		// by the second-operand address are ORed with bits 56-63 of
+		// general register R1. [...] When the R1 field is zero, no ORing takes place
+		// "
+		// This means we just save the neutral element for ORing, so 0.
+		SystemZ_get_detail_op(MI, 0)->type = SYSTEMZ_OP_IMM;
+		SystemZ_get_detail_op(MI, 0)->imm = 0;
+		SystemZ_get_detail_op(MI, 0)->access = map_get_op_access(MI, op_num);
+		SystemZ_get_detail_op(MI, 0)->imm_width = 0;
+		SystemZ_inc_op_count(MI);
+		return;
+	}
 
 	SystemZ_get_detail_op(MI, 0)->type = SYSTEMZ_OP_REG;
 	SystemZ_get_detail_op(MI, 0)->reg = Reg;

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6263,3 +6263,21 @@ test_cases:
       insns:
         -
           asm_text: "c.srli a4, 5"
+  -
+    input:
+      name: "issue 2741 - SystemZ addresses with 0 operand."
+      bytes: [ 0xc6,0x00,0x00,0x00,0x00,0x05 ]
+      arch: "CS_ARCH_SYSTEMZ"
+      options: [ CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "exrl	0, 0xa"
+        details:
+          systemz:
+            operands:
+              - type: SYSTEMZ_OP_IMM
+                imm: 0
+              - type: SYSTEMZ_OP_IMM
+                imm: 0xa


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Handles the edge case from the ISA when the R1 field of an instruction is 0.
In this case the R1 field is not ORed with the upper instruction bits.
In order to have unchanged instruction details even for this edge case, the instructions have now only a 0 immediate as neutral operand. 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

added

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes https://github.com/capstone-engine/capstone/issues/2741
