### PR TITLE
Fix SH `decode` table being exported globally

### DIFF
--- a/arch/SH/SHInsnTable.inc
+++ b/arch/SH/SHInsnTable.inc
@@ -1,4 +1,4 @@
-bool (*decode[])(uint16_t code, uint64_t address, MCInst *MI, cs_mode mode, sh_info *info, cs_detail *detail) = {
+static bool (*decode[])(uint16_t code, uint64_t address, MCInst *MI, cs_mode mode, sh_info *info, cs_detail *detail) = {
 	/// 00000000
 	NULL, NULL, opSTC, op0xx3, opMOV_B, opMOV_W, opMOV_L, opMUL_L, 
 	/// 00001000


### PR DESCRIPTION
**Detailed description**

When linking Capstone and other libraries into a project, the globally exported `decode` table can override `decode` functions provided by other libraries, causing invalid jumps into the `decode` table at runtime. I've marked the table as static to make it local to the compilation unit.

**Test plan**
**Closing issues**
