### PR TITLE
Update WebAssembly to auto-sync

### DIFF
--- a/suite/auto-sync/src/autosync/Targets.py
+++ b/suite/auto-sync/src/autosync/Targets.py
@@ -14,6 +14,7 @@ TARGETS_LLVM_NAMING = [
     "TriCore",
     "ARC",
     "Sparc",
+    "WebAssembly",
 ]
 
 # Names of the target architecture as they are used in code and pretty much everywhere else.
@@ -29,6 +30,7 @@ ARCH_LLVM_NAMING = [
     "TriCore",
     "ARC",
     "Sparc",
+    "WebAssembly",
 ]
 
 # Maps the target full name to the name used in code (and pretty much everywhere else).
@@ -45,6 +47,7 @@ TARGET_TO_IN_CODE_NAME = {
     "ARC": "ARC",
     "Sparc": "Sparc",
     "ARCH": "ARCH",  # For testing
+    "WebAssembly": "WebAssembly"
 }
 
 # Maps the name from ARCH_LLVM_NAMING to the directory name in LLVM
@@ -61,4 +64,5 @@ TARGET_TO_DIR_NAME = {
     "ARC": "ARC",
     "Sparc": "Sparc",
     "ARCH": "ARCH",  # For testing
+    "WebAssembly": "WebAssembly"
 }

--- a/suite/auto-sync/src/autosync/cpptranslator/arch_config.json
+++ b/suite/auto-sync/src/autosync/cpptranslator/arch_config.json
@@ -314,5 +314,24 @@
     ],
     "templates_with_arg_deduction": [],
     "manually_edited_files": []
+  },
+  "WebAssembly": {
+    "files_to_translate": [
+      {
+        "in": "{LLVM_ROOT}/llvm/lib/Target/WebAssembly/Disassembler/WebAssemblyDisassembler.cpp",
+        "out": "WebAssemblyDisassembler.c"
+      },{
+        "in": "{LLVM_ROOT}/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyInstPrinter.cpp",
+        "out": "WebAssemblyInstPrinter.c"
+      },{
+        "in": "{LLVM_ROOT}/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyInstPrinter.h",
+        "out": "WebAssemblyInstPrinter.h"
+      }
+    ],
+    "files_for_template_search": [
+    ],
+    "templates_with_arg_deduction": [],
+    "manually_edited_files": [
+    ]
   }
 }


### PR DESCRIPTION
This PR will update the WebAssembly module to use the new auto-sync mechanism. 

The `llvm-capstone` component is in: https://github.com/capstone-engine/llvm-capstone/pull/87

I am following the guides at https://github.com/capstone-engine/capstone/blob/next/suite/auto-sync/README.md and https://github.com/capstone-engine/capstone/blob/next/suite/auto-sync/README.md