### PR TITLE
Add instruction details to cstest logging

### DIFF
--- a/bindings/python/cstest_py/src/cstest_py/cstest.py
+++ b/bindings/python/cstest_py/src/cstest_py/cstest.py
@@ -237,7 +237,8 @@ class TestExpected:
         for a_insn, e_insn in zip(actual_insns, self.insns):
             def _check(res: bool):
                 if not res:
-                    raise Exception(f"Failed instruction: {a_insn}")
+                    log.error(f"Failed instruction: {a_insn}")
+                    return TestResult.FAILED
 
             _check(compare_asm_text(a_insn, e_insn.get("asm_text"), bits))
 
@@ -293,9 +294,10 @@ class TestCase:
         try:
             self.input.setup()
             insns = self.input.decode()
-            return self.expected.compare(insns, self.input.arch_bits)
         except Exception as e:
             return _log_err("Setup", e)
+        
+        return self.expected.compare(insns, self.input.arch_bits)
 
 
 class TestFile:

--- a/bindings/python/cstest_py/src/cstest_py/cstest.py
+++ b/bindings/python/cstest_py/src/cstest_py/cstest.py
@@ -229,10 +229,11 @@ class TestExpected:
 
     def compare(self, actual_insns: list[CsInsn], bits: int) -> TestResult:
         if len(actual_insns) != len(self.insns):
-            raise Exception(
+            log.error(
                 "Number of decoded instructions don't match (actual != expected): "
                 f"{len(actual_insns)} != {len(self.insns):#x}"
             )
+            return TestResult.FAILED
 
         for a_insn, e_insn in zip(actual_insns, self.insns):
             def _check(res: bool):

--- a/bindings/python/cstest_py/src/cstest_py/cstest.py
+++ b/bindings/python/cstest_py/src/cstest_py/cstest.py
@@ -286,18 +286,27 @@ class TestCase:
         if self.skip:
             log.info(f"Skip {self}\nReason: {self.skip_reason}")
             return TestResult.SKIPPED
-        
-        def _log_err(step: str, e: Exception):
-            log.error(e)
-            return TestResult.ERROR
 
         try:
             self.input.setup()
+        except Exception as e:
+            log.error(f"Setup failed at with: {e}")
+            traceback.print_exc()
+            return TestResult.ERROR
+
+        try:
             insns = self.input.decode()
         except Exception as e:
-            return _log_err("Setup", e)
-        
-        return self.expected.compare(insns, self.input.arch_bits)
+            log.error(f"Decode failed with: {e}")
+            traceback.print_exc()
+            return TestResult.ERROR
+
+        try:
+            return self.expected.compare(insns, self.input.arch_bits)
+        except Exception as e:
+            log.error(f"Compare expected failed with: {e}")
+            traceback.print_exc()
+            return TestResult.ERROR
 
 
 class TestFile:

--- a/bindings/python/cstest_py/src/cstest_py/cstest.py
+++ b/bindings/python/cstest_py/src/cstest_py/cstest.py
@@ -229,42 +229,34 @@ class TestExpected:
 
     def compare(self, actual_insns: list[CsInsn], bits: int) -> TestResult:
         if len(actual_insns) != len(self.insns):
-            log.error(
+            raise Exception(
                 "Number of decoded instructions don't match (actual != expected): "
                 f"{len(actual_insns)} != {len(self.insns):#x}"
             )
-            return TestResult.FAILED
+
         for a_insn, e_insn in zip(actual_insns, self.insns):
-            if not compare_asm_text(
-                a_insn,
-                e_insn.get("asm_text"),
-                bits,
-            ):
-                return TestResult.FAILED
+            def _check(res: bool):
+                if not res:
+                    raise Exception(f"Failed instruction: {a_insn}")
 
-            if not compare_str(a_insn.mnemonic, e_insn.get("mnemonic"), "mnemonic"):
-                return TestResult.FAILED
+            _check(compare_asm_text(a_insn, e_insn.get("asm_text"), bits))
 
-            if not compare_str(a_insn.op_str, e_insn.get("op_str"), "op_str"):
-                return TestResult.FAILED
+            _check(compare_str(a_insn.mnemonic, e_insn.get("mnemonic"), "mnemonic"))
 
-            if not compare_enum(a_insn.id, e_insn.get("id"), "id"):
-                return TestResult.FAILED
+            _check(compare_str(a_insn.op_str, e_insn.get("op_str"), "op_str"))
 
-            if not compare_tbool(a_insn.is_alias, e_insn.get("is_alias"), "is_alias"):
-                return TestResult.FAILED
+            _check(compare_enum(a_insn.id, e_insn.get("id"), "id"))
 
-            if not compare_tbool(a_insn.illegal, e_insn.get("illegal"), "illegal"):
-                return TestResult.FAILED
+            _check(compare_tbool(a_insn.is_alias, e_insn.get("is_alias"), "is_alias"))
 
-            if not compare_uint32(a_insn.size, e_insn.get("size"), "size"):
-                return TestResult.FAILED
+            _check(compare_tbool(a_insn.illegal, e_insn.get("illegal"), "illegal"))
 
-            if not compare_enum(a_insn.alias_id, e_insn.get("alias_id"), "alias_id"):
-                return TestResult.FAILED
+            _check(compare_uint32(a_insn.size, e_insn.get("size"), "size"))
 
-            if not compare_details(a_insn, e_insn.get("details")):
-                return TestResult.FAILED
+            _check(compare_enum(a_insn.alias_id, e_insn.get("alias_id"), "alias_id"))
+
+            _check(compare_details(a_insn, e_insn.get("details")))
+
         return TestResult.SUCCESS
 
 
@@ -293,27 +285,17 @@ class TestCase:
         if self.skip:
             log.info(f"Skip {self}\nReason: {self.skip_reason}")
             return TestResult.SKIPPED
+        
+        def _log_err(step: str, e: Exception):
+            log.error(e)
+            return TestResult.ERROR
 
         try:
             self.input.setup()
-        except Exception as e:
-            log.error(f"Setup failed at with: {e}")
-            traceback.print_exc()
-            return TestResult.ERROR
-
-        try:
             insns = self.input.decode()
-        except Exception as e:
-            log.error(f"Decode failed with: {e}")
-            traceback.print_exc()
-            return TestResult.ERROR
-
-        try:
             return self.expected.compare(insns, self.input.arch_bits)
         except Exception as e:
-            log.error(f"Compare expected failed with: {e}")
-            traceback.print_exc()
-            return TestResult.ERROR
+            return _log_err("Setup", e)
 
 
 class TestFile:

--- a/suite/cstest/src/test_case.c
+++ b/suite/cstest/src/test_case.c
@@ -75,11 +75,12 @@ char *test_input_stringify(const TestInput *test_input, const char *postfix)
 		}
 	}
 	str_append_no_realloc(opt_seq, sizeof(opt_seq), "]");
-	cs_snprintf(msg, msg_len,
-		    "%sTestInput { arch: %s, options: %s, addr: 0x%" PRIx64
-		    ", bytes: %s }",
-		    postfix, test_input->arch, opt_seq, test_input->address,
-		    byte_seq);
+	cs_snprintf(
+		msg, msg_len,
+		"%sTestInput { name: %s, arch: %s, options: %s, addr: 0x%" PRIx64
+		", bytes: %s }",
+		postfix, test_input->name, test_input->arch, opt_seq,
+		test_input->address, byte_seq);
 	cs_mem_free(byte_seq);
 	return msg;
 }
@@ -213,6 +214,17 @@ static bool ids_match(uint32_t actual, const char *expected)
 	return true;
 }
 
+static void _print_insn(csh *handle, cs_insn *insn)
+{
+	cm_print_error("Failed instruction: %s %s", insn->mnemonic,
+		       insn->op_str);
+	cm_print_error("(0x%x", insn->bytes[0]);
+	for (int i = 1; i < insn->size; i++) {
+		cm_print_error(", 0x%x", insn->bytes[i]);
+	}
+	cm_print_error("%s", ")\n");
+}
+
 /// Compares the decoded instructions @insns against the @expected values and returns the result.
 void test_expected_compare(csh *handle, TestExpected *expected, cs_insn *insns,
 			   size_t insns_count, size_t arch_bits)
@@ -233,53 +245,76 @@ void test_expected_compare(csh *handle, TestExpected *expected, cs_insn *insns,
 			str_append_no_realloc(asm_text, sizeof(asm_text),
 					      insns[i].op_str);
 		}
+
+#define CS_TEST_FAIL(msg) \
+	_print_insn(handle, &insns[i]); \
+	fail_msg(msg);
+
 		if (!compare_asm_text(asm_text, expec_data->asm_text,
 				      arch_bits)) {
-			fail_msg("asm-text mismatch\n");
+			CS_TEST_FAIL("asm-text mismatch\n");
 		}
 
 		// Not mandatory fields. If not initialized they should still match.
 		if (expec_data->id) {
-			assert_true(ids_match((uint32_t)insns[i].id,
-					      expec_data->id));
+			if (!ids_match((uint32_t)insns[i].id, expec_data->id)) {
+				CS_TEST_FAIL("ids mismatch");
+			}
 		}
 		if (expec_data->is_alias != 0) {
 			if (expec_data->is_alias > 0) {
-				assert_true(insns[i].is_alias);
+				if (!insns[i].is_alias) {
+					CS_TEST_FAIL("should be an alias");
+				}
 			} else {
-				assert_false(insns[i].is_alias);
+				if (insns[i].is_alias) {
+					CS_TEST_FAIL("should not be an alias");
+				}
 			}
 		}
 		if (expec_data->illegal != 0) {
 			if (expec_data->illegal > 0) {
-				assert_true(insns[i].illegal);
+				if (!insns[i].illegal) {
+					CS_TEST_FAIL("should be illegal");
+				}
 			} else {
-				assert_false(insns[i].illegal);
+				if (insns[i].illegal) {
+					CS_TEST_FAIL("should not be illegal");
+				}
 			}
 		}
 		if (expec_data->size) {
-			assert_int_equal(insns[i].size, expec_data->size);
+			if (insns[i].size != expec_data->size) {
+				CS_TEST_FAIL("size mismatch");
+			}
 		}
 		if (expec_data->alias_id) {
-			assert_true(ids_match((uint32_t)insns[i].alias_id,
-					      expec_data->alias_id));
+			if (!ids_match((uint32_t)insns[i].alias_id,
+				       expec_data->alias_id)) {
+				CS_TEST_FAIL("alias ids mismatch");
+			}
 		}
 		if (expec_data->mnemonic) {
-			assert_string_equal(insns[i].mnemonic,
-					    expec_data->mnemonic);
+			if (strcmp(insns[i].mnemonic, expec_data->mnemonic) !=
+			    0) {
+				CS_TEST_FAIL("mnemonics don't match");
+			}
 		}
 		if (expec_data->op_str) {
-			assert_string_equal(insns[i].op_str,
-					    expec_data->op_str);
+			if (strcmp(insns[i].op_str, expec_data->op_str) != 0) {
+				CS_TEST_FAIL("operands don't match");
+			}
 		}
 		if (expec_data->details) {
 			if (!insns[i].detail) {
-				fprintf(stderr, "detail is NULL\n");
-				assert_non_null(insns[i].detail);
+				CS_TEST_FAIL("detail is NULL");
 			}
-			assert_true(test_expected_detail(handle, &insns[i],
-							 expec_data->details));
+			if (!test_expected_detail(handle, &insns[i],
+						  expec_data->details)) {
+				CS_TEST_FAIL("test_expected_detail");
+			}
 		}
+#undef CS_TEST_FAIL
 	}
 }
 

--- a/suite/cstest/src/test_case.c
+++ b/suite/cstest/src/test_case.c
@@ -55,7 +55,7 @@ TestInput *test_input_clone(TestInput *test_input)
 	return ti;
 }
 
-char *test_input_stringify(const TestInput *test_input, const char *postfix)
+char *test_input_stringify(const TestInput *test_input, const char *prefix)
 {
 	size_t msg_len = 2048;
 	char *msg = cs_mem_calloc(sizeof(char), msg_len);
@@ -79,7 +79,7 @@ char *test_input_stringify(const TestInput *test_input, const char *postfix)
 		msg, msg_len,
 		"%sTestInput { name: %s, arch: %s, options: %s, addr: 0x%" PRIx64
 		", bytes: %s }",
-		postfix, test_input->name, test_input->arch, opt_seq,
+		prefix, test_input->name, test_input->arch, opt_seq,
 		test_input->address, byte_seq);
 	cs_mem_free(byte_seq);
 	return msg;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**cstest.py**

Now prints the stringified instruction.

before:
```
INFO  - Run test: Interrupt instructions, 64-bit decode mode -- TestInput { arch: x86, options: ['CS_OPT_DETAIL', 'CS_MODE_64'], addr: 0, bytes: [ 0xcc,0xcd,0x80,0xf1 ] }
WARNING - CS_ARCH: Capstone doesn't have the attribute 'x86'
ERROR - opcode: 241 != 242
INFO  - TestResult.FAILED
```

after:
```
INFO  - Run test: Interrupt instructions, 64-bit decode mode -- TestInput { arch: x86, options: ['CS_OPT_DETAIL', 'CS_MODE_64'], addr: 0, bytes: [ 0xcc,0xcd,0x80,0xf1 ] }
WARNING - CS_ARCH: Capstone doesn't have the attribute 'x86'
ERROR - opcode: 241 != 242
ERROR - Failed instruction: <CsInsn 0x3 [f1]: int1 >
INFO  - TestResult.ERROR
```
---
**cstest.c**

Now prints the test name and the stringified instruction. If a test has no name, it prints the default "(null)". I can change that, if preferred.

before:
```
[ RUN      ] /x86.yaml - TC #11: TestInput { arch: x86, options: [CS_OPT_DETAIL, CS_MODE_64], addr: 0x0, bytes: 0xcc, 0xcd, 0x80, 0xf1 }
actual->opcode[i] != expected->opcode[i]: 241 != 242
[  ERROR   ] --- test_expected_detail(handle, &insns[i], expec_data->details)
[   LINE   ] --- /path/to/capstone/suite/cstest/src/test_case.c:280: error: Failure!
```

after:
```
[ RUN      ] /x86.yaml - TC #11: TestInput { name: Interrupt instructions, 64-bit decode mode, arch: x86, options: [CS_OPT_DETAIL, CS_MODE_64], addr: 0x0, bytes: 0xcc, 0xcd, 0x80, 0xf1 }
actual->opcode[i] != expected->opcode[i]: 241 != 242
[  ERROR   ] --- Failed instruction: int1 (0xf1)
ERROR: test_expected_detail
[   LINE   ] --- /path/to/capstone/suite/cstest/src/test_case.c:313: error: Failure!
```