### PR TITLE
Build static libs with PIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -814,6 +814,7 @@ set_property(TARGET capstone PROPERTY C_STANDARD 99)
 target_include_directories(capstone PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )
+set_property(TARGET capstone PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 if(CAPSTONE_BUILD_STATIC_LIBS)
     add_library(capstone_static STATIC $<TARGET_OBJECTS:capstone>)
@@ -825,7 +826,6 @@ if(CAPSTONE_BUILD_STATIC_LIBS)
 endif()
 
 if(CAPSTONE_BUILD_SHARED_LIBS)
-    set_property(TARGET capstone PROPERTY POSITION_INDEPENDENT_CODE 1)
     add_library(capstone_shared SHARED $<TARGET_OBJECTS:capstone>)
     # Use normal capstone name. Otherwise we get libcapstone_shared.so
     set_target_properties(capstone_shared PROPERTIES OUTPUT_NAME "capstone")

--- a/docs/cs_v6_release_guide.md
+++ b/docs/cs_v6_release_guide.md
@@ -220,6 +220,7 @@ Nonetheless, we hope this additional information is useful to you.
 - Architecture modules from a static library, can be initialized on demand to decrease footprint (see: `cmake` option `CAPSTONE_USE_ARCH_REGISTRATION`).
 - New `cmake` option to choose between fat and thin binary for Apple.
 - Cross compilation support improved.
+- The static library (e.g., libcapstone.a) is now built with PIC to allow linking into shared libraries or PIE binaries.
 
 **Code quality**
 


### PR DESCRIPTION
**Detailed description**

This allows the static library to be linked into a shared object or PIE executable without affecting non-PIC linking.

**Test plan**

None.

---

I think refactoring the `set_property` out of the `CAPSTONE_BUILD_SHARED_LIBS` would be a better change. Thoughts?