### PR TITLE
cs_disasm_iter: return early on zero-size input

### DIFF
--- a/cs.c
+++ b/cs.c
@@ -1517,6 +1517,9 @@ CAPSTONE_EXPORT
 bool CAPSTONE_API cs_disasm_iter(csh ud, const uint8_t **code, size_t *size,
 				 uint64_t *address, cs_insn *insn)
 {
+	if (*size == 0)
+		return false;
+
 	struct cs_struct *handle;
 	uint16_t insn_size;
 	MCInst mci;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

cs_disasm_iter() does not stop when size reaches zero, allowing the backend decoder to be called with no remaining input. This results in out-of-bounds reads, observed in the RISC-V unit test introduced in #2881 under ASan.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
