### PR TITLE
[alpha] Fix immediate to be 64bit wide

### DIFF
--- a/bindings/python/capstone/alpha.py
+++ b/bindings/python/capstone/alpha.py
@@ -12,7 +12,7 @@ class AlphaOpMem(ctypes.Structure):
 class AlphaOpValue(ctypes.Union):
     _fields_ = (
         ('reg', ctypes.c_uint),
-        ('imm', ctypes.c_int32),
+        ('imm', ctypes.c_int64),
     )
 
 

--- a/bindings/python/cstest_py/src/cstest_py/details.py
+++ b/bindings/python/cstest_py/src/cstest_py/details.py
@@ -965,7 +965,7 @@ def test_expected_alpha(actual: CsInsn, expected: dict) -> bool:
             if not compare_reg(actual, aop.reg, eop.get("reg"), "reg"):
                 return False
         elif aop.type == ALPHA_OP_IMM:
-            if not compare_int32(aop.imm, eop.get("imm"), "imm"):
+            if not compare_int64(aop.imm, eop.get("imm"), "imm"):
                 return False
         else:
             raise ValueError("Operand type not handled.")

--- a/cstool/cstool_alpha.c
+++ b/cstool/cstool_alpha.c
@@ -30,8 +30,8 @@ void print_insn_detail_alpha(csh handle, cs_insn *ins)
 			       cs_reg_name(handle, op->reg));
 			break;
 		case ALPHA_OP_IMM:
-			printf("\t\toperands[%u].type: IMM = 0x%x\n", i,
-			       op->imm);
+			printf("\t\toperands[%u].type: IMM = 0x%" PRIx64 "\n",
+			       i, op->imm);
 			break;
 		}
 

--- a/include/capstone/alpha.h
+++ b/include/capstone/alpha.h
@@ -33,7 +33,7 @@ typedef struct cs_alpha_op {
 	alpha_op_type type; // operand type
 	union {
 		unsigned int reg; // register value for REG operand
-		int32_t imm; // immediate value for IMM operand
+		int64_t imm; // immediate value for IMM operand
 	};
 	enum cs_ac_type access;
 } cs_alpha_op;

--- a/suite/cstest/include/test_detail_alpha.h
+++ b/suite/cstest/include/test_detail_alpha.h
@@ -13,7 +13,7 @@ typedef struct {
 	char *access;
 
 	char *reg;
-	int32_t imm;
+	int64_t imm;
 } TestDetailAlphaOp;
 
 static const cyaml_schema_field_t test_detail_alpha_op_mapping_schema[] = {

--- a/suite/cstest/src/test_detail_alpha.c
+++ b/suite/cstest/src/test_detail_alpha.c
@@ -90,7 +90,7 @@ bool test_expected_alpha(csh *handle, const cs_alpha *actual,
 			compare_reg_ret(*handle, op->reg, eop->reg, false);
 			break;
 		case ALPHA_OP_IMM:
-			compare_int32_ret(op->imm, eop->imm, false);
+			compare_int64_ret(op->imm, eop->imm, false);
 			break;
 		}
 	}

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6302,4 +6302,22 @@ test_cases:
     expected:
       insns:
       -
-        asm_text: "mov	esi, dword ptr [rdx + rax*4]"
+        asm_text: "mov  esi, dword ptr [rdx + rax*4]"
+  -
+    input:
+      name: "alpha 64bit addresses"
+      bytes: [ 0x04, 0x00, 0x40, 0xf4 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ CS_OPT_DETAIL, CS_MODE_LITTLE_ENDIAN ]
+      address: 0x12001b33c
+    expected:
+      insns:
+      -
+        asm_text: "bne $2,0x12001b350"
+        details:
+          alpha:
+            operands:
+              - type: ALPHA_OP_REG
+                reg: $2
+              - type: ALPHA_OP_IMM
+                imm: 0x12001b350


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Fix the immediate value to be 64 bit wide instead of 32.

**Test plan**

Added regression test

