### PR TITLE
Python binding: Support 3.14 free-threaded CPython build

### DIFF
--- a/.github/workflows/build-wheels-publish.yml
+++ b/.github/workflows/build-wheels-publish.yml
@@ -43,27 +43,27 @@ jobs:
         include:
           # NOTE: Making this to parallelize and speed up workflow
           # i686 - manylinux
-          # - { os: ubuntu-latest, arch: i686, cibw_build: 'cp*-manylinux*', cibw_skip: '*36* *37*' }
+          # - { os: ubuntu-latest, arch: i686, cibw_build: 'cp*-manylinux*', cibw_skip: '' }
           # i686 - musllinux
-          # - { os: ubuntu-latest, arch: i686, cibw_build: 'cp*-musllinux*', cibw_skip: '*36* *37*' }
+          # - { os: ubuntu-latest, arch: i686, cibw_build: 'cp*-musllinux*', cibw_skip: '' }
           # x86_64 - manylinux
-          - { os: ubuntu-latest, arch: x86_64, cibw_build: 'cp*-manylinux*', cibw_skip: '*36* *37*' }
+          - { os: ubuntu-latest, arch: x86_64, cibw_build: 'cp*-manylinux*', cibw_skip: '' }
           # x86_64 - musllinux
-          - { os: ubuntu-latest, arch: x86_64, cibw_build: 'cp*-musllinux*', cibw_skip: '*36* *37*' }
+          - { os: ubuntu-latest, arch: x86_64, cibw_build: 'cp*-musllinux*', cibw_skip: '' }
           # aarch64 - manylinux
-          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp*-manylinux*', cibw_skip: '*36* *37*' }
+          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp*-manylinux*', cibw_skip: '' }
           # aarch64 - musllinux
-          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp*-musllinux*', cibw_skip: '*36* *37*' }
+          - { os: ubuntu-24.04-arm, arch: aarch64, cibw_build: 'cp*-musllinux*', cibw_skip: '' }
           # macos - x86_64
-          - { os: macos-13, arch: x86_64, cibw_build: 'cp*', cibw_skip: '*36* *37*' }
+          - { os: macos-13, arch: x86_64, cibw_build: 'cp*', cibw_skip: '' }
           # macos - arm64
-          - { os: macos-latest, arch: arm64, cibw_build: 'cp*', cibw_skip: '*36* *37*' }
+          - { os: macos-latest, arch: arm64, cibw_build: 'cp*', cibw_skip: '' }
           # windows - amd64
-          - { os: windows-latest, arch: AMD64, cibw_build: 'cp*', cibw_skip: '*36* *37*' }
+          - { os: windows-latest, arch: AMD64, cibw_build: 'cp*', cibw_skip: '' }
           # windows - x86
-          # - { os: windows-latest, arch: x86, cibw_build: 'cp*', cibw_skip: '*36* *37*' }
+          # - { os: windows-latest, arch: x86, cibw_build: 'cp*', cibw_skip: '' }
           # windows - arm64
-          - { os: windows-11-arm, arch: ARM64, cibw_build: 'cp*', cibw_skip: '*36* *37* *38* *39* *310*' }
+          - { os: windows-11-arm, arch: ARM64, cibw_build: 'cp*', cibw_skip: '*38* *39* *310*' }
 
     steps:
       - uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: '🚧 cibuildwheel run'
-        uses: pypa/cibuildwheel@v3.0.1
+        uses: pypa/cibuildwheel@v3.1.3
         env:
           CIBW_BUILD_FRONTEND: build
           CIBW_BUILD: ${{ matrix.cibw_build }}

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import sys
+import sysconfig
 from setuptools import setup
 from setuptools.command.build_py import build_py
 from setuptools.command.sdist import sdist
@@ -205,7 +206,9 @@ setup(
         "capstone": ["lib/*", "include/capstone/*"],
     },
     has_ext_modules=lambda: True,  # It's not a Pure Python wheel
-    options={"bdist_wheel": {"py_limited_api": "cp38"}},  # to have ABI3 tagged wheel
+    # to have ABI3 tagged wheel
+    # NOTE: Free-threaded CPython doesn't support limited API yet, remove when it will
+    options={"bdist_wheel": {"py_limited_api": False if sysconfig.get_config_var("Py_GIL_DISABLED") else "cp38"}},
     install_requires=[
         "importlib_resources;python_version<'3.9'",
     ],


### PR DESCRIPTION
- Support free-threaded CPython build for python 3.14
- Bump cibuildwheel to 3.1.3
- Remove 3.6 and 3.7 from cibw_skip since they are skipped by default by the newer cibuildwheel

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

There is an open issue: https://github.com/python/cpython/issues/111506
This PR allows building for such use case. Possibly will be removed once/if CPython upstream will add support.

**Test plan**

...

**Closing issues**

Closes #2767
