### PR TITLE
x86: fix decoding of mandatory prefixes

### DIFF
--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -1382,19 +1382,17 @@ bool X86_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 			if (insn.hasAdSize)
 				Flags |= X86_IP_HAS_AD_SIZE;
 
-			if (!insn.mandatoryPrefix) {
-				if (insn.hasOpSize)
-					Flags |= X86_IP_HAS_OP_SIZE;
+			if (insn.hasOpSize)
+				Flags |= X86_IP_HAS_OP_SIZE;
 
-				if (insn.repeatPrefix == 0xf2)
-					Flags |= X86_IP_HAS_REPEAT_NE;
-				else if (insn.repeatPrefix == 0xf3 &&
-					 // It should not be 'pause' f3 90
-					 insn.opcode != 0x90)
-					Flags |= X86_IP_HAS_REPEAT;
-				if (insn.hasLockPrefix)
-					Flags |= X86_IP_HAS_LOCK;
-			}
+			if (insn.repeatPrefix == 0xf2)
+				Flags |= X86_IP_HAS_REPEAT_NE;
+			else if (insn.repeatPrefix == 0xf3 &&
+					// It should not be 'pause' f3 90
+					insn.opcode != 0x90)
+				Flags |= X86_IP_HAS_REPEAT;
+			if (insn.hasLockPrefix)
+				Flags |= X86_IP_HAS_LOCK;
 
 			instr->flags = Flags;
 		}

--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -1388,8 +1388,8 @@ bool X86_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 			if (insn.repeatPrefix == 0xf2)
 				Flags |= X86_IP_HAS_REPEAT_NE;
 			else if (insn.repeatPrefix == 0xf3 &&
-					// It should not be 'pause' f3 90
-					insn.opcode != 0x90)
+				 // It should not be 'pause' f3 90
+				 insn.opcode != 0x90)
 				Flags |= X86_IP_HAS_REPEAT;
 			if (insn.hasLockPrefix)
 				Flags |= X86_IP_HAS_LOCK;

--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -1117,7 +1117,7 @@ static uint16_t resolveMandatoryPrefixConflict(struct InternalInstruction *insn,
 		case 0xA0:
 			resolution = IGNORE_REP;
 			break;
-		default: // 0x80
+		default: // 0xB0
 			resolution = DO_NOT_RESOLVE;
 			break;
 		}

--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -1120,6 +1120,18 @@ static uint16_t resolveMandatoryPrefixConflict(struct InternalInstruction *insn,
 		}
 		break;
 	case THREEBYTE_38:
+		// Exception: the ADOX and CRC32 instructions.
+		// These ignore the data size override prefix even though they
+		// operate on general-purpose registers.
+		if ((insn->opcode & 0xF0) == 0xF0) {
+			resolution = IGNORE_DATA_SIZE;
+			break;
+		}
+
+		// Do not need to be resolved, all REP+DATA16 combinations are UD
+		// or separately specified.
+		resolution = DO_NOT_RESOLVE;
+		break;
 	case THREEBYTE_3A:
 		// Do not need to be resolved, all REP+DATA16 combinations are UD
 		// or separately specified.

--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -353,15 +353,13 @@ static bool isREX(struct InternalInstruction *insn, uint8_t prefix)
 }
 
 /*
- * setPrefixPresent - Marks that a particular prefix is present as mandatory
+ * setGroup0Prefix - Updates the decoded instruction according to the group 0-prefix.
  *
- * @param insn      - The instruction to be marked as having the prefix.
- * @param prefix    - The prefix that is present.
+ * @param insn      - The instruction to be updated.
+ * @param prefix    - The group 0 prefix that is present.
  */
-static void setPrefixPresent(struct InternalInstruction *insn, uint8_t prefix)
+static void setGroup0Prefix(struct InternalInstruction *insn, uint8_t prefix)
 {
-	uint8_t nextByte;
-
 	switch (prefix) {
 	case 0xf0: // LOCK
 		insn->hasLockPrefix = true;
@@ -370,30 +368,8 @@ static void setPrefixPresent(struct InternalInstruction *insn, uint8_t prefix)
 
 	case 0xf2: // REPNE/REPNZ
 	case 0xf3: // REP or REPE/REPZ
-		if (lookAtByte(insn, &nextByte))
-			break;
-		// TODO:
-		//  1. There could be several 0x66
-		//  2. if (nextByte == 0x66) and nextNextByte != 0x0f then
-		//      it's not mandatory prefix
-		//  3. if (nextByte >= 0x40 && nextByte <= 0x4f) it's REX and we need
-		//     0x0f exactly after it to be mandatory prefix
-		if (isREX(insn, nextByte) || nextByte == 0x0f ||
-		    nextByte == 0x66)
-			// The last of 0xf2 /0xf3 is mandatory prefix
-			insn->mandatoryPrefix = prefix;
-
 		insn->repeatPrefix = prefix;
 		insn->hasLockPrefix = false;
-		break;
-
-	case 0x66:
-		if (lookAtByte(insn, &nextByte))
-			break;
-		// 0x66 can't overwrite existing mandatory prefix and should be ignored
-		if (!insn->mandatoryPrefix &&
-		    (nextByte == 0x0f || isREX(insn, nextByte)))
-			insn->mandatoryPrefix = prefix;
 		break;
 	}
 }
@@ -552,7 +528,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 		case 0xf2: /* REPNE/REPNZ */
 		case 0xf3: /* REP or REPE/REPZ */
 			// only accept the last prefix
-			setPrefixPresent(insn, byte);
+			setGroup0Prefix(insn, byte);
 			insn->prefix0 = byte;
 			break;
 
@@ -585,18 +561,15 @@ static int readPrefixes(struct InternalInstruction *insn)
 				// debug("Unhandled override");
 				return -1;
 			}
-			setPrefixPresent(insn, byte);
 			break;
 
 		case 0x66: /* Operand-size override */
 			insn->hasOpSize = true;
-			setPrefixPresent(insn, byte);
 			insn->prefix2 = byte;
 			break;
 
 		case 0x67: /* Address-size override */
 			insn->hasAdSize = true;
-			setPrefixPresent(insn, byte);
 			insn->prefix3 = byte;
 			break;
 		default: /* Not a prefix byte */
@@ -943,10 +916,7 @@ static int readOpcode(struct InternalInstruction *insn)
 			// dbgprintf(insn, "Didn't find a three-byte escape prefix");
 			insn->opcodeType = TWOBYTE;
 		}
-	} else if (insn->mandatoryPrefix)
-		// The opcode with mandatory prefix must start with opcode escape.
-		// If not it's legacy repeat prefix
-		insn->mandatoryPrefix = 0;
+	}
 
 	/*
 	 * At this point we have consumed the full opcode.
@@ -1041,6 +1011,143 @@ static bool is64Bit(uint16_t id)
 
 	// not found??
 	return false;
+}
+
+typedef enum {
+	DO_NOT_RESOLVE = 0,
+	IGNORE_REP = 1,
+	IGNORE_DATA_SIZE = 2,
+} MandatoryPrefixResolution;
+
+/*
+ * shouldResolveMandatoryPrefixConflict - Resolves conflicts between the 
+ * data size override prefix and the REP/REPNZ prefixes in the attribute 
+ * mask when needed.
+ *
+ * We need to resolve these conflicts, because the TableGen lookups we 
+ * perform distinguish between instructions with and without REP.
+ * For example, there may be an entry for SHLD with a DATA16 data size 
+ * override prefix, but no entry for REP + DATA16.
+ * These entries are split, because in some cases the REP and DATA16
+ * prefixes are used as mandatory prefixes.
+ * When both are mandatory prefixes, the effect of prefixing both 
+ * to an instruction at the same time is not specified by
+ * reference manuals.
+ *
+ * Conflicts are resolved by one of these three resolutions:
+ *   - If conflicts should not be resolved, take no action.
+ *   - If conflicts should be resolved and the instruction has no 
+ *     mandatory prefixes, resolves in favor of data size override.
+ *   - If conflicts should be resolved and the instruction has mandatory 
+ *     prefixes, resolves in favor of REP/REPNZ.
+ * 
+ * @param insn - The instruction
+ * @param attrMask - The current attribute mask.
+ */
+static uint16_t resolveMandatoryPrefixConflict(struct InternalInstruction *insn,
+					       uint16_t attrMask)
+{
+	MandatoryPrefixResolution resolution = DO_NOT_RESOLVE;
+
+	// We inspect the opcode map and opcode to determine how we need to resolve
+	// a mandatory prefix conflict.
+	switch (insn->opcodeType) {
+	// No one-byte opcodes have mandatory prefixes.
+	case ONEBYTE:
+		resolution = DO_NOT_RESOLVE;
+		break;
+	case TWOBYTE:
+		// Exceptions for instructions that operate on data size-overridable
+		// operands.
+		if (
+			// XADD
+			(insn->opcode & 0xFE) == 0xC0
+
+			// BSWAP
+			|| (insn->opcode & 0xF8) == 0xC8
+
+			// CMPXCHG, LSS, BTR, LFS, LGS, MOVZX
+			|| (insn->opcode & 0xB8) == 0xB0
+
+			// UD0
+			|| insn->opcode == 0xFF) {
+			resolution = IGNORE_REP;
+			break;
+		}
+
+		// We inspect the instruction to determine if it operates on xmm
+		// registers or general-purpose registers.
+		//
+		// If it operates on general purpose registers, the data size override
+		// prefix is not a mandatory prefix and should not be ignored.
+		// In most cases, this also means that the REP prefix is not a mandatory
+		// prefix and should be ignored.
+		//
+		// If the instruction operates on xmm registers, the data size override
+		// is used to select the operation type (SS, SD, PS, or PD).
+		// In this case, the REP prefixes take priority over the data size [1]
+		// override prefixes, and when both are present the data size override
+		// prefix should be ignored.
+		//
+		// The exception is 0xB0, where the REP prefixes are mandatory prefixes
+		// but the data size override prefix should still be respected.
+		// For this case we return DO_NOT_RESOLVE, which returns attrMask as-is.
+		//
+		// [1]: https://stackoverflow.com/a/7197365
+		switch (insn->opcode & 0xf0) {
+		case 0x10:
+		case 0x50:
+		case 0x60:
+		case 0x70:
+		case 0xC0:
+		case 0xD0:
+		case 0xE0:
+		case 0xF0:
+			resolution = IGNORE_DATA_SIZE;
+			break;
+		case 0x00:
+		case 0x20:
+		case 0x30:
+		case 0x40:
+		case 0x80:
+		case 0x90:
+		case 0xA0:
+			resolution = IGNORE_REP;
+			break;
+		default: // 0x80
+			resolution = DO_NOT_RESOLVE;
+			break;
+		}
+		break;
+	case THREEBYTE_38:
+	case THREEBYTE_3A:
+		// Do not need to be resolved, all REP+DATA16 combinations are UD
+		// or separately specified.
+		resolution = DO_NOT_RESOLVE;
+		break;
+	case XOP8_MAP:
+	case XOP9_MAP:
+	case XOPA_MAP:
+		// These instructions do not appear to operate on XMM/SSE registers,
+		// so the REP prefixes can be safely ignored.
+		resolution = IGNORE_REP;
+		break;
+	case THREEDNOW_MAP:
+		// AMD Reference Manual Volume 3, Section 1.2.1, states that all
+		// 3DNow! instructions ignore the data size override prefix.
+		resolution = IGNORE_DATA_SIZE;
+		break;
+	}
+
+	switch (resolution) {
+	case IGNORE_REP:
+		return attrMask & ~(ATTR_XD | ATTR_XS);
+	case IGNORE_DATA_SIZE:
+		return attrMask & ~ATTR_OPSIZE;
+	default:
+	case DO_NOT_RESOLVE:
+		return attrMask;
+	}
 }
 
 /*
@@ -1139,10 +1246,10 @@ static int getID(struct InternalInstruction *insn)
 		} else {
 			return -1;
 		}
-	} else if (!insn->mandatoryPrefix) {
-		// If we don't have mandatory prefix we should use legacy prefixes here
-		if (insn->hasOpSize && (insn->mode != MODE_16BIT))
+	} else {
+		if (insn->hasOpSize && insn->mode != MODE_16BIT) {
 			attrMask |= ATTR_OPSIZE;
+		}
 		if (insn->hasAdSize)
 			attrMask |= ATTR_ADSIZE;
 		if (insn->opcodeType == ONEBYTE) {
@@ -1156,21 +1263,11 @@ static int getID(struct InternalInstruction *insn)
 			else if (insn->repeatPrefix == 0xf3)
 				attrMask |= ATTR_XS;
 		}
-	} else {
-		switch (insn->mandatoryPrefix) {
-		case 0xf2:
-			attrMask |= ATTR_XD;
-			break;
-		case 0xf3:
-			attrMask |= ATTR_XS;
-			break;
-		case 0x66:
-			if (insn->mode != MODE_16BIT)
-				attrMask |= ATTR_OPSIZE;
-			break;
-		case 0x67:
-			attrMask |= ATTR_ADSIZE;
-			break;
+
+		if ((attrMask & ATTR_OPSIZE) &&
+		    (attrMask & (ATTR_XD | ATTR_XS))) {
+			attrMask =
+				resolveMandatoryPrefixConflict(insn, attrMask);
 		}
 	}
 

--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -1067,7 +1067,10 @@ static uint16_t resolveMandatoryPrefixConflict(struct InternalInstruction *insn,
 			|| (insn->opcode & 0xF8) == 0xC8
 
 			// CMPXCHG, LSS, BTR, LFS, LGS, MOVZX
-			|| (insn->opcode & 0xB8) == 0xB0
+			|| (insn->opcode & 0xF8) == 0xB0
+
+			// Group 16, various NOPs
+			|| (insn->opcode & 0xF8) == 0x18
 
 			// UD0
 			|| insn->opcode == 0xFF) {

--- a/arch/X86/X86DisassemblerDecoder.h
+++ b/arch/X86/X86DisassemblerDecoder.h
@@ -590,9 +590,6 @@ typedef struct InternalInstruction {
 	// The repeat prefix if any
 	uint8_t repeatPrefix;
 
-	// The possible mandatory prefix
-	uint8_t mandatoryPrefix;
-
 	/* The value of the vector extension prefix(EVEX/VEX/XOP), if present */
 	uint8_t vectorExtensionPrefix[4];
 

--- a/docs/cs_v6_release_guide.md
+++ b/docs/cs_v6_release_guide.md
@@ -249,6 +249,7 @@ Nonetheless, we hope this additional information is useful to you.
 
 - Decoding of conflicting segment overrides was changed to match CPU behavior:
   For instructions with both an FS/GS and a ES/CS/SS/DS overrides the FS/GS override now takes priority, regardless of prefix ordering.
+- Decoding of instructions with multiple mandatory prefixes was fixed. (e.g., `shld` with a data size override and a redundant `F3` prefix, or `addss` with an additional `66` prefix)
 
 **BPF**
 

--- a/tests/issues/x86-mandatory-prefixes.yaml
+++ b/tests/issues/x86-mandatory-prefixes.yaml
@@ -224,3 +224,43 @@ test_cases:
       insns:
       -
         asm_text: "cmpxchg ax, bx"
+  -
+    input:
+      name: "x86: ADOX with data size override should decode correctly"
+      bytes: [ 0x66, 0xF3, 0x0F, 0x38, 0xF6, 0x24, 0x27 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "adox esp, dword ptr [rdi + riz]"
+  -
+    input:
+      name: "x86: CRC32 with data size override should decode correctly"
+      bytes: [ 0x66, 0xF2, 0x0F, 0x38, 0xF1, 0x24, 0x27 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "crc32 esp, word ptr [rdi + riz]"
+  -
+    input:
+      name: "x86: CRC32 with data size override should decode correctly"
+      bytes: [ 0xF2, 0x0F, 0x38, 0xF1, 0x24, 0x27 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "crc32 esp, dword ptr [rdi + riz]"
+  -
+    input:
+      name: "x86: MOVBE should decode correctly (is encoded as CRC32 without F2)"
+      bytes: [ 0x0F, 0x38, 0xF1, 0x24, 0x27 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "movbe dword ptr [rdi + riz], esp"

--- a/tests/issues/x86-mandatory-prefixes.yaml
+++ b/tests/issues/x86-mandatory-prefixes.yaml
@@ -1,0 +1,226 @@
+test_cases:
+  -
+    input:
+      name: "x86: last mandatory F2/F3 prefix should take priority"
+      bytes: [ 0x66, 0xF2, 0x0F, 0x58, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "addsd xmm0, xmm1"
+  -
+    input:
+      name: "x86: last mandatory F2/F3 prefix should take priority"
+      bytes: [ 0xF2, 0x66, 0xF3, 0x0F, 0x58, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "addss xmm0, xmm1"
+  -
+    input:
+      name: "x86: last mandatory F2/F3 prefix should take priority"
+      bytes: [ 0xF2, 0x3e, 0x66, 0xF3, 0x2e, 0x66, 0x66, 0x0F, 0x58, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "addss xmm0, xmm1"
+  -
+    input:
+      name: "x86: do not ignore mandatory 66 prefix when no mandatory F2/F3 prefix is present"
+      bytes: [ 0x66, 0x3e, 0x0F, 0x58, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "addpd xmm0, xmm1"
+  -
+    input:
+      name: "x86: SHLD should not ignore data size override prefix, because it is not a mandatory prefix"
+      bytes: [ 0xf3, 0x3e, 0x66, 0x67, 0x0f, 0xa4, 0x84, 0x17, 0x00, 0x00, 0x00, 0x00, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "shld word ptr [edi + edx], ax, 0"
+  -
+    input:
+      name: "x86: POPCNT requires mandatory prefix, but also should allow data size override"
+      bytes: [ 0xf3, 0x0f, 0xb8, 0xc3 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "popcnt eax, ebx"
+  -
+    input:
+      name: "x86: POPCNT requires mandatory prefix, but also should allow data size override"
+      bytes: [ 0x66, 0xf3, 0x0f, 0xb8, 0xc3 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "popcnt ax, bx"
+  -
+    input:
+      name: "x86: POPCNT requires mandatory prefix, but also should allow data size override"
+      bytes: [ 0xf3, 0x66, 0x0f, 0xb8, 0xc3 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "popcnt ax, bx"
+  -
+    input:
+      name: "x86: POPCNT without mandatory prefix should not decode successfully"
+      bytes: [ 0x0f, 0xb8, 0xc3 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns: []
+  -
+    input:
+      name: "x86: POPCNT with incorrect mandatory prefix should not decode successfully"
+      bytes: [ 0xf2, 0x0f, 0xb8, 0xc3 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns: []
+  -
+    input:
+      name: "x86: POPCNT without mandatory prefix but with data size override should not decode successfully"
+      bytes: [ 0x66, 0x0f, 0xb8, 0xc3 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns: []
+  -
+    input:
+      name: "x86: XADD without data size override should decode correctly"
+      bytes: [ 0x0f, 0xc1, 0xd8 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "xadd eax, ebx"
+  -
+    input:
+      name: "x86: XADD with data size override should decode correctly"
+      bytes: [ 0x66, 0x0f, 0xc1, 0xd8 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "xadd ax, bx"
+  -
+    input:
+      name: "x86: XADD with redundant REP prefix should decode correctly"
+      bytes: [ 0xF2, 0x0f, 0xc1, 0xd8 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "xadd eax, ebx"
+  -
+    input:
+      name: "x86: XADD with redundant REP prefix should decode correctly"
+      bytes: [ 0xF3, 0x0f, 0xc1, 0xd8 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "xadd eax, ebx"
+  -
+    input:
+      name: "x86: XADD with redundant REP prefix and data size override should decode correctly"
+      bytes: [ 0x66, 0xF3, 0x0f, 0xc1, 0xd8 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "xadd ax, bx"
+  -
+    input:
+      name: "x86: XADD with redundant REP prefix and data size override should decode correctly"
+      bytes: [ 0xF2, 0x66, 0x0f, 0xc1, 0xd8 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "xadd ax, bx"
+  # We test CMPEQPS because it shares the same 0xB_ opcodes with XADD. XADD ignores the REP prefix, while it is relevant for CMPEQPS.
+  -
+    input:
+      name: "x86: CMPEQPS should decode correctly"
+      bytes: [ 0x0f, 0xc2, 0xc1, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "cmpeqps xmm0, xmm1"
+  -
+    input:
+      name: "x86: CMPEQSS should decode correctly"
+      bytes: [ 0xf3, 0x0f, 0xc2, 0xc1, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "cmpeqss xmm0, xmm1"
+  -
+    input:
+      name: "x86: CMPEQPD should decode correctly"
+      bytes: [ 0x66, 0x0f, 0xc2, 0xc1, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "cmpeqpd xmm0, xmm1"
+  -
+    input:
+      name: "x86: CMPEQPS should decode correctly"
+      bytes: [ 0xf2, 0x0f, 0xc2, 0xc1, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "cmpeqsd xmm0, xmm1"
+  -
+    input:
+      name: "x86: CMPXCHG should decode correctly with data size override"
+      bytes: [ 0x66, 0x0f, 0xb1, 0xd8 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "cmpxchg ax, bx"
+  -
+    input:
+      name: "x86: CMPXCHG should decode correctly with data size override and redundant REP prefixes"
+      bytes: [ 0xf2, 0x67, 0xf3, 0x3e, 0x66, 0x0f, 0xb1, 0xd8 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "cmpxchg ax, bx"

--- a/tests/issues/x86-mandatory-prefixes.yaml
+++ b/tests/issues/x86-mandatory-prefixes.yaml
@@ -1,7 +1,87 @@
 test_cases:
   -
     input:
-      name: "x86: last mandatory F2/F3 prefix should take priority"
+      name: "x86 (16-bit): last mandatory F2/F3 prefix should take priority"
+      bytes: [ 0x66, 0xF2, 0x0F, 0x58, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns:
+      -
+        asm_text: "addsd xmm0, xmm1"
+  -
+    input:
+      name: "x86 (16-bit): last mandatory F2/F3 prefix should take priority"
+      bytes: [ 0xF2, 0x66, 0xF3, 0x0F, 0x58, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns:
+      -
+        asm_text: "addss xmm0, xmm1"
+  -
+    input:
+      name: "x86 (16-bit): last mandatory F2/F3 prefix should take priority"
+      bytes: [ 0xF2, 0x3e, 0x66, 0xF3, 0x2e, 0x66, 0x66, 0x0F, 0x58, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns:
+      -
+        asm_text: "addss xmm0, xmm1"
+  -
+    input:
+      name: "x86 (16-bit): do not ignore mandatory 66 prefix when no mandatory F2/F3 prefix is present"
+      bytes: [ 0x66, 0x3e, 0x0F, 0x58, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns:
+      -
+        asm_text: "addpd xmm0, xmm1"
+  -
+    input:
+      name: "x86 (32-bit): last mandatory F2/F3 prefix should take priority"
+      bytes: [ 0x66, 0xF2, 0x0F, 0x58, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns:
+      -
+        asm_text: "addsd xmm0, xmm1"
+  -
+    input:
+      name: "x86 (32-bit): last mandatory F2/F3 prefix should take priority"
+      bytes: [ 0xF2, 0x66, 0xF3, 0x0F, 0x58, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns:
+      -
+        asm_text: "addss xmm0, xmm1"
+  -
+    input:
+      name: "x86 (32-bit): last mandatory F2/F3 prefix should take priority"
+      bytes: [ 0xF2, 0x3e, 0x66, 0xF3, 0x2e, 0x66, 0x66, 0x0F, 0x58, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns:
+      -
+        asm_text: "addss xmm0, xmm1"
+  -
+    input:
+      name: "x86 (32-bit): do not ignore mandatory 66 prefix when no mandatory F2/F3 prefix is present"
+      bytes: [ 0x66, 0x3e, 0x0F, 0x58, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns:
+      -
+        asm_text: "addpd xmm0, xmm1"
+  -
+    input:
+      name: "x86 (64-bit): last mandatory F2/F3 prefix should take priority"
       bytes: [ 0x66, 0xF2, 0x0F, 0x58, 0xC1 ]
       arch: "CS_ARCH_X86"
       options: [ CS_MODE_64 ]
@@ -11,7 +91,7 @@ test_cases:
         asm_text: "addsd xmm0, xmm1"
   -
     input:
-      name: "x86: last mandatory F2/F3 prefix should take priority"
+      name: "x86 (64-bit): last mandatory F2/F3 prefix should take priority"
       bytes: [ 0xF2, 0x66, 0xF3, 0x0F, 0x58, 0xC1 ]
       arch: "CS_ARCH_X86"
       options: [ CS_MODE_64 ]
@@ -21,7 +101,7 @@ test_cases:
         asm_text: "addss xmm0, xmm1"
   -
     input:
-      name: "x86: last mandatory F2/F3 prefix should take priority"
+      name: "x86 (64-bit): last mandatory F2/F3 prefix should take priority"
       bytes: [ 0xF2, 0x3e, 0x66, 0xF3, 0x2e, 0x66, 0x66, 0x0F, 0x58, 0xC1 ]
       arch: "CS_ARCH_X86"
       options: [ CS_MODE_64 ]
@@ -31,7 +111,7 @@ test_cases:
         asm_text: "addss xmm0, xmm1"
   -
     input:
-      name: "x86: do not ignore mandatory 66 prefix when no mandatory F2/F3 prefix is present"
+      name: "x86 (64-bit): do not ignore mandatory 66 prefix when no mandatory F2/F3 prefix is present"
       bytes: [ 0x66, 0x3e, 0x0F, 0x58, 0xC1 ]
       arch: "CS_ARCH_X86"
       options: [ CS_MODE_64 ]
@@ -41,7 +121,27 @@ test_cases:
         asm_text: "addpd xmm0, xmm1"
   -
     input:
-      name: "x86: SHLD should not ignore data size override prefix, because it is not a mandatory prefix"
+      name: "x86 (16-bit): SHLD should not ignore data size override prefix, because it is not a mandatory prefix"
+      bytes: [ 0xf3, 0x3e, 0x66, 0x0f, 0xa4, 0x84, 0x17, 0x00, 0x00, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_16 ]
+    expected:
+      insns:
+      -
+        asm_text: "shld dword ptr ds:[si + 23], eax, 0"
+  -
+    input:
+      name: "x86 (32-bit): SHLD should not ignore data size override prefix, because it is not a mandatory prefix"
+      bytes: [ 0xf3, 0x3e, 0x66, 0x67, 0x0f, 0xa4, 0x84, 0x17, 0x00, 0x00, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns:
+      -
+        asm_text: "shld word ptr ds:[si + 0x17], ax, 0"
+  -
+    input:
+      name: "x86 (64-bit): SHLD should not ignore data size override prefix, because it is not a mandatory prefix"
       bytes: [ 0xf3, 0x3e, 0x66, 0x67, 0x0f, 0xa4, 0x84, 0x17, 0x00, 0x00, 0x00, 0x00, 0x00 ]
       arch: "CS_ARCH_X86"
       options: [ CS_MODE_64 ]
@@ -264,3 +364,253 @@ test_cases:
       insns:
       -
         asm_text: "movbe dword ptr [rdi + riz], esp"
+  -
+    input:
+      name: "x86: PHADDSW should decode correctly without 66 prefix"
+      bytes: [ 0x0F, 0x38, 0x03, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "phaddsw mm0, mm1"
+  -
+    input:
+      name: "x86: PHADDSW should decode correctly with 66 prefix"
+      bytes: [ 0x66, 0x0F, 0x38, 0x03, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "phaddsw xmm0, xmm1"
+  -
+    input:
+      name: "x86: PHADDSW should fail to decode with F2 prefix"
+      bytes: [ 0xF2, 0x0F, 0x38, 0x03, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns: []
+  -
+    input:
+      name: "x86: PHADDSW should fail to decode with F3 prefix"
+      bytes: [ 0xF3, 0x0F, 0x38, 0x03, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns: []
+  -
+    input:
+      name: "x86: PHADDSW should fail to decode with F2 and 66 prefix"
+      bytes: [ 0xF2, 0x66, 0x0F, 0x38, 0x03, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns: []
+  -
+    input:
+      name: "x86: PHADDSW should fail to decode with F3 and 66 prefix"
+      bytes: [ 0xF3, 0x66, 0x0F, 0x38, 0x03, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns: []
+  -
+    input:
+      name: "x86: SYSCALL should decode correctly without prefixes"
+      bytes: [ 0x0F, 0x05 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "syscall"
+  -
+    input:
+      name: "x86: SYSCALL should decode correctly with 66 prefix"
+      bytes: [ 0x66, 0x0F, 0x05 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "syscall"
+  -
+    input:
+      name: "x86: SYSCALL should decode correctly with F2 prefix"
+      bytes: [ 0xF2, 0x0F, 0x05 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "syscall"
+  -
+    input:
+      name: "x86: SYSCALL should decode correctly with F3 prefix"
+      bytes: [ 0xF3, 0x0F, 0x05 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "syscall"
+  -
+    input:
+      name: "x86: SYSCALL should decode correctly with many ignored prefixes"
+      bytes: [ 0x67, 0xF2, 0x3E, 0x66, 0xF3, 0x66, 0x64, 0xF2, 0xF2, 0x66, 0x0F, 0x05 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "syscall"
+  -
+    input:
+      name: "x86: MOV reg, creg should decode correctly without prefixes"
+      bytes: [ 0x0F, 0x20, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "mov rax, cr0"
+  -
+    input:
+      name: "x86: MOV reg, creg should ignore data size override prefix"
+      bytes: [ 0x66, 0x0F, 0x20, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "mov rax, cr0"
+  -
+    input:
+      name: "x86: MOV reg, creg should decode correctly with F2 prefix"
+      bytes: [ 0xF2, 0x0F, 0x20, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "mov rax, cr0"
+  -
+    input:
+      name: "x86: MOV reg, creg should decode correctly with F3 prefix"
+      bytes: [ 0xF3, 0x0F, 0x20, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "mov rax, cr0"
+  -
+    input:
+      name: "x86: MOV reg, creg should decode correctly with many ignored prefixes"
+      bytes: [ 0x67, 0xF2, 0x3E, 0x66, 0xF3, 0x66, 0x64, 0xF2, 0xF2, 0x66, 0x0F, 0x20, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "mov rax, cr0"
+  -
+    input:
+      name: "x86: CMOVo should respect data size override"
+      bytes: [ 0x66, 0x0f, 0x40, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "cmovo ax, word ptr [rax]"
+  -
+    input:
+      name: "x86: PACKUSWB should be invalid with F2 prefix"
+      bytes: [ 0xF2, 0x0f, 0x67, 0xc1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns: []
+  -
+    input:
+      name: "x86: PACKUSWB should be invalid with F2, 66 prefix"
+      bytes: [ 0xF2, 0x66, 0x0f, 0x67, 0xc1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns: []
+  -
+    input:
+      name: "x86: PACKUSWB should be invalid with F3 prefix"
+      bytes: [ 0xF3, 0x0f, 0x67, 0xc1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns: []
+  -
+    input:
+      name: "x86: PACKUSWB should be invalid with F3, 66 prefix"
+      bytes: [ 0xF3, 0x66, 0x0f, 0x67, 0xc1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_32 ]
+    expected:
+      insns: []
+  -
+    input:
+      name: "x86: NOP should respect data size override prefix"
+      bytes: [ 0xF3, 0xF2, 0x66, 0xF3, 0x0f, 0x19, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "nop word ptr [rax]"
+  -
+    input:
+      name: "x86: NOP should respect data size override prefix"
+      bytes: [ 0xF3, 0xF2, 0xF3, 0x0f, 0x19, 0x00 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns:
+      -
+        asm_text: "nop dword ptr [rax]"
+  -
+    input:
+      name: "x86: PSLLW with F2 prefix should be invalid"
+      bytes: [ 0xF2, 0x66, 0x0F, 0xF1, 0xC1 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns: []
+  -
+    input:
+      name: "x86: RDRAND should decode correctly"
+      bytes: [ 0x0F, 0xC7, 0xF0 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns: 
+      -
+        asm_text: "rdrand eax"
+  -
+    input:
+      name: "x86: RDRAND should respect data size override"
+      bytes: [ 0x66, 0x0F, 0xC7, 0xF0 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns: 
+      -
+        asm_text: "rdrand ax"
+  -
+    input:
+      name: "x86: RDRAND should fail to decode with F2 prefix"
+      bytes: [ 0xF2, 0x0F, 0xC7, 0xF0 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64 ]
+    expected:
+      insns: []


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

As mentioned in #2853, the current decoding of mandatory prefixes is not correct. It expects a hard-coded ordering of prefixes that is not required by instruction reference manuals, [and also does not handle repeated `66` prefixes](https://github.com/capstone-engine/capstone/blob/5ba9e8081239bcb74c0bc6bb25a5d0b3a1700599/arch/X86/X86DisassemblerDecoder.c#L375).

Initially, I tried to modify the existing function with additional checks. However, it is not possible in general to determine whether a prefix should function as a mandatory prefix without inspecting the opcode, so these checks need to occur later in the decoding process.

To fix this, I have removed the `mandatoryPrefix` field and replaced it with a function that resolves conflicting mandatory prefixes in the `getID` function.

**Test plan**

I have added ~~23~~ ~~27~~ 64 tests, comprised of instructions that were originally decoded incorrectly by capstone as well as unexpected edge-cases. For example, instructions with opcode `0FB8..0FBF` treat only the REPE/REPNE prefixes as mandatory, and still expect the data size override to function normally.

In general, this patch should only affect instructions in the secondary opcode map with both a REP (`F2`/`F3`) and a data size override (`66`) prefix.

**Closing issues**

closes #2853
