### PR TITLE
riscv: remove extra RISCV_INS_INVALID

### DIFF
--- a/arch/RISCV/RISCVMapping.c
+++ b/arch/RISCV/RISCVMapping.c
@@ -348,8 +348,6 @@ void RISCV_get_insn_id(cs_struct *h, cs_insn *insn, unsigned int id)
 }
 
 static const char *const insn_name_maps[] = {
-	/*RISCV_INS_INVALID:*/ NULL,
-
 #include "RISCVGenCSMappingInsnName.inc"
 };
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

There are two `RISCV_INS_INVALID` in `insn_name_maps`. Remove one to fix `cs_insn_name`.

https://github.com/capstone-engine/capstone/blob/e1c899a15a9ab0f0f689fd9ebd1b9297ce079467/arch/RISCV/RISCVGenCSMappingInsnName.inc#L14

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
