### PR TITLE
Python MANIFEST: add missing xprint.py in tests/

### DIFF
--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include src *
+recursive-include tests *
 recursive-include prebuilt *
 include BUILDING.md
 graft capstone/lib


### PR DESCRIPTION
When setup.py is executed, the packaged tests directory will be missing the xprint.py file, which will cause test cases to fail.

**Closing issues**

closes https://github.com/capstone-engine/capstone/issues/2870