### PR TITLE
Backport for 5.0.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ cmake_policy(SET CMP0042 NEW)
 # Enable support for MSVC_RUNTIME_LIBRARY
 cmake_policy(SET CMP0091 NEW)
 
-# Check if VERSION is provided externally, otherwise default to 5.0.3
-if(NOT DEFINED PROJECT_VERSION)
+# Check if VERSION is provided externally, otherwise default to 5.0.6
+if(NOT DEFINED PROJECT_VERSION OR PROJECT_VERSION STREQUAL "")
     set(PROJECT_VERSION "5.0.6")
 endif()
 


### PR DESCRIPTION
GitHub Actions has started to roll out CMake 4 so projects using capstone will be hit by this issue https://github.com/capstone-engine/capstone/issues/2778 and build workflows will fail.

Hence, I would like to have the fix (https://github.com/capstone-engine/capstone/commit/f557fa229ebe669434049b93aa9aab48e9df476f) added to the v5 branch ASAP and a new tag created (5.0.7) so people can upgrade and avoid build issues.