### PR TITLE
Release v6.0.0-Alpha7

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,27 @@
 This file details the changelog of Capstone.
 
 -----------------------------
+Version 6.0.0-Alpha7: February 15th, 2026
+
+## What's Changed
+* Refactoring the RISCV architecture to Auto-Sync on LLVM by @moste00 in https://github.com/capstone-engine/capstone/pull/2756
+* Added RISCV v6 release notes by @moste00 in https://github.com/capstone-engine/capstone/pull/2846
+* Package build workflow fix by @Rot127 in https://github.com/capstone-engine/capstone/pull/2849
+* Ignore ES/CS/SS/DS segment overrides in x64 mode by @jxors in https://github.com/capstone-engine/capstone/pull/2819
+* RISCV: Details: Fix ret groups by @moste00 in https://github.com/capstone-engine/capstone/pull/2859
+* RISCV: Fix spurious return groups for JALR instructions using ra as a source for indirect jumps. by @moste00 in https://github.com/capstone-engine/capstone/pull/2860
+* x86: fix decoding of mandatory prefixes by @jxors in https://github.com/capstone-engine/capstone/pull/2856
+* Fix unchecked allocations by @Grond66 in https://github.com/capstone-engine/capstone/pull/2844
+* Convert all README's to markdown files. by @Rot127 in https://github.com/capstone-engine/capstone/pull/2863
+* Fix 32bit build by @Rot127 in https://github.com/capstone-engine/capstone/pull/2796
+
+## New Contributors
+* @jxors made their first contribution in https://github.com/capstone-engine/capstone/pull/2819
+* @Grond66 made their first contribution in https://github.com/capstone-engine/capstone/pull/2844
+
+**Full Changelog**: https://github.com/capstone-engine/capstone/compare/6.0.0-Alpha6...gen-changelog
+
+-----------------------------
 Version 6.0.0-Alpha6: January 13th, 2026
 
 ## What's Changed

--- a/pkgconfig.mk
+++ b/pkgconfig.mk
@@ -9,4 +9,4 @@ PKG_MINOR = 0
 PKG_EXTRA = 0
 
 # version tag. Examples: rc1, b2, post1 - or just comment out for no tag
-PKG_TAG = alpha6
+PKG_TAG = alpha7


### PR DESCRIPTION

# Highlights

**RISC-V**

This release contains the highly awaited RISC-V module update.
Because RISC-V is in such active development the changes compared to the old module are enormous.

Please check out the RISC-V summary in the [release guide](https://github.com/capstone-engine/capstone/blob/next/docs/cs_v6_release_guide.md#new-features) for an overview.
We expect it to have some bugs so we are grateful for reports!

**Capstone 32 bit builds**

Capstone is now build and tested on several 32 bit architectures, including i686 Windows.

**Consistent error reporting of `CS_ERR_MEM`**

Fix possible NULL-pointer dereferences for out of memory events.
Capstone's API will now always return `CS_ERR_MEM` if allocations fail.

**x86-64: Decoding of conflicting segment overrides was changed to match CPU behavior.**

Please see the `x86-64` section in the [release guide](https://github.com/capstone-engine/capstone/blob/next/docs/cs_v6_release_guide.md#new-features) for details.