### PR TITLE
Fix position of comments to not break const_generator.py

### DIFF
--- a/include/capstone/arm.h
+++ b/include/capstone/arm.h
@@ -425,22 +425,20 @@ typedef enum arm_op_type {
 	ARM_OP_IMM = CS_OP_IMM, ///< Immediate operand
 	ARM_OP_FP = CS_OP_FP, ///< Floating-Point operand
 	ARM_OP_PRED = CS_OP_PRED, ///< Predicate
-	ARM_OP_CIMM =
-		CS_OP_SPECIAL + 0, ///< C-Immediate (coprocessor registers)
-	ARM_OP_PIMM =
-		CS_OP_SPECIAL + 1, ///< P-Immediate (coprocessor registers)
+	// C-Immediate (coprocessor registers)
+	ARM_OP_CIMM = CS_OP_SPECIAL + 0,
+	// P-Immediate (coprocessor registers)
+	ARM_OP_PIMM = CS_OP_SPECIAL + 1,
 	ARM_OP_SETEND = CS_OP_SPECIAL + 2, ///< operand for SETEND instruction
 	ARM_OP_SYSREG = CS_OP_SPECIAL + 3, ///< MSR/MRS special register operand
 	ARM_OP_BANKEDREG = CS_OP_SPECIAL + 4, ///< Banked register operand
 	ARM_OP_SPSR = CS_OP_SPECIAL + 5, ///< Collection of SPSR bits
 	ARM_OP_CPSR = CS_OP_SPECIAL + 6, ///< Collection of CPSR bits
 	ARM_OP_SYSM = CS_OP_SPECIAL + 7, ///< Raw SYSm field
-	ARM_OP_VPRED_R =
-		CS_OP_SPECIAL +
-		8, ///< Vector predicate. Leaves inactive lanes of output vector register unchanged.
-	ARM_OP_VPRED_N =
-		CS_OP_SPECIAL +
-		9, ///< Vector predicate. Don't preserved inactive lanes of output register.
+	// Vector predicate. Leaves inactive lanes of output vector register unchanged.
+	ARM_OP_VPRED_R = CS_OP_SPECIAL + 8,
+	// Vector predicate. Don't preserved inactive lanes of output register.
+	ARM_OP_VPRED_N = CS_OP_SPECIAL + 9,
 	ARM_OP_MEM = CS_OP_MEM, ///< Memory operand
 } arm_op_type;
 

--- a/include/capstone/m68k.h
+++ b/include/capstone/m68k.h
@@ -114,14 +114,13 @@ typedef enum m68k_op_type {
 	M68K_OP_INVALID = CS_OP_INVALID, ///< = CS_OP_INVALID (Uninitialized).
 	M68K_OP_REG = CS_OP_REG, ///< = CS_OP_REG (Register operand).
 	M68K_OP_IMM = CS_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
-	M68K_OP_FP_SINGLE =
-		CS_OP_SPECIAL + 0, ///< single precision Floating-Point operand
-	M68K_OP_FP_DOUBLE =
-		CS_OP_SPECIAL + 1, ///< double precision Floating-Point operand
+	// single precision Floating-Point operand
+	M68K_OP_FP_SINGLE = CS_OP_SPECIAL + 0,
+	// double precision Floating-Point operand
+	M68K_OP_FP_DOUBLE = CS_OP_SPECIAL + 1,
 	M68K_OP_REG_BITS = CS_OP_SPECIAL + 2, ///< Register bits move
-	M68K_OP_REG_PAIR =
-		CS_OP_SPECIAL +
-		3, ///< Register pair in the same op (upper 4 bits for first reg, lower for second)
+	// Register pair in the same op (upper 4 bits for first reg, lower for second)
+	M68K_OP_REG_PAIR = CS_OP_SPECIAL + 3,
 	M68K_OP_BR_DISP = CS_OP_SPECIAL + 4, ///< Branch displacement
 	M68K_OP_MEM = CS_OP_MEM, ///< = CS_OP_MEM (Memory operand).
 } m68k_op_type;

--- a/include/capstone/mos65xx.h
+++ b/include/capstone/mos65xx.h
@@ -171,8 +171,8 @@ typedef enum mos65xx_group_type {
 
 /// Operand type for instruction's operands
 typedef enum mos65xx_op_type {
-	MOS65XX_OP_INVALID =
-		CS_OP_INVALID, ///< = CS_OP_INVALID (Uninitialized).
+	// = CS_OP_INVALID (Uninitialized).
+	MOS65XX_OP_INVALID = CS_OP_INVALID,
 	MOS65XX_OP_REG = CS_OP_REG, ///< = CS_OP_REG (Register operand).
 	MOS65XX_OP_IMM = CS_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
 	MOS65XX_OP_MEM = CS_OP_MEM, ///< = CS_OP_MEM (Memory operand).

--- a/include/capstone/riscv.h
+++ b/include/capstone/riscv.h
@@ -26,12 +26,12 @@ extern "C" {
 
 //> Operand type for instruction's operands
 typedef enum riscv_op_type {
-	RISCV_OP_INVALID = CS_OP_INVALID, // = CS_OP_INVALID (Uninitialized).
-	RISCV_OP_REG = CS_OP_REG, // = CS_OP_REG (Register operand).
-	RISCV_OP_IMM = CS_OP_IMM, // = CS_OP_IMM (Immediate operand).
-	RISCV_OP_MEM = CS_OP_MEM, // = CS_OP_MEM (Memory operand).
-	RISCV_OP_FP = CS_OP_FP, // = CS_OP_FP (FP immediate operand).
-	RISCV_OP_CSR = CS_OP_SPECIAL // =  Control and Status Register.
+	RISCV_OP_INVALID = CS_OP_INVALID, ///< = CS_OP_INVALID (Uninitialized).
+	RISCV_OP_REG = CS_OP_REG, ///< = CS_OP_REG (Register operand).
+	RISCV_OP_IMM = CS_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
+	RISCV_OP_MEM = CS_OP_MEM, ///< = CS_OP_MEM (Memory operand).
+	RISCV_OP_FP = CS_OP_FP, ///< = CS_OP_FP (FP immediate operand).
+	RISCV_OP_CSR = CS_OP_SPECIAL, ///< =  Control and Status Register.
 } riscv_op_type;
 
 // Instruction's operand referring to memory

--- a/include/capstone/sparc.h
+++ b/include/capstone/sparc.h
@@ -52,11 +52,11 @@ typedef enum sparc_cc {
 	SPARC_CC_FCC_E = 9 + SPARC_CC_FCC_BEGIN, // Equal
 	SPARC_CC_FCC_UE = 10 + SPARC_CC_FCC_BEGIN, // Unordered or Equal
 	SPARC_CC_FCC_GE = 11 + SPARC_CC_FCC_BEGIN, // Greater or Equal
-	SPARC_CC_FCC_UGE =
-		12 + SPARC_CC_FCC_BEGIN, // Unordered or Greater or Equal
+	// Unordered or Greater or Equal
+	SPARC_CC_FCC_UGE = 12 + SPARC_CC_FCC_BEGIN,
 	SPARC_CC_FCC_LE = 13 + SPARC_CC_FCC_BEGIN, // Less or Equal
-	SPARC_CC_FCC_ULE =
-		14 + SPARC_CC_FCC_BEGIN, // Unordered or Less or Equal
+	// Unordered or Less or Equal
+	SPARC_CC_FCC_ULE = 14 + SPARC_CC_FCC_BEGIN,
 	SPARC_CC_FCC_O = 15 + SPARC_CC_FCC_BEGIN, // Ordered
 
 	SPARC_CC_CPCC_BEGIN = 32, ///< Co-processor conditional branches
@@ -83,8 +83,8 @@ typedef enum sparc_cc {
 	SPARC_CC_REG_LZ = 3 + SPARC_CC_REG_BEGIN, // Less than zero
 	SPARC_CC_REG_NZ = 5 + SPARC_CC_REG_BEGIN, // Is not zero
 	SPARC_CC_REG_GZ = 6 + SPARC_CC_REG_BEGIN, // Greater than zero
-	SPARC_CC_REG_GEZ =
-		7 + SPARC_CC_REG_BEGIN, // Greater than or equal to zero
+	// Greater than or equal to zero
+	SPARC_CC_REG_GEZ = 7 + SPARC_CC_REG_BEGIN,
 
 	SPARC_CC_UNDEF = 0xffff,
 } sparc_cc;

--- a/include/capstone/tms320c64x.h
+++ b/include/capstone/tms320c64x.h
@@ -17,12 +17,12 @@ extern "C" {
 #endif
 
 typedef enum tms320c64x_op_type {
-	TMS320C64X_OP_INVALID =
-		CS_OP_INVALID, ///< = CS_OP_INVALID (Uninitialized).
+	// = CS_OP_INVALID (Uninitialized).
+	TMS320C64X_OP_INVALID = CS_OP_INVALID,
 	TMS320C64X_OP_REG = CS_OP_REG, ///< = CS_OP_REG (Register operand).
 	TMS320C64X_OP_IMM = CS_OP_IMM, ///< = CS_OP_IMM (Immediate operand).
-	TMS320C64X_OP_REGPAIR =
-		CS_OP_SPECIAL + 0, ///< Register pair for double word ops
+	// Register pair for double word ops
+	TMS320C64X_OP_REGPAIR = CS_OP_SPECIAL + 0,
 	TMS320C64X_OP_MEM = CS_OP_MEM, ///< = CS_OP_MEM (Memory operand).
 } tms320c64x_op_type;
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**
Ran the `const_generator.py` to generate python bindings.

Changed the comment placement in a few places because the generator wasn't able to parse them and it resulted in the RHS being left blank

**Test plan**
No tests added. All tests pass

**Closing issues**
none
