### PR TITLE
fix: use uintptr_t to maintain pointer provenance

### DIFF
--- a/cs.c
+++ b/cs.c
@@ -1020,7 +1020,7 @@ static uint8_t skipdata_size(cs_struct *handle)
 }
 
 CAPSTONE_EXPORT
-cs_err CAPSTONE_API cs_option(csh ud, cs_opt_type type, size_t value)
+cs_err CAPSTONE_API cs_option(csh ud, cs_opt_type type, uintptr_t value)
 {
 	struct cs_struct *handle;
 	cs_opt_mnem *opt;

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -4,6 +4,7 @@
 /* Capstone Disassembly Engine */
 /* By Nguyen Anh Quynh <aquynh@gmail.com>, 2013-2016 */
 
+#include <stdint.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -70,7 +71,7 @@ extern "C" {
 #define CS_MNEMONIC_SIZE 32
 
 // Handle using with all API
-typedef size_t csh;
+typedef uintptr_t csh;
 
 /// Architecture type
 typedef enum cs_arch {
@@ -723,7 +724,7 @@ cs_err CAPSTONE_API cs_close(csh *handle);
  even before cs_open()
 */
 CAPSTONE_EXPORT
-cs_err CAPSTONE_API cs_option(csh handle, cs_opt_type type, size_t value);
+cs_err CAPSTONE_API cs_option(csh handle, cs_opt_type type, uintptr_t value);
 
 /**
  Report the last error number when some API function fail.

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -4,7 +4,6 @@
 /* Capstone Disassembly Engine */
 /* By Nguyen Anh Quynh <aquynh@gmail.com>, 2013-2016 */
 
-#include <stdint.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -15,6 +14,7 @@ extern "C" {
 #include <libkern/libkern.h>
 #else
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdio.h>
 #endif
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

On systems such as CHERI which distinguish integers and pointers, `uintptr_t` should be used to prevent pointer provenance issues.
The fix allows capstone to be compiled and run on ARM Morello.

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

N/A.

If a physical CHERI machine is not available, one can use [cheribuild](https://github.com/CTSRD-CHERI/cheribuild) to build QEMU for Morello and CHERI-RISC-V and run code inside it.

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

...

**Closing issues**

N/A

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
