### PR TITLE
Fix cstest missing size checks

### DIFF
--- a/bindings/python/cstest_py/src/cstest_py/cstest.py
+++ b/bindings/python/cstest_py/src/cstest_py/cstest.py
@@ -22,6 +22,7 @@ from cstest_py.compare import (
     compare_str,
     compare_tbool,
     compare_enum,
+    compare_uint32,
 )
 from enum import Enum
 from pathlib import Path
@@ -254,6 +255,9 @@ class TestExpected:
                 return TestResult.FAILED
 
             if not compare_tbool(a_insn.illegal, e_insn.get("illegal"), "illegal"):
+                return TestResult.FAILED
+
+            if not compare_uint32(a_insn.size, e_insn.get("size"), "size"):
                 return TestResult.FAILED
 
             if not compare_enum(a_insn.alias_id, e_insn.get("alias_id"), "alias_id"):

--- a/suite/cstest/include/test_case.h
+++ b/suite/cstest/include/test_case.h
@@ -63,6 +63,7 @@ typedef struct {
 	char *op_str;
 	int32_t is_alias; ///< 0 == not given, >0 == true, <0 == false
 	int32_t illegal; ///< 0 == not given, >0 == true, <0 == false
+	uint32_t size;
 	char *alias_id;
 	char *mnemonic;
 	TestDetail *details;
@@ -84,6 +85,8 @@ static const cyaml_schema_field_t test_insn_data_mapping_schema[] = {
 			 is_alias),
 	CYAML_FIELD_INT("illegal", CYAML_FLAG_OPTIONAL, TestInsnData,
 			 illegal),
+	CYAML_FIELD_UINT("size", CYAML_FLAG_OPTIONAL, TestInsnData,
+			 size),
 	CYAML_FIELD_STRING_PTR("alias_id",
 			CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
 			TestInsnData, alias_id, 0, CYAML_UNLIMITED),

--- a/suite/cstest/include/test_case.h
+++ b/suite/cstest/include/test_case.h
@@ -61,8 +61,8 @@ typedef struct {
 	char *id;
 	char *asm_text;	  // mandatory
 	char *op_str;
-	int32_t is_alias; ///< 0 == not given, >0 == true, <0 == false
-	int32_t illegal; ///< 0 == not given, >0 == true, <0 == false
+	tbool is_alias;
+	tbool illegal;
 	uint32_t size;
 	char *alias_id;
 	char *mnemonic;

--- a/suite/cstest/src/test_case.c
+++ b/suite/cstest/src/test_case.c
@@ -116,6 +116,7 @@ TestInsnData *test_insn_data_clone(TestInsnData *test_insn_data)
 				NULL;
 	tid->is_alias = test_insn_data->is_alias;
 	tid->illegal = test_insn_data->illegal;
+	tid->size = test_insn_data->size;
 	tid->mnemonic = test_insn_data->mnemonic ?
 				cs_strdup(test_insn_data->mnemonic) :
 				NULL;
@@ -255,6 +256,9 @@ void test_expected_compare(csh *handle, TestExpected *expected, cs_insn *insns,
 			} else {
 				assert_false(insns[i].illegal);
 			}
+		}
+		if (expec_data->size) {
+			assert_int_equal(insns[i].size, expec_data->size);
 		}
 		if (expec_data->alias_id) {
 			assert_true(ids_match((uint32_t)insns[i].alias_id,

--- a/suite/cstest/src/test_detail_x86.c
+++ b/suite/cstest/src/test_detail_x86.c
@@ -226,7 +226,9 @@ bool test_expected_x86(csh *handle, cs_x86 *actual, TestDetailX86 *expected)
 		cs_x86_op *op = &actual->operands[i];
 		TestDetailX86Op *eop = expected->operands[i];
 		compare_enum_ret(op->type, eop->type, false);
-		compare_uint8_ret(op->size, eop->size, false);
+		if (eop->size) {
+			compare_uint8_ret(op->size, eop->size, false);
+		}
 		compare_enum_ret(op->access, eop->access, false);
 		compare_enum_ret(op->avx_bcast, eop->avx_bcast, false);
 		compare_tbool_ret(op->avx_zero_opmask, eop->avx_zero_opmask,

--- a/suite/cstest/src/test_detail_x86.c
+++ b/suite/cstest/src/test_detail_x86.c
@@ -226,6 +226,7 @@ bool test_expected_x86(csh *handle, cs_x86 *actual, TestDetailX86 *expected)
 		cs_x86_op *op = &actual->operands[i];
 		TestDetailX86Op *eop = expected->operands[i];
 		compare_enum_ret(op->type, eop->type, false);
+		compare_uint8_ret(op->size, eop->size, false);
 		compare_enum_ret(op->access, eop->access, false);
 		compare_enum_ret(op->avx_bcast, eop->avx_bcast, false);
 		compare_tbool_ret(op->avx_zero_opmask, eop->avx_zero_opmask,

--- a/tests/details/x86.yaml
+++ b/tests/details/x86.yaml
@@ -9,6 +9,7 @@ test_cases:
       insns:
       -
         asm_text: "lea cx, [si + 0x32]"
+        size: 3
         details:
           x86:
             prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Adds a missing `cs_ins->size` check, as well as a missing `x86_operand->size` check in `cstest`.

cc @hainest 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Failure manually tested. Added one for `cs_insn->size` 

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
