### PR TITLE
Fix log message in cstest_py/compare.compare_bit_flags

### DIFF
--- a/bindings/python/cstest_py/src/cstest_py/compare.py
+++ b/bindings/python/cstest_py/src/cstest_py/compare.py
@@ -323,7 +323,7 @@ def compare_bit_flags(actual: int, expected: None | list[str], msg: str) -> bool
     for flag in expected:
         enum_val = cs_const_getattr(flag)
         if not actual & enum_val:
-            log.error(f"{msg}: In {actual:x} the flag {expected} isn't set.")
+            log.error(f"{msg}: In {actual:x} the flag {flag} isn't set.")
             return False
     return True
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [ x ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ x ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

The message printed the entire input instead of just the missing flag name.
...

**Test plan**

None needed.