### PR TITLE
Fix duplication of memory operand

### DIFF
--- a/Mapping.c
+++ b/Mapping.c
@@ -338,7 +338,7 @@ const cs_ac_type mapping_get_op_access(MCInst *MI, unsigned OpNum,
 		if (!MI->flat_insn->detail) \
 			return NULL; \
 		int OpIdx = MI->flat_insn->detail->arch.op_count + offset; \
-		if (OpIdx < 0 && OpIdx >= NUM_##ARCH_UPPER##_OPS) { return NULL; } \
+		if (OpIdx < 0 || OpIdx >= NUM_##ARCH_UPPER##_OPS) { return NULL; } \
 		return &MI->flat_insn->detail->arch.operands[OpIdx]; \
 	}
 

--- a/Mapping.c
+++ b/Mapping.c
@@ -331,31 +331,31 @@ const cs_ac_type mapping_get_op_access(MCInst *MI, unsigned OpNum,
 }
 
 /// Returns the operand at detail->arch.operands[op_count + offset]
-/// Or NULL if detail is not set.
-#define DEFINE_get_detail_op(arch, ARCH) \
+/// Or NULL if detail is not set or the offset would be out of bounds.
+#define DEFINE_get_detail_op(arch, ARCH, ARCH_UPPER) \
 	cs_##arch##_op *ARCH##_get_detail_op(MCInst *MI, int offset) \
 	{ \
 		if (!MI->flat_insn->detail) \
 			return NULL; \
 		int OpIdx = MI->flat_insn->detail->arch.op_count + offset; \
-		assert(OpIdx >= 0 && OpIdx < MAX_MC_OPS); \
+		if (OpIdx < 0 && OpIdx >= NUM_##ARCH_UPPER##_OPS) { return NULL; } \
 		return &MI->flat_insn->detail->arch.operands[OpIdx]; \
 	}
 
-DEFINE_get_detail_op(arm, ARM);
-DEFINE_get_detail_op(ppc, PPC);
-DEFINE_get_detail_op(tricore, TriCore);
-DEFINE_get_detail_op(aarch64, AArch64);
-DEFINE_get_detail_op(alpha, Alpha);
-DEFINE_get_detail_op(hppa, HPPA);
-DEFINE_get_detail_op(loongarch, LoongArch);
-DEFINE_get_detail_op(mips, Mips);
-DEFINE_get_detail_op(riscv, RISCV);
-DEFINE_get_detail_op(systemz, SystemZ);
-DEFINE_get_detail_op(xtensa, Xtensa);
-DEFINE_get_detail_op(bpf, BPF);
-DEFINE_get_detail_op(arc, ARC);
-DEFINE_get_detail_op(sparc, Sparc);
+DEFINE_get_detail_op(arm, ARM, ARM);
+DEFINE_get_detail_op(ppc, PPC, PPC);
+DEFINE_get_detail_op(tricore, TriCore, TRICORE);
+DEFINE_get_detail_op(aarch64, AArch64, AARCH64);
+DEFINE_get_detail_op(alpha, Alpha, ALPHA);
+DEFINE_get_detail_op(hppa, HPPA, HPPA);
+DEFINE_get_detail_op(loongarch, LoongArch, LOONGARCH);
+DEFINE_get_detail_op(mips, Mips, MIPS);
+DEFINE_get_detail_op(riscv, RISCV, RISCV);
+DEFINE_get_detail_op(systemz, SystemZ, SYSTEMZ);
+DEFINE_get_detail_op(xtensa, Xtensa, XTENSA);
+DEFINE_get_detail_op(bpf, BPF, BPF);
+DEFINE_get_detail_op(arc, ARC, ARC);
+DEFINE_get_detail_op(sparc, Sparc, SPARC);
 
 /// Returns true if for this architecture the
 /// alias operands should be filled.

--- a/arch/Sparc/SparcMapping.c
+++ b/arch/Sparc/SparcMapping.c
@@ -400,6 +400,10 @@ static inline bool is_single_reg_mem_case(MCInst *MI, unsigned OpNo)
 	if (map_get_op_type(MI, OpNo) != CS_OP_MEM_REG) {
 		return false;
 	}
+	cs_sparc_op *prev_op = Sparc_get_detail_op(MI, -1);
+	if (prev_op && prev_op->type == SPARC_OP_MEM) {
+		return false;
+	}
 	if (MI->size == 1) {
 		return true;
 	} else if (MI->size > OpNo + 1 && Sparc_get_detail(MI)->operands[0].type != SPARC_OP_MEM) {
@@ -450,6 +454,11 @@ void Sparc_add_cs_detail_0(MCInst *MI, sparc_op_group op_group, unsigned OpNo)
 		break;
 	}
 	case Sparc_OP_GROUP_MemOperand: {
+		cs_sparc_op *prev_op = Sparc_get_detail_op(MI, -1);
+		if (prev_op && prev_op->type == SPARC_OP_MEM) {
+			// Already added.
+			break;
+		}
 		MCOperand *Op1 = MCInst_getOperand(MI, (OpNo));
 		MCOperand *Op2 = MCInst_getOperand(MI, (OpNo + 1));
 		if (!MCOperand_isReg(Op1) ||

--- a/bindings/python/capstone/mips.py
+++ b/bindings/python/capstone/mips.py
@@ -44,7 +44,7 @@ class MipsOp(ctypes.Structure):
 class CsMips(ctypes.Structure):
     _fields_ = (
         ('op_count', ctypes.c_uint8),
-        ('operands', MipsOp * 10),
+        ('operands', MipsOp * 16),
     )
 
 def get_arch_info(a):

--- a/include/capstone/mips.h
+++ b/include/capstone/mips.h
@@ -697,7 +697,7 @@ typedef struct cs_mips_op {
 	cs_ac_type access;
 } cs_mips_op;
 
-#define NUM_MIPS_OPS 10
+#define NUM_MIPS_OPS 16
 
 /// Instruction structure
 typedef struct cs_mips {

--- a/include/capstone/sparc.h
+++ b/include/capstone/sparc.h
@@ -545,7 +545,7 @@ typedef struct cs_sparc_op {
 	cs_ac_type access; ///< The way the operand is accessed.
 } cs_sparc_op;
 
-#define NUM_SPARC_OPS 4
+#define NUM_SPARC_OPS 6
 
 /// Instruction structure
 typedef struct cs_sparc {

--- a/include/capstone/xtensa.h
+++ b/include/capstone/xtensa.h
@@ -1715,11 +1715,11 @@ typedef struct cs_xtensa_op {
 	};
 } cs_xtensa_op;
 
-#define MAX_XTENSA_OPS 8
+#define NUM_XTENSA_OPS 8
 
 typedef struct cs_xtensa {
 	uint8_t op_count;
-	cs_xtensa_op operands[MAX_XTENSA_OPS];
+	cs_xtensa_op operands[NUM_XTENSA_OPS];
 	xtensa_insn_form format;
 } cs_xtensa;
 

--- a/suite/cstest/include/test_detail_mips.h
+++ b/suite/cstest/include/test_detail_mips.h
@@ -15,6 +15,7 @@ typedef struct {
 	uint64_t imm;
 	char *mem_base;
 	int64_t mem_disp;
+	tbool is_reglist;
 } TestDetailMipsOp;
 
 static const cyaml_schema_field_t test_detail_mips_op_mapping_schema[] = {
@@ -31,6 +32,8 @@ static const cyaml_schema_field_t test_detail_mips_op_mapping_schema[] = {
 			       TestDetailMipsOp, mem_base, 0, CYAML_UNLIMITED),
 	CYAML_FIELD_INT("mem_disp", CYAML_FLAG_OPTIONAL, TestDetailMipsOp,
 			mem_disp),
+	CYAML_FIELD_INT("is_reglist", CYAML_FLAG_OPTIONAL, TestDetailMipsOp,
+			is_reglist),
 	CYAML_FIELD_END
 };
 

--- a/suite/cstest/src/test_detail_mips.c
+++ b/suite/cstest/src/test_detail_mips.c
@@ -56,6 +56,7 @@ TestDetailMipsOp *test_detail_mips_op_clone(const TestDetailMipsOp *op)
 	clone->imm = op->imm;
 	clone->mem_base = op->mem_base ? strdup(op->mem_base) : NULL;
 	clone->mem_disp = op->mem_disp;
+	clone->is_reglist = op->is_reglist;
 
 	return clone;
 }
@@ -90,6 +91,7 @@ bool test_expected_mips(csh *handle, const cs_mips *actual,
 			return false;
 		case MIPS_OP_REG:
 			compare_reg_ret(*handle, op->reg, eop->reg, false);
+			compare_tbool_ret(op->is_reglist, eop->is_reglist, false);
 			break;
 		case MIPS_OP_IMM:
 			compare_uint64_ret(op->imm, eop->imm, false);

--- a/tests/details/mips.yaml
+++ b/tests/details/mips.yaml
@@ -267,3 +267,60 @@ test_cases:
               -
                 type: MIPS_OP_REG
                 reg: f0
+  -
+    input:
+      bytes: [ 0x23, 0x20, 0x5c, 0x6d ]
+      arch: "CS_ARCH_MIPS"
+      options: [ CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_MICRO32R6 ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "lwm32	$s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7, $fp, $ra, -0x393($zero)"
+        details:
+          mips:
+            operands:
+              -
+                type: MIPS_OP_REG
+                reg: s0
+                is_reglist: 1
+              -
+                type: MIPS_OP_REG
+                reg: s1
+                is_reglist: 1
+              -
+                type: MIPS_OP_REG
+                reg: s2
+                is_reglist: 1
+              -
+                type: MIPS_OP_REG
+                reg: s3
+                is_reglist: 1
+              -
+                type: MIPS_OP_REG
+                reg: s4
+                is_reglist: 1
+              -
+                type: MIPS_OP_REG
+                reg: s5
+                is_reglist: 1
+              -
+                type: MIPS_OP_REG
+                reg: s6
+                is_reglist: 1
+              -
+                type: MIPS_OP_REG
+                reg: s7
+                is_reglist: 1
+              -
+                type: MIPS_OP_REG
+                reg: fp
+                is_reglist: 1
+              -
+                type: MIPS_OP_REG
+                reg: ra
+                is_reglist: 1
+              -
+                type: MIPS_OP_MEM
+                mem_base: zero
+                mem_disp: -0x393

--- a/tests/details/sparc.yaml
+++ b/tests/details/sparc.yaml
@@ -950,3 +950,25 @@ test_cases:
                     reg: l2
               cc_field: SPARC_CC_FIELD_FCC0
               cc: SPARC_CC_FCC_U
+  -
+    input:
+      bytes: [ 0xd0, 0x3d, 0x40, 0x16 ]
+      arch: "sparc"
+      options: [ CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_V9 ]
+      address: 0x0
+    expected:
+      insns:
+        -
+          asm_text: "std	%o0, [%l5+%l6]"
+          details:
+            sparc:
+              operands:
+                  -
+                    type: SPARC_OP_REG
+                    access: CS_AC_READ
+                    reg: o0
+                  -
+                    type: SPARC_OP_MEM
+                    mem_base: l5
+                    mem_index: l6
+                    access: CS_AC_WRITE


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

- Sparc stores have the memory operand at the index 1. Due to nnot checking if a memory operand already exists, it disassembled to two memory operands instead of one.
- Fixes an invalid OOB check. Compares against the wrong constant (MAX_MC_OPS) and not against the one defined by the arch module.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Added

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
