### PR TITLE
M68K: add displacement size fields to disassembler

### DIFF
--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -370,11 +370,24 @@ static void get_with_index_address_mode(m68k_info *info, cs_m68k_op *op,
 					 read_imm_32(info) :
 					 (int16_t)read_imm_16(info)) :
 				0;
+
+		op->mem.in_disp_size =
+			EXT_BASE_DISPLACEMENT_PRESENT(extension) &&
+					EXT_BASE_DISPLACEMENT_LONG(extension) ?
+				1 :
+				0;
+
 		op->mem.out_disp =
 			EXT_OUTER_DISPLACEMENT_PRESENT(extension) ?
 				(EXT_OUTER_DISPLACEMENT_LONG(extension) ?
 					 read_imm_32(info) :
 					 (int16_t)read_imm_16(info)) :
+				0;
+
+		op->mem.out_disp_size =
+			EXT_OUTER_DISPLACEMENT_PRESENT(extension) &&
+					EXT_OUTER_DISPLACEMENT_LONG(extension) ?
+				1 :
 				0;
 
 		if (EXT_BASE_REGISTER_PRESENT(extension)) {
@@ -444,6 +457,7 @@ static void get_with_index_address_mode(m68k_info *info, cs_m68k_op *op,
 		}
 
 		op->mem.disp = (int8_t)(extension & 0xff);
+		op->mem.disp_size = 0;
 	}
 
 	if (EXT_INDEX_SCALE(extension)) {
@@ -539,6 +553,7 @@ static void get_ea_mode_op(m68k_info *info, cs_m68k_op *op,
 		op->address_mode = M68K_AM_REGI_ADDR_DISP;
 		op->mem.base_reg = M68K_REG_A0 + (instruction & 7);
 		op->mem.disp = (int16_t)read_imm_16(info);
+		op->mem.disp_size = 1;
 		break;
 
 	case 0x30:
@@ -569,6 +584,7 @@ static void get_ea_mode_op(m68k_info *info, cs_m68k_op *op,
 		/* program counter with displacement */
 		op->address_mode = M68K_AM_PCI_DISP;
 		op->mem.disp = (int16_t)read_imm_16(info);
+		op->mem.disp_size = 1;
 		break;
 
 	case 0x3b:

--- a/bindings/python/capstone/m68k.py
+++ b/bindings/python/capstone/m68k.py
@@ -18,6 +18,9 @@ class M68KOpMem(ctypes.Structure):
         ('width', ctypes.c_ubyte),
         ('offset', ctypes.c_ubyte),
         ('index_size', ctypes.c_ubyte),
+        ('in_disp_size', ctypes.c_ubyte),
+        ('out_disp_size', ctypes.c_ubyte),
+        ('disp_size', ctypes.c_ubyte),
     )
 
 class M68KOpRegPair(ctypes.Structure):

--- a/bindings/python/cstest_py/src/cstest_py/details.py
+++ b/bindings/python/cstest_py/src/cstest_py/details.py
@@ -1169,6 +1169,18 @@ def test_expected_m68k(actual: CsInsn, expected: dict) -> bool:
                 aop.mem.index_size, eop["mem"].get("index_size"), "index_size"
             ):
                 return False
+            if not compare_tbool(
+                aop.mem.in_disp_size, eop["mem"].get("in_disp_size"), "in_disp_size"
+            ):
+                return False
+            if not compare_tbool(
+                aop.mem.out_disp_size, eop["mem"].get("out_disp_size"), "out_disp_size"
+            ):
+                return False
+            if not compare_tbool(
+                aop.mem.disp_size, eop["mem"].get("disp_size"), "disp_size"
+            ):
+                return False
             if not compare_int16(aop.mem.disp, eop["mem"].get("disp"), "disp"):
                 return False
             if not compare_int32(

--- a/docs/cs_v6_release_guide.md
+++ b/docs/cs_v6_release_guide.md
@@ -401,6 +401,9 @@ Such an instruction is ill-defined in LLVM and should be fixed upstream.
 | Keyword | Change | Justification |
 |---------|--------|---------------|
 | m68k_op_mem.in_disp, m68k_op_mem.out_disp | These fields are now signed instead of unsigned. | The M68K architecture uses sign extended displacements for effective address calculation. |
+| m68k_op_mem.disp_size | Defines if the .disp field was encoded as a byte (false) or word (true) | Necessary for accurate printing. |
+| m68k_op_mem.in_disp_size, m68k_op_mem.out_disp_size | Defines if the .in_disp and .out_disp fields respectively were encoded as words (false) or longs (true) | Necessary for accurate printing. |
+
 
 ### Notes about AArch64, SystemZ and ARM renaming
 

--- a/include/capstone/m68k.h
+++ b/include/capstone/m68k.h
@@ -139,7 +139,10 @@ typedef struct m68k_op_mem {
 	uint8_t bitfield; ///< set to true if the two values below should be used
 	uint8_t width; ///< used for bf* instructions
 	uint8_t offset; ///< used for bf* instructions
-	uint8_t index_size; ///< 0 = w, 1 = l
+	uint8_t index_size; ///< 0 = word, 1 = long
+	uint8_t in_disp_size; ///< 0 = word, 1 = long
+	uint8_t out_disp_size; ///< 0 = word, 1 = long
+	uint8_t disp_size; ///< 0 = byte, 1 = word
 } m68k_op_mem;
 
 /// Operand type for instruction's operands

--- a/suite/cstest/include/test_detail_m68k.h
+++ b/suite/cstest/include/test_detail_m68k.h
@@ -13,6 +13,9 @@ typedef struct {
 	char *index_reg;
 	char *in_base_reg;
 	tbool index_size; // -1 == word, 1 == long
+	tbool disp_size; // -1 == byte, 1 == word
+	tbool in_disp_size; // -1 == word, 1 == long
+	tbool out_disp_size; // -1 == word, 1 == long
 	int16_t disp;
 	int32_t in_disp;
 	int32_t out_disp;
@@ -48,6 +51,14 @@ static const cyaml_schema_field_t test_detail_m68k_op_mem_mapping_schema[] = {
 			 width),
 	CYAML_FIELD_UINT("offset", CYAML_FLAG_OPTIONAL, TestDetailM68KOpMem,
 			 offset),
+	CYAML_FIELD_INT("in_disp_size",
+			CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+			TestDetailM68KOpMem, in_disp_size),
+	CYAML_FIELD_INT("out_disp_size",
+			CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+			TestDetailM68KOpMem, out_disp_size),
+	CYAML_FIELD_INT("disp_size", CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+			TestDetailM68KOpMem, disp_size),
 	CYAML_FIELD_END
 };
 

--- a/suite/cstest/src/test_detail_m68k.c
+++ b/suite/cstest/src/test_detail_m68k.c
@@ -29,6 +29,9 @@ TestDetailM68KOpMem *test_detail_m68k_op_mem_clone(TestDetailM68KOpMem *mem)
 	clone->bitfield = mem->bitfield;
 	clone->width = mem->width;
 	clone->offset = mem->offset;
+	clone->in_disp_size = mem->in_disp_size;
+	clone->out_disp_size = mem->out_disp_size;
+	clone->disp_size = mem->disp_size;
 
 	return clone;
 }
@@ -218,6 +221,12 @@ bool test_expected_m68k(csh *handle, cs_m68k *actual, TestDetailM68K *expected)
 				compare_uint8_ret(op->mem.offset,
 						  eop->mem->offset, false);
 			}
+			compare_tbool_ret(op->mem.in_disp_size,
+					  eop->mem->in_disp_size, false);
+			compare_tbool_ret(op->mem.out_disp_size,
+					  eop->mem->out_disp_size, false);
+			compare_tbool_ret(op->mem.disp_size,
+					  eop->mem->disp_size, false);
 			break;
 		}
 	}

--- a/tests/details/m68k.yaml
+++ b/tests/details/m68k.yaml
@@ -33,6 +33,7 @@ test_cases:
                 mem:
                   base_reg: a7
                   disp: 0x7fff
+                  disp_size: 1
                 address_mode: M68K_AM_REGI_ADDR_DISP
       -
         asm_text: "move.b ([$7fffffff, a0], d0.w, $12345678), ([$10101010, a0, d0.w], $32323232)"
@@ -46,6 +47,10 @@ test_cases:
                   base_reg: a0
                   index_reg: d0
                   index_size: -1
+                  in_disp: 0x7fffffff
+                  out_disp: 0x12345678
+                  in_disp_size: 1
+                  out_disp_size: 1
                 address_mode: M68K_AM_MEMI_POST_INDEX
               -
                 type: M68K_OP_MEM
@@ -53,6 +58,10 @@ test_cases:
                   base_reg: a0
                   index_reg: d0
                   index_size: -1
+                  in_disp: 0x10101010
+                  out_disp: 0x32323232
+                  in_disp_size: 1
+                  out_disp_size: 1
                 address_mode: M68K_AM_MEMI_PRE_INDEX
       -
         asm_text: "mulu.l d0, d4:d5"
@@ -137,6 +146,8 @@ test_cases:
                   index_reg: d5
                   index_size: 1
                   scale: 4
+                  disp: 0
+                  disp_size: -1
                 address_mode: M68K_AM_AREGI_INDEX_BASE_DISP
       -
         asm_text: "move.b d0, ([a6, d7.w], $123)"
@@ -153,6 +164,9 @@ test_cases:
                   base_reg: a6
                   index_reg: d7
                   index_size: -1
+                  out_disp: 0x123
+                  out_disp_size: -1
+                  in_disp: 0
                 address_mode: M68K_AM_MEMI_PRE_INDEX
       -
         asm_text: "fadd.s #3.141500, fp0"
@@ -224,7 +238,9 @@ test_cases:
                   index_reg: d2
                   index_size: -1
                   in_disp: -0x2a
+                  in_disp_size: -1
                   out_disp: -0x57
+                  out_disp_size: -1
                 address_mode: M68K_AM_MEMI_PRE_INDEX
               -
                 type: M68K_OP_REG
@@ -244,6 +260,7 @@ test_cases:
                   index_size: -1
                   in_disp: 0
                   out_disp: -0x57
+                  out_disp_size: -1
                 address_mode: M68K_AM_MEMI_PRE_INDEX
               -
                 type: M68K_OP_REG
@@ -262,7 +279,9 @@ test_cases:
                   index_reg: d2
                   index_size: -1
                   in_disp: -0x2a
+                  in_disp_size: -1
                   out_disp: 0
+                  out_disp_size: -1
                 address_mode: M68K_AM_MEMI_PRE_INDEX
               -
                 type: M68K_OP_REG
@@ -281,7 +300,9 @@ test_cases:
                   index_reg: d2
                   index_size: -1
                   in_disp: -0x2a
+                  in_disp_size: -1
                   out_disp: -0x57
+                  out_disp_size: -1
                 address_mode: M68K_AM_MEMI_POST_INDEX
               -
                 type: M68K_OP_REG
@@ -301,6 +322,8 @@ test_cases:
                   index_size: -1
                   in_disp: -0x2a
                   out_disp: 0
+                  in_disp_size: -1
+                  out_disp_size: -1
                 address_mode: M68K_AM_AREGI_INDEX_BASE_DISP
               -
                 type: M68K_OP_REG
@@ -320,6 +343,7 @@ test_cases:
                   index_size: -1
                   in_disp: -0x632
                   out_disp: 0
+                  in_disp_size: -1
                 address_mode: M68K_AM_PCI_INDEX_BASE_DISP
               -
                 type: M68K_OP_REG
@@ -339,6 +363,7 @@ test_cases:
                   index_size: -1
                   in_disp: -0x638
                   out_disp: 0
+                  in_disp_size: 1
                 address_mode: M68K_AM_PCI_INDEX_BASE_DISP
               -
                 type: M68K_OP_REG
@@ -356,6 +381,7 @@ test_cases:
                   base_reg: pc
                   index_size: -1
                   in_disp: -0x640
+                  in_disp_size: 1
                 address_mode: M68K_AM_PCI_INDEX_BASE_DISP
               -
                 type: M68K_OP_REG
@@ -373,6 +399,7 @@ test_cases:
                   index_reg: d2
                   index_size: 1
                   disp: 0
+                  disp_size: -1
                 address_mode: M68K_AM_AREGI_INDEX_BASE_DISP
               -
                 type: M68K_OP_REG


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

In the 68K ISA, displacements can be encoded as bytes, words or longs depending on the address mode. When writing assembly code, programmers usually specify these explicitly instead of relying on the default word size. Disassemblers usually, if not always, append the size specifier to displacements.

The PR enables this functionality to be implemented, but doesn't update the built-in assembly printer. The reason for this is the way these addressing modes are currently printed - they do not follow the convention set by Motorola in the 68000 Programmer's Reference Manual. This convention will implemented as an option in a later PR. For now only the API change is implemented, as I consider these separate concerns.

Three size fields have been added - in_disp_size, out_disp_size and disp_size, which provide information about the encoded size of in_disp, out_disp and disp respectively.

**Test plan**

Tests of the new fields have been added to tests/details/m68k.yaml. The existing opcode stream already contains a sufficient selection of encodings.
