### PR TITLE
X86: Fix movabsq immediates >= 2^63 printed as decimal in ATT syntax

### DIFF
--- a/arch/X86/X86ATTInstPrinter.c
+++ b/arch/X86/X86ATTInstPrinter.c
@@ -732,7 +732,8 @@ static void printOperand(MCInst *MI, unsigned OpNo, SStream *O)
 		case X86_INS_MOVABS:
 		case X86_INS_MOV:
 			// do not print number in negative form
-			if (imm > HEX_THRESHOLD)
+			// Use unsigned comparison to handle values >= 2^63 correctly
+			if ((uint64_t)imm > HEX_THRESHOLD)
 				SStream_concat(O, "$0x%" PRIx64, imm);
 			else
 				SStream_concat(O, "$%" PRIu64, imm);


### PR DESCRIPTION
Fix issue #2817: In AT&T syntax, movabsq instructions with immediate values >= 2^63 (0x8000000000000000) were incorrectly printed in decimal instead of hexadecimal.

Root cause: The comparison 'imm > HEX_THRESHOLD' used a signed int64_t, so values with bit 63 set appeared negative and failed the comparison.

Fix: Cast imm to uint64_t for the comparison to handle the full 64-bit unsigned range correctly.

Added test cases for issue 2817 covering both 0x8000000000000000 and 0xffffffffffffffff in ATT syntax.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
