### PR TITLE
wasm: add missing error check in read_memoryimmediate()

### DIFF
--- a/arch/WASM/WASMDisassembler.c
+++ b/arch/WASM/WASMDisassembler.c
@@ -465,6 +465,9 @@ static bool read_memoryimmediate(const uint8_t *code, size_t code_len,
 
 	len = tmp;
 	data[1] = get_varuint32(&code[len], code_len - len, &tmp);
+	if (tmp == -1) {
+		return false;
+	}
 
 	if (MI->flat_insn->detail) {
 		MI->flat_insn->detail->wasm.operands[1].type =

--- a/tests/issues/fuzzing.yaml
+++ b/tests/issues/fuzzing.yaml
@@ -27,3 +27,12 @@ test_cases:
     expected:
       insns: []
 
+  -
+    input:
+      name: "WASM truncated memory immediate should fail (#2865)"
+      bytes: [ 0x28, 0x01 ]
+      arch: "wasm"
+      options: [ CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns: []


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've documented or updated the documentation of every API function and struct this PR changes.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

The second `get_varuint32()` call in `read_memoryimmediate()` had no error check. When it fails (truncated input), `tmp` is set to `(size_t)-1`, which gets written into `operand[1].size` as `0xFFFFFFFF` and causes integer wraparound in the instruction size calculation.

Affects all WASM memory load/store opcodes (0x28-0x3E).

**Test plan**

#2865

Before fix: `operand[1].size = 4294967295`
After fix: correctly rejected

**Closing issues**

Fixes: #2865
