### PR TITLE
Fix stale values in the detail struct

### DIFF
--- a/arch/RISCV/RISCVDisassembler.c
+++ b/arch/RISCV/RISCVDisassembler.c
@@ -38,6 +38,7 @@
 #include "../../utils.h"
 #include "RISCVDisassemblerExtension.h"
 #include "RISCVBaseInfo.h"
+#include "RISCVMapping.h"
 
 #define GET_SUBTARGETINFO_ENUM
 #include "RISCVGenSubtargetInfo.inc"
@@ -745,6 +746,7 @@ bool RISCV_LLVM_getInstruction(csh handle, const uint8_t *Bytes, size_t ByteLen,
 			       MCInst *MI, uint16_t *Size, uint64_t Address,
 			       void *Info)
 {
+	RISCV_init_cs_detail(MI);
 	MI->MRI = (MCRegisterInfo *)Info;
 	return RISCV_getInstruction(MI, Size, Bytes, ByteLen, Address, NULL) !=
 	       MCDisassembler_Fail;

--- a/arch/RISCV/RISCVMapping.c
+++ b/arch/RISCV/RISCVMapping.c
@@ -262,6 +262,23 @@ static inline void RISCV_add_adhoc_groups(MCInst *MI)
 	RISCV_add_ret_group(MI);
 }
 
+// memset all stalled values in the detail struct to 0 before disassembling any next instruction
+void RISCV_init_cs_detail(MCInst *MI)
+{
+	if (detail_is_set(MI)) {
+		memset(get_detail(MI), 0,
+		       offsetof(cs_detail, riscv) + sizeof(cs_riscv));
+
+		// RISCV_OP_INVALID must be 0 to avoid explicit initialization of all operand
+		// types. If this changes, uncomment the loop below to reset them.
+		_Static_assert(
+			RISCV_OP_INVALID == 0,
+			"RISCV_OP_INVALID is not 0, uncomment the loop below");
+		//for (size_t i = 0; i < ARR_SIZE(RISCV_get_detail(MI)->operands); ++i)
+		//      RISCV_get_detail(MI)->operands[i].type = RISCV_OP_INVALID;
+	}
+}
+
 // for weird reasons some instructions end up with valid operands that are
 // interspersed with invalid operands, i.e. the operands array is an "island"
 // of valid operands with invalid gaps between them, this function will compactify

--- a/arch/RISCV/RISCVMapping.c
+++ b/arch/RISCV/RISCVMapping.c
@@ -265,18 +265,9 @@ static inline void RISCV_add_adhoc_groups(MCInst *MI)
 // memset all stalled values in the detail struct to 0 before disassembling any next instruction
 void RISCV_init_cs_detail(MCInst *MI)
 {
-	if (detail_is_set(MI)) {
+	if (detail_is_set(MI))
 		memset(get_detail(MI), 0,
 		       offsetof(cs_detail, riscv) + sizeof(cs_riscv));
-
-		// RISCV_OP_INVALID must be 0 to avoid explicit initialization of all operand
-		// types. If this changes, uncomment the loop below to reset them.
-		_Static_assert(
-			RISCV_OP_INVALID == 0,
-			"RISCV_OP_INVALID is not 0, uncomment the loop below");
-		//for (size_t i = 0; i < ARR_SIZE(RISCV_get_detail(MI)->operands); ++i)
-		//      RISCV_get_detail(MI)->operands[i].type = RISCV_OP_INVALID;
-	}
 }
 
 // for weird reasons some instructions end up with valid operands that are

--- a/arch/RISCV/RISCVMapping.h
+++ b/arch/RISCV/RISCVMapping.h
@@ -25,6 +25,8 @@ void RISCV_add_cs_detail_0(MCInst *MI, riscv_op_group opgroup, unsigned OpNum);
 
 void RISCV_add_groups(MCInst *MI);
 
+void RISCV_init_cs_detail(MCInst *MI);
+
 void RISCV_compact_operands(MCInst *MI);
 
 void RISCV_add_missing_write_access(MCInst *MI);

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6321,3 +6321,81 @@ test_cases:
                 reg: $2
               - type: ALPHA_OP_IMM
                 imm: 0x12001b350
+  -
+    input:
+      name: "RISCV - #2881 - op_count must not accumulate across instructions (real)"
+      bytes: [ 0x41, 0x11, 0x13, 0x85, 0x15, 0x00, 0x41, 0x11 ]
+      arch: "CS_ARCH_RISCV"
+      options: [ CS_MODE_RISCV64, CS_MODE_RISCV_C, CS_OPT_DETAIL, CS_OPT_DETAIL_REAL, CS_OPT_SYNTAX_NO_ALIAS_TEXT, CS_OPT_SYNTAX_NO_ALIAS_TEXT_COMPRESSED ]
+    expected:
+      insns:
+      -
+        asm_text: "c.addi sp, -0x10"
+        details:
+          riscv:
+            operands:
+            - type: "RISCV_OP_REG"
+              reg: "sp"
+            - type: "RISCV_OP_IMM"
+              imm: -0x10
+      -
+        asm_text: "addi a0, a1, 1"
+        details:
+          riscv:
+            operands:
+            - type: "RISCV_OP_REG"
+              reg: "a0"
+            - type: "RISCV_OP_REG"
+              reg: "a1"
+            - type: "RISCV_OP_IMM"
+              imm: 1
+      -
+        asm_text: "c.addi sp, -0x10"
+        details:
+          riscv:
+            operands:
+            - type: "RISCV_OP_REG"
+              reg: "sp"
+            - type: "RISCV_OP_IMM"
+              imm: -0x10
+  -
+    input:
+      name: "RISCV - #2881 - op_count must not accumulate across instructions (alias)"
+      bytes: [ 0x41, 0x11, 0x13, 0x85, 0x15, 0x00, 0x41, 0x11 ]
+      arch: "CS_ARCH_RISCV"
+      options: [ CS_MODE_RISCV64, CS_MODE_RISCV_C, CS_OPT_DETAIL ]
+    expected:
+      insns:
+      -
+        asm_text: "addi sp, sp, -0x10"
+        details:
+          riscv:
+            operands:
+            - type: "RISCV_OP_REG"
+              reg: "sp"
+            - type: "RISCV_OP_REG"
+              reg: "sp"
+            - type: "RISCV_OP_IMM"
+              imm: -0x10
+      -
+        asm_text: "addi a0, a1, 1"
+        details:
+          riscv:
+            operands:
+            - type: "RISCV_OP_REG"
+              reg: "a0"
+            - type: "RISCV_OP_REG"
+              reg: "a1"
+            - type: "RISCV_OP_IMM"
+              imm: 1
+      -
+        asm_text: "addi sp, sp, -0x10"
+        details:
+          riscv:
+            operands:
+            - type: "RISCV_OP_REG"
+              reg: "sp"
+            - type: "RISCV_OP_REG"
+              reg: "sp"
+            - type: "RISCV_OP_IMM"
+              imm: -0x10

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 enable_testing()
-set(UNIT_TEST_SOURCES sstream.c utils.c)
+set(UNIT_TEST_SOURCES sstream.c utils.c riscv_op_count_iter.c)
 include_directories(include)
 
 foreach(TSRC ${UNIT_TEST_SOURCES})

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.15)
 
 enable_testing()
-set(UNIT_TEST_SOURCES sstream.c utils.c riscv_op_count_iter.c)
+set(UNIT_TEST_SOURCES sstream.c utils.c)
+if(CAPSTONE_RISCV_SUPPORT)
+    list(APPEND UNIT_TEST_SOURCES riscv_op_count_iter.c)
+endif()
 include_directories(include)
 
 foreach(TSRC ${UNIT_TEST_SOURCES})

--- a/tests/unit/riscv_op_count_iter.c
+++ b/tests/unit/riscv_op_count_iter.c
@@ -1,0 +1,47 @@
+#include "unit_test.h"
+#include <capstone/capstone.h>
+#include <stdio.h>
+#include <inttypes.h>
+
+// c.addi sp, -16 (2 ops) -> addi a0, a1, 1 (3 ops) -> c.addi sp, -16 (2 ops)
+// Without RISCV_init_cs_detail(), op_count accumulates: 2, 5, 7
+static bool test_riscv_op_count_no_stale()
+{
+	printf("Test test_riscv_op_count_no_stale\n");
+	static const uint8_t code[] = {
+		0x41, 0x11, // c.addi sp, -16
+		0x13, 0x85, 0x15, 0x00, // addi a0, a1, 1
+		0x41, 0x11, // c.addi sp, -16
+	};
+	static const int32_t expected_op_counts[] = { 2, 3, 2 };
+
+	csh handle;
+	cs_open(CS_ARCH_RISCV, CS_MODE_RISCV64 | CS_MODE_RISCV_C, &handle);
+	cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON | CS_OPT_DETAIL_REAL);
+	cs_option(handle, CS_OPT_SYNTAX,
+		  CS_OPT_SYNTAX_NO_ALIAS_TEXT |
+			  CS_OPT_SYNTAX_NO_ALIAS_TEXT_COMPRESSED);
+	cs_insn *insn = cs_malloc(handle);
+
+	const uint8_t *start = code;
+	size_t size = sizeof(code);
+	uint64_t address = 0;
+	size_t i = 0;
+
+	while (cs_disasm_iter(handle, &start, &size, &address, insn)) {
+		CHECK_INT_EQUAL_RET_FALSE((size_t)insn->detail->riscv.op_count,
+					  expected_op_counts[i]);
+		++i;
+	}
+
+	cs_free(insn, 1);
+	cs_close(&handle);
+	return true;
+}
+
+int main(void)
+{
+	bool ret = true;
+	ret &= test_riscv_op_count_no_stale();
+	return ret ? 0 : -1;
+}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The bug: The detail struct (`cs_detail`) isn't cleared between instructions, causing stale values. For example, `op_count` would grow with each new instruction, and was only reset in rare cases when alias instructions are used but alias details are disabled (see [`RISCV_LLVM_printInstruction():411`](https://github.com/capstone-engine/capstone/blob/next/arch/RISCV/RISCVInstPrinter.c#L411)).

The fix: Added `RISCV_init_cs_detail()` that gets called once from `RISCV_LLVM_getInstruction()` before decoding each instruction.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Pseudo snippet:
```c
cs_open(CS_ARCH_RISCV, CS_MODE_RISCV64 | CS_MODE_RISCV_C, &handle);
cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);

while (cs_disasm_iter(handle, &start, &size, &address, insn))
	printf("%d\n", insn->detail->riscv.op_count);
```
Without the patch, `op_count` would grow up to the max value of uint8_t (255).

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
