### PR TITLE
 RISCV: Fix spurious return groups for JALR instructions using ra as a source for indirect jumps.

### DIFF
--- a/arch/RISCV/RISCVMapping.c
+++ b/arch/RISCV/RISCVMapping.c
@@ -231,12 +231,21 @@ static inline void RISCV_add_ret_group(MCInst *MI)
 	}
 	if (MI->Opcode == RISCV_JALR) {
 		// indirect jumps whose source is ra
+		cs_riscv_op *dstreg = RISCV_get_detail_op_at(MI, 0);
 		cs_riscv_op *op = RISCV_get_detail_op_at(MI, 1);
+		cs_riscv_op *op2 = RISCV_get_detail_op_at(MI, 2);
 		if ((op->type == (riscv_op_type)CS_OP_REG) &&
-		    op->reg == RISCV_REG_X1) {
+		    op->reg == RISCV_REG_X1 &&
+		    op2->type == (riscv_op_type)CS_OP_IMM && op2->imm == 0 &&
+		    dstreg->type == (riscv_op_type)CS_OP_REG &&
+		    dstreg->reg == RISCV_REG_X0) {
 			add_group(MI, RISCV_GRP_RET);
 		} else {
-			add_group(MI, RISCV_GRP_JUMP);
+			if (!((dstreg->type == (riscv_op_type)CS_OP_REG) &&
+			      dstreg->reg != RISCV_REG_X0 &&
+			      (dstreg->access & CS_AC_WRITE))) {
+				add_group(MI, RISCV_GRP_JUMP);
+			}
 		}
 	}
 }

--- a/tests/details/riscv.yaml
+++ b/tests/details/riscv.yaml
@@ -331,7 +331,7 @@ test_cases:
                 - type: RISCV_OP_IMM
                   imm: 0x4
                   access: CS_AC_READ
-            groups: [RISCV_GRP_CALL, RISCV_GRP_JUMP]
+            groups: [RISCV_GRP_CALL]
         - asm_text: "jalr ra, -4(zero)"
           details:
             riscv:
@@ -345,7 +345,7 @@ test_cases:
                 - type: RISCV_OP_IMM
                   imm: -4
                   access: CS_AC_READ
-            groups: [RISCV_GRP_CALL, RISCV_GRP_JUMP]
+            groups: [RISCV_GRP_CALL]
         - asm_text: "beq sp, tp, 4130"
           details:
             riscv:
@@ -1772,7 +1772,7 @@ test_cases:
                 - type: RISCV_OP_IMM
                   imm: 0x4
                   access: CS_AC_READ
-            groups: [RISCV_GRP_CALL, RISCV_GRP_JUMP]
+            groups: [RISCV_GRP_CALL]
   - input:
       bytes: [0xe7, 0x00, 0xc0, 0xff]
       arch: "CS_ARCH_RISCV"
@@ -1793,7 +1793,7 @@ test_cases:
                 - type: RISCV_OP_IMM
                   imm: -4
                   access: CS_AC_READ
-            groups: [RISCV_GRP_CALL, RISCV_GRP_JUMP]
+            groups: [RISCV_GRP_CALL]
   - input:
       bytes: [0x63, 0x05, 0x41, 0x00]
       arch: "CS_ARCH_RISCV"
@@ -5047,8 +5047,8 @@ test_cases:
                   access: CS_AC_READ
             groups: [RISCV_FEATURE_HasStdExtCOrZca, RISCV_GRP_RET]
   
-  # Edge case: JALR x2, 5(ra) - unusual, classified as both CALL and RET
-  # This writes to x2 (sp) which makes it a call, but uses ra as base (ret pattern)
+  # Edge case: JALR x2, 5(ra) - NOT A RETURN
+  # A return MUST have an x0 destination link register and zero offset
   - input:
       bytes: [0x67, 0x81, 0x50, 0x00]
       arch: "CS_ARCH_RISCV"
@@ -5069,10 +5069,10 @@ test_cases:
                 - type: RISCV_OP_IMM
                   imm: 0x5
                   access: CS_AC_READ
-            groups: [RISCV_GRP_CALL, RISCV_GRP_RET]
+            groups: [RISCV_GRP_CALL]
   
-  # Edge case: JALR x0, 5(ra) - return with non-zero offset (unusual)
-  # Classified as RET because rd=x0, but offset is non-zero
+  # Edge case: JALR x0, 5(ra) - NOT A RETURN
+  # A return MUST have a zero offset
   - input:
       bytes: [0x67, 0x80, 0x50, 0x00]
       arch: "CS_ARCH_RISCV"
@@ -5093,10 +5093,10 @@ test_cases:
                 - type: RISCV_OP_IMM
                   imm: 0x5
                   access: CS_AC_READ
-            groups: [RISCV_GRP_RET]
+            groups: [RISCV_GRP_JUMP]
   
-  # Edge case: JALR x1, 0(ra) - writes to ra, unusual return pattern
-  # This is classified as CALL because rd=x1 (ra), even though rs1=ra too
+  # Edge case: JALR x1, 0(ra) - NOT A RETURN
+  # A return MUST have an x0 destination link register
   - input:
       bytes: [0xe7, 0x80, 0x00, 0x00]
       arch: "CS_ARCH_RISCV"
@@ -5117,10 +5117,11 @@ test_cases:
                 - type: RISCV_OP_IMM
                   imm: 0x0
                   access: CS_AC_READ
-            groups: [RISCV_GRP_CALL, RISCV_GRP_RET]
+            groups: [RISCV_GRP_CALL]
   
  
-  # Edge case: JALR x0, -4(ra) - return with negative offset
+  # Edge case: JALR x0, -4(ra) - NOT A RETURN
+  # A return MUST have a zero offset
   - input:
       bytes: [0x67, 0x80, 0xc0, 0xff]
       arch: "CS_ARCH_RISCV"
@@ -5141,10 +5142,10 @@ test_cases:
                 - type: RISCV_OP_IMM
                   imm: -4
                   access: CS_AC_READ
-            groups: [RISCV_GRP_RET]
+            groups: [RISCV_GRP_JUMP]
   
-  # Edge case: JALR x5, 0(ra) - writes to a saved register
-  # Classified as CALL because rd != x0
+  # Edge case: JALR x5, 0(ra) - NOT A RETURN
+  # A return MUST have an x0 destination link register
   - input:
       bytes: [0xe7, 0x82, 0x00, 0x00]
       arch: "CS_ARCH_RISCV"
@@ -5165,7 +5166,7 @@ test_cases:
                 - type: RISCV_OP_IMM
                   imm: 0x0
                   access: CS_AC_READ
-            groups: [RISCV_GRP_CALL, RISCV_GRP_RET]
+            groups: [RISCV_GRP_CALL]
   
   # RV64 specific: Same tests should work in RV64 mode
   # Standard return in RV64: JALR x0, 0(ra)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Fix spurious return groups for JALR instructions using ra as a source for indirect jumps

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

For example, both `jalr ra, 0(ra)` and `jalr x0, n(ra)` are legtimiate indirect jump patterns used by compilers in the wild, but they were counted as returns. This was fixed by checking both the destination and the immediate to be `x0` and `0` respectively.

**Test plan**
 
<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

...

**Closing issues**.
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
