### PR TITLE
Update read/written registers for x86 unconditional jump instructions

### DIFF
--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -1237,6 +1237,24 @@ void X86_get_insn_id(cs_struct *h, cs_insn *insn, unsigned int id)
 				} break;
 				}
 				break;
+
+			case X86_INS_JMP:
+			case X86_INS_LJMP:
+				switch (h->mode) {
+				default:
+					break;
+				case CS_MODE_16:
+					arr_replace(
+						insn->detail->regs_read,
+						insn->detail->regs_read_count,
+						X86_REG_EIP, X86_REG_IP);
+					arr_replace(
+						insn->detail->regs_write,
+						insn->detail->regs_write_count,
+						X86_REG_EIP, X86_REG_IP);
+					break;
+				}
+				break;
 			}
 
 			memcpy(insn->detail->groups, insns[i].groups,

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -1253,6 +1253,16 @@ void X86_get_insn_id(cs_struct *h, cs_insn *insn, unsigned int id)
 						insn->detail->regs_write_count,
 						X86_REG_EIP, X86_REG_IP);
 					break;
+				case CS_MODE_64:
+					arr_replace(
+						insn->detail->regs_read,
+						insn->detail->regs_read_count,
+						X86_REG_EIP, X86_REG_RIP);
+					arr_replace(
+						insn->detail->regs_write,
+						insn->detail->regs_write_count,
+						X86_REG_EIP, X86_REG_RIP);
+					break;
 				}
 				break;
 			}

--- a/arch/X86/X86MappingInsn.inc
+++ b/arch/X86/X86MappingInsn.inc
@@ -5277,35 +5277,35 @@
 {
 	X86_FARJMP16i, X86_INS_LJMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
+	{ 0 }, { X86_REG_EIP, 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
 #endif
 },
 
 {
 	X86_FARJMP16m, X86_INS_LJMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 1, 1
+	{ 0 }, { X86_REG_EIP, 0 }, { 0 }, 1, 1
 #endif
 },
 
 {
 	X86_FARJMP32i, X86_INS_LJMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
+	{ 0 }, { X86_REG_EIP, 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
 #endif
 },
 
 {
 	X86_FARJMP32m, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 1, 1
+	{ 0 }, { X86_REG_EIP, 0 }, { 0 }, 1, 1
 #endif
 },
 
 {
 	X86_FARJMP64, X86_INS_LJMP, 1,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 1, 1
+	{ 0 }, { X86_REG_RIP, 0 }, { 0 }, 1, 1
 #endif
 },
 
@@ -6866,21 +6866,21 @@
 {
 	X86_JMP_1, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { X86_REG_EIP, 0 }, { X86_GRP_BRANCH_RELATIVE, 0 }, 1, 0
+	{ X86_REG_EIP, 0 }, { X86_REG_EIP, 0 }, { X86_GRP_BRANCH_RELATIVE, 0 }, 1, 0
 #endif
 },
 
 {
 	X86_JMP_2, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { X86_REG_EIP, 0 }, { X86_GRP_BRANCH_RELATIVE, 0 }, 1, 0
+	{ X86_REG_EIP, 0 }, { X86_REG_EIP, 0 }, { X86_GRP_BRANCH_RELATIVE, 0 }, 1, 0
 #endif
 },
 
 {
 	X86_JMP_4, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { X86_REG_EIP, 0 }, { X86_GRP_BRANCH_RELATIVE, 0 }, 1, 0
+	{ X86_REG_EIP, 0 }, { X86_REG_EIP, 0 }, { X86_GRP_BRANCH_RELATIVE, 0 }, 1, 0
 #endif
 },
 

--- a/arch/X86/X86MappingInsn_reduce.inc
+++ b/arch/X86/X86MappingInsn_reduce.inc
@@ -3170,35 +3170,35 @@
 {
 	X86_FARJMP16i, X86_INS_LJMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
+	{ 0 }, { X86_REG_EIP, 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
 #endif
 },
 
 {
 	X86_FARJMP16m, X86_INS_LJMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 1, 1
+	{ 0 }, { X86_REG_EIP, 0 }, { 0 }, 1, 1
 #endif
 },
 
 {
 	X86_FARJMP32i, X86_INS_LJMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
+	{ 0 }, { X86_REG_EIP, 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
 #endif
 },
 
 {
 	X86_FARJMP32m, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 1, 1
+	{ 0 }, { X86_REG_EIP, 0 }, { 0 }, 1, 1
 #endif
 },
 
 {
 	X86_FARJMP64, X86_INS_LJMP, 1,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 1, 1
+	{ 0 }, { X86_REG_RIP, 0 }, { 0 }, 1, 1
 #endif
 },
 
@@ -3933,105 +3933,105 @@
 {
 	X86_JMP16m, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
+	{ X86_REG_EIP, 0 }, { X86_REG_EIP, 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
 #endif
 },
 
 {
 	X86_JMP16m_NT, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 0, 0
+	{ X86_REG_EIP, 0 }, { X86_REG_EIP, 0 }, { 0 }, 0, 0
 #endif
 },
 
 {
 	X86_JMP16r, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
+	{ X86_REG_EIP, 0 }, { X86_REG_EIP, 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
 #endif
 },
 
 {
 	X86_JMP16r_NT, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 0, 0
+	{ X86_REG_EIP, 0 }, { X86_REG_EIP, 0 }, { 0 }, 0, 0
 #endif
 },
 
 {
 	X86_JMP32m, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
+	{ 0 }, { X86_REG_EIP, 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
 #endif
 },
 
 {
 	X86_JMP32m_NT, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 0, 0
+	{ 0 }, { X86_REG_EIP, 0 }, { 0 }, 0, 0
 #endif
 },
 
 {
 	X86_JMP32r, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
+	{ 0 }, { X86_REG_EIP, 0 }, { X86_GRP_NOT64BITMODE, 0 }, 1, 1
 #endif
 },
 
 {
 	X86_JMP32r_NT, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 0, 0
+	{ 0 }, { X86_REG_EIP, 0 }, { 0 }, 0, 0
 #endif
 },
 
 {
 	X86_JMP64m, X86_INS_JMP, 1,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { X86_GRP_MODE64, 0 }, 1, 1
+	{ 0 }, { X86_REG_RIP, 0 }, { X86_GRP_MODE64, 0 }, 1, 1
 #endif
 },
 
 {
 	X86_JMP64m_NT, X86_INS_JMP, 1,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 0, 0
+	{ 0 }, { X86_REG_RIP, 0 }, { 0 }, 0, 0
 #endif
 },
 
 {
 	X86_JMP64r, X86_INS_JMP, 1,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { X86_GRP_MODE64, 0 }, 1, 1
+	{ 0 }, { X86_REG_RIP, 0 }, { X86_GRP_MODE64, 0 }, 1, 1
 #endif
 },
 
 {
 	X86_JMP64r_NT, X86_INS_JMP, 1,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 0, 0
+	{ 0 }, { X86_REG_RIP, 0 }, { 0 }, 0, 0
 #endif
 },
 
 {
 	X86_JMP_1, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 1, 0
+	{ X86_REG_EIP, 0 }, { X86_REG_EIP, 0 }, { X86_GRP_BRANCH_RELATIVE, 0 }, 1, 0
 #endif
 },
 
 {
 	X86_JMP_2, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 1, 0
+	{ X86_REG_EIP, 0 }, { X86_REG_EIP, 0 }, { X86_GRP_BRANCH_RELATIVE, 0 }, 1, 0
 #endif
 },
 
 {
 	X86_JMP_4, X86_INS_JMP, 0,
 #ifndef CAPSTONE_DIET
-	{ 0 }, { 0 }, { 0 }, 1, 0
+	{ X86_REG_EIP, 0 }, { X86_REG_EIP, 0 }, { X86_GRP_BRANCH_RELATIVE, 0 }, 1, 0
 #endif
 },
 

--- a/tests/details/x86.yaml
+++ b/tests/details/x86.yaml
@@ -6175,3 +6175,67 @@ test_cases:
             opcode: [ 0xff, 0x00, 0x00, 0x00 ]
           regs_read: [ ]
           regs_write: [ ip ]
+
+  -
+    input:
+      name: "Unconditional jump, 32-bit decode mode"
+      bytes: [
+         0xeb, 0x10,                                 # jmp 0x12
+         0xe9, 0x71, 0x56, 0x34, 0x12,               # jmp 0x1234
+         0xff, 0xa0, 0x78, 0x56, 0x34, 0x12,         # jmp dword ptr [eax+0x12345678]
+         0xff, 0xe0,                                 # jmp eax
+         0xea, 0x78, 0x56, 0x34, 0x12, 0x78, 0x56,   # ljmp 0x5678:0x12345678
+         0xff, 0xa8, 0x78, 0x56, 0x34, 0x12,         # jmp far [eax + 0x1234]
+      ]
+      arch: "x86"
+      options: [ CS_OPT_DETAIL, CS_MODE_32 ]
+    expected:
+      insns:
+      -
+        asm_text: "jmp 0x12"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xeb, 0x00, 0x00, 0x00 ]
+          regs_read: [ eip ]
+          regs_write: [ eip ]
+      -
+        asm_text: "jmp 0x12345678"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xe9, 0x00, 0x00, 0x00 ]
+          regs_read: [ eip ]
+          regs_write: [ eip ]
+      -
+        asm_text: "jmp dword ptr [eax + 0x12345678]"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xff, 0x00, 0x00, 0x00 ]
+          regs_read: [ eax ]
+          regs_write: [ eip ]
+      -
+        asm_text: "jmp eax"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xff, 0x00, 0x00, 0x00 ]
+          regs_read: [ eax ]
+          regs_write: [ eip ]
+      -
+        asm_text: "ljmp 0x5678:0x12345678"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xea, 0x00, 0x00, 0x00 ]
+          regs_read: [ ]
+          regs_write: [ eip ]
+      -
+        asm_text: "jmp ptr [eax + 0x12345678]"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xff, 0x00, 0x00, 0x00 ]
+          regs_read: [ eax ]
+          regs_write: [ eip ]

--- a/tests/details/x86.yaml
+++ b/tests/details/x86.yaml
@@ -6111,3 +6111,67 @@ test_cases:
             eflags: [ X86_EFLAGS_TEST_ZF ]
           regs_read: [ rip, rcx, rflags ]
           regs_write: [ rip, rcx ]      # BUG: should be ecx
+
+  -
+    input:
+      name: "Unconditional jump, 16-bit decode mode"
+      bytes: [
+         0xeb, 0x10,                     # jmp 0x12
+         0xe9, 0x2f, 0x12,               # jmp 0x1234
+         0xff, 0xa0, 0x34, 0x12,         # jmp word ptr [bx+si+0x1234]
+         0xff, 0xe0,                     # jmp ax
+         0xea, 0x34, 0x12, 0x78, 0x56,   # ljmp 0x5678:0x1234
+         0xff, 0xa8, 0x34, 0x12,         # jmp far [bx + si + 0x1234]
+      ]
+      arch: "x86"
+      options: [ CS_OPT_DETAIL, CS_MODE_16 ]
+    expected:
+      insns:
+      -
+        asm_text: "jmp 0x12"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xeb, 0x00, 0x00, 0x00 ]
+          regs_read: [ ip ]
+          regs_write: [ ip ]
+      -
+        asm_text: "jmp 0x1234"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xe9, 0x00, 0x00, 0x00 ]
+          regs_read: [ ip ]
+          regs_write: [ ip ]
+      -
+        asm_text: "jmp word ptr [bx + si + 0x1234]"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xff, 0x00, 0x00, 0x00 ]
+          regs_read: [ bx, si ]
+          regs_write: [ ip ]
+      -
+        asm_text: "jmp ax"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xff, 0x00, 0x00, 0x00 ]
+          regs_read: [ ax ]
+          regs_write: [ ip ]
+      -
+        asm_text: "ljmp 0x5678:0x1234"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xea, 0x00, 0x00, 0x00 ]
+          regs_read: [ ]
+          regs_write: [ ip ]
+      -
+        asm_text: "ljmp [bx + si + 0x1234]"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xff, 0x00, 0x00, 0x00 ]
+          regs_read: [ ]
+          regs_write: [ ip ]

--- a/tests/details/x86.yaml
+++ b/tests/details/x86.yaml
@@ -6239,3 +6239,67 @@ test_cases:
             opcode: [ 0xff, 0x00, 0x00, 0x00 ]
           regs_read: [ eax ]
           regs_write: [ eip ]
+
+  -
+    input:
+      name: "Unconditional jump, 64-bit decode mode"
+      bytes: [
+         0xeb, 0x10,                                 # jmp 0x12
+         0xe9, 0x71, 0x56, 0x34, 0x12,               # jmp 0x12345678
+         0xff, 0xa0, 0x78, 0x56, 0x34, 0x12,         # jmp qword ptr [rax+0x12345678]
+         0xff, 0xe0,                                 # jmp rax
+         0xff, 0xa8, 0x78, 0x56, 0x34, 0x12,         # jmp ptr far [rax + 0x12345678]
+         0x48, 0xff, 0xa8, 0x78, 0x56, 0x34, 0x12,   # REX.W jmp ptr far [rax + 0x12345678]
+      ]
+      arch: "x86"
+      options: [ CS_OPT_DETAIL, CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "jmp 0x12"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xeb, 0x00, 0x00, 0x00 ]
+          regs_read: [ rip ]
+          regs_write: [ rip ]
+      -
+        asm_text: "jmp 0x12345678"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xe9, 0x00, 0x00, 0x00 ]
+          regs_read: [ rip ]
+          regs_write: [ rip ]
+      -
+        asm_text: "jmp qword ptr [rax + 0x12345678]"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xff, 0x00, 0x00, 0x00 ]
+          regs_read: [ rax ]
+          regs_write: [ rip ]
+      -
+        asm_text: "jmp rax"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xff, 0x00, 0x00, 0x00 ]
+          regs_read: [ rax ]
+          regs_write: [ rip ]
+      -
+        asm_text: "jmp ptr [rax + 0x12345678]"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xff, 0x00, 0x00, 0x00 ]
+          regs_read: [ rax ]
+          regs_write: [ rip ]
+      -
+        asm_text: "ljmp [rax + 0x12345678]"
+        details:
+          x86:
+            prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0 ]
+            opcode: [ 0xff, 0x00, 0x00, 0x00 ]
+          regs_read: [ rax ]
+          regs_write: [ rip ]


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Add semantics for the instruction pointer that is read and written by all jump instructions. This is the companion to https://github.com/capstone-engine/capstone/pull/2798.


**Test plan**

Tests are included.