### PR TITLE
Fix decoding of the FCC fields of FBPcc (format 2_3).

### DIFF
--- a/arch/Sparc/SparcMapping.c
+++ b/arch/Sparc/SparcMapping.c
@@ -66,7 +66,12 @@ static void Sparc_add_bit_details(MCInst *MI, const uint8_t *Bytes,
 		break;
 	}
 	case SPARC_INSN_FORM_F2_3:
-		detail->cc_field = 0x4 | get_insn_field_r(insn, 20, 21);
+		detail->cc_field = get_insn_field_r(insn, 20, 21);
+		if (get_insn_field_r(insn, 22, 24) == 1) {
+			// BPcc and FBPcc encode their fields in two bits.
+			// BPcc needs the upper bit set to match our CC field enum.
+			detail->cc_field |= 0x4;
+		}
 		break;
 	case SPARC_INSN_FORM_TRAPSP:
 		detail->cc_field = 0x4 | get_insn_field_r(insn, 11, 12);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

FBPcc CC fields were incorrectly decoded.
FBPcc and BPcc both encode the CC field in `0b00-0b11`. But in our Capstone CC field enum
only the BPcc fields (xcc/icc) have additionally bit 3 set.
It was set wrongfully also for the FCC fields. 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

added

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
