### PR TITLE
Add support for the cross-compiling for Android

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -30,6 +30,20 @@ cmake.exe --build build --config Release # For debug build change "Release" to "
 cmake.exe --install build
 ```
 
+**Cross-compiling for Android**
+```bash
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=$NDK_PATH/build/cmake/android.toolchain.cmake -DANDROID_NDK=$NDK_PATH -DANDROID_ABI=arm64-v8a
+cmake --build build
+```
+
+**Cross-compiling static library for arm64**
+
+```bash
+# apt-get install gcc-aarch64-linux-gnu
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_EXE_LINKER_FLAGS=-static
+cmake --build build
+```
+
 ## Tailor Capstone to your needs.
 
 Enable and disable options in the "configure" step (first `cmake` command from above).


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

cross compile static library for android arm64

**Test plan**

method 1: download [Android NDK](https://dl.google.com/android/repository/android-ndk-r27d-linux.zip?hl=zh-cn)

```bash
cmake -B build -DCMAKE_TOOLCHAIN_FILE=$NDK_PATH/build/cmake/android.toolchain.cmake -DANDROID_NDK=$NDK_PATH -DANDROID_ABI=arm64-v8a
cmake --build build
```

method 2: install aarch64-linux-gnu
```bash
apt install gcc-aarch64-linux-gnu
cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_EXE_LINKER_FLAGS=-static
cmake --build build
```


**Closing issues**

close #2771
