### PR TITLE
fix: avoid strnlen() in cs_strndup for Mac OS X 10.5 portability

### DIFF
--- a/suite/cstest/include/helper.h
+++ b/suite/cstest/include/helper.h
@@ -6,6 +6,8 @@
 
 #include <stddef.h>
 
+#include "../../../utils.h"
+
 #define MAX_ASM_TXT_MEM 1024
 #define X86_16 0
 #define X86_32 1
@@ -18,9 +20,5 @@ void replace_negative(char *src, size_t src_len, size_t arch_bits);
 void norm_spaces(char *str);
 void str_to_lower(char *str);
 char *cs_strndup(const char *s, size_t n);
-
-// Provided by libcapstone (utils.c). Portable strnlen replacement
-// for platforms that lack it.
-#include "../../../utils.h"
 
 #endif /* HELPER_H */

--- a/suite/cstest/include/helper.h
+++ b/suite/cstest/include/helper.h
@@ -19,4 +19,8 @@ void norm_spaces(char *str);
 void str_to_lower(char *str);
 char *cs_strndup(const char *s, size_t n);
 
+// Provided by libcapstone (utils.c). Portable strnlen replacement
+// for platforms that lack it.
+size_t cs_strnlen(const char *str, size_t n);
+
 #endif /* HELPER_H */

--- a/suite/cstest/include/helper.h
+++ b/suite/cstest/include/helper.h
@@ -21,6 +21,6 @@ char *cs_strndup(const char *s, size_t n);
 
 // Provided by libcapstone (utils.c). Portable strnlen replacement
 // for platforms that lack it.
-size_t cs_strnlen(const char *str, size_t n);
+#include "../../../utils.h"
 
 #endif /* HELPER_H */

--- a/suite/cstest/src/helper.c
+++ b/suite/cstest/src/helper.c
@@ -17,7 +17,13 @@ char *cs_strndup(const char *s, size_t n)
 	if (!s) {
 		return NULL;
 	}
-	size_t l = strnlen(s, n);
+	/* Find length up to n bytes without using strnlen(),
+	 * which is not available on older platforms such as
+	 * Mac OS X 10.5 (Leopard). */
+	size_t l = 0;
+	while (l < n && s[l] != '\0') {
+		l++;
+	}
 	if (l == SIZE_MAX) {
 		return NULL;
 	}

--- a/suite/cstest/src/helper.c
+++ b/suite/cstest/src/helper.c
@@ -17,13 +17,7 @@ char *cs_strndup(const char *s, size_t n)
 	if (!s) {
 		return NULL;
 	}
-	/* Find length up to n bytes without using strnlen(),
-	 * which is not available on older platforms such as
-	 * Mac OS X 10.5 (Leopard). */
-	size_t l = 0;
-	while (l < n && s[l] != '\0') {
-		l++;
-	}
+	size_t l = cs_strnlen(s, n);
 	if (l == SIZE_MAX) {
 		return NULL;
 	}

--- a/utils.c
+++ b/utils.c
@@ -47,6 +47,18 @@ char *cs_strdup(const char *str)
 	return (char *)memmove(new, str, len);
 }
 
+// Portable strnlen replacement for platforms that lack it
+// (e.g. Mac OS X 10.5 Leopard).
+size_t cs_strnlen(const char *str, size_t n)
+{
+	size_t l = 0;
+
+	while (l < n && str[l] != '\0')
+		l++;
+
+	return l;
+}
+
 // we need this since Windows doesn't have snprintf()
 int cs_snprintf(char *buffer, size_t size, const char *fmt, ...)
 {

--- a/utils.c
+++ b/utils.c
@@ -51,6 +51,9 @@ char *cs_strdup(const char *str)
 // (e.g. Mac OS X 10.5 Leopard).
 size_t cs_strnlen(const char *str, size_t n)
 {
+	if (!str)
+		return 0;
+
 	size_t l = 0;
 
 	while (l < n && str[l] != '\0')

--- a/utils.h
+++ b/utils.h
@@ -26,6 +26,11 @@ unsigned int count_positive8(const unsigned char *list);
 
 char *cs_strdup(const char *str);
 
+// Portable strnlen replacement. Returns the length of @str,
+// up to a maximum of @n. Needed because strnlen() is not
+// available on all platforms (e.g. Mac OS X 10.5 Leopard).
+size_t cs_strnlen(const char *str, size_t n);
+
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
 
 // we need this since Windows doesn't have snprintf()


### PR DESCRIPTION
Fixes #2517

The cs_strndup() function in cstest uses strnlen(), which is a POSIX.1-2008 addition and is not available on older platforms -- in our case Mac OS X 10.5 Leopard on PowerPC (we build on a Power Mac G4).

This just replaces the strnlen() call with a plain loop that does the same bounded-length scan. No functional change, just makes it compile on systems that lack strnlen.

Tested building cstest with -DCAPSTONE_BUILD_CSTEST=ON on Leopard.