### PR TITLE
Fix comisd memory operand size: xmmword -> qword

### DIFF
--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -237,7 +237,6 @@ static void printf64mem(MCInst *MI, unsigned OpNo, SStream *O)
 				MI->x86opsize = 8;
 				break;
 			case X86_MOVPQI2QImr:
-			case X86_COMISDrm:
 				SStream_concat0(O, "xmmword ptr ");
 				MI->x86opsize = 16;
 				break;

--- a/tests/details/x86.yaml
+++ b/tests/details/x86.yaml
@@ -1344,3 +1344,36 @@ test_cases:
             sib_scale: 0
           regs_read: [ rsp ]
           regs_write: [ rsp, rip ]
+  -
+    input:
+      bytes: [ 0x66, 0x45, 0x0f, 0x2f, 0x38 ]
+      arch: "x86"
+      options: [ CS_OPT_DETAIL, CS_MODE_64 ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "comisd	xmm15, qword ptr [r8]"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_OPSIZE, X86_PREFIX_0 ]
+            opcode: [ 0x0f, 0x2f, 0x00, 0x00 ]
+            rex: 0x45
+            addr_size: 8
+            modrm: 0x38
+            disp: 0x0
+            sib: 0x0
+            sib_scale: 0
+            operands:
+              -
+                type: X86_OP_REG
+                reg: xmm15
+                size: 16
+                access: CS_AC_READ
+              -
+                type: X86_OP_MEM
+                mem_base: r8
+                size: 8
+                access: CS_AC_READ
+          regs_read: [ xmm15, r8 ]
+          regs_write: [ rflags ]

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -1805,7 +1805,7 @@ test_cases:
         asm_text: "lock adc al, byte ptr [ebp + 8]"
   -
     input:
-      name: "issue 1456 xmmword"
+      name: "issue 1456/2748 xmmword"
       bytes: [ 0x66,0x0f,0x2f,0x00 ]
       arch: "CS_ARCH_X86"
       options: [ CS_MODE_32 ]
@@ -1813,7 +1813,7 @@ test_cases:
     expected:
       insns:
       -
-        asm_text: "comisd xmm0, xmmword ptr [eax]"
+        asm_text: "comisd xmm0, qword ptr [eax]"
   -
     input:
       name: "issue 1456 ARM printPKHASRShiftImm"


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Before:

comisd	xmm15, xmmword ptr [r8]

After:

comisd	xmm15, qword ptr [r8]

The new one is correct, according to binutils-gdb.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Run `./suite/cstest/cstest ../tests/details/x86.yaml`, all tests passed.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #2748.
