### PR TITLE
v5: Speedup x86 decoding with the help of LUT tables

### DIFF
--- a/arch/X86/X86ATTInstPrinter.c
+++ b/arch/X86/X86ATTInstPrinter.c
@@ -960,7 +960,7 @@ void X86_ATT_printInst(MCInst *MI, SStream *OS, void *info)
 
 		//printf(">>> opcode = %u\n", MCInst_getOpcode(MI));
 
-		reg = X86_insn_reg_att(MCInst_getOpcode(MI), &access1);
+		reg = X86_insn_reg_att_h(MI->csh, MCInst_getOpcode(MI), &access1);
 		if (reg) {
 			// shift all the ops right to leave 1st slot for this new register op
 			memmove(&(MI->flat_insn->detail->x86.operands[1]), &(MI->flat_insn->detail->x86.operands[0]),

--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -697,7 +697,7 @@ static void printInstruction(MCInst *MI, SStream *O);
 
 void X86_Intel_printInst(MCInst *MI, SStream *O, void *Info)
 {
-	x86_reg reg, reg2;
+	x86_reg reg = X86_REG_INVALID, reg2;
 	enum cs_ac_type access1, access2;
 
 	// printf("opcode = %u\n", MCInst_getOpcode(MI));
@@ -711,7 +711,6 @@ void X86_Intel_printInst(MCInst *MI, SStream *O, void *Info)
 	X86_lockrep(MI, O);
 	printInstruction(MI, O);
 
-	reg = X86_insn_reg_intel(MCInst_getOpcode(MI), &access1);
 	if (MI->csh->detail) {
 #ifndef CAPSTONE_DIET
 		uint8_t access[6] = {0};
@@ -719,6 +718,7 @@ void X86_Intel_printInst(MCInst *MI, SStream *O, void *Info)
 
 		// first op can be embedded in the asm by llvm.
 		// so we have to add the missing register as the first operand
+		reg = X86_insn_reg_intel_h(MI->csh, MCInst_getOpcode(MI), &access1);
 		if (reg) {
 			// shift all the ops right to leave 1st slot for this new register op
 			memmove(&(MI->flat_insn->detail->x86.operands[1]), &(MI->flat_insn->detail->x86.operands[0]),

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -976,18 +976,25 @@ static void arr_replace(uint16_t *arr, uint8_t max, x86_reg r1, x86_reg r2)
 }
 #endif
 
-// look for @id in @insns
-// return -1 if not found
+// O(1) lookup with per-handle table. Used by functions that have a cs_struct *.
+static inline unsigned int find_insn_h(cs_struct *h, unsigned int id)
+{
+	if (h && h->x86_insn_lut && id <= h->x86_insn_lut_max)
+		return (unsigned int)(int16_t)h->x86_insn_lut[id];
+
+	return find_insn(id);
+}
+
+// Fallback find_insn for callers without a cs_struct * (e.g., the decoder).
+// Uses binary search since no per-handle table is available.
 unsigned int find_insn(unsigned int id)
 {
-	// binary searching since the IDs are sorted in order
 	unsigned int left, right, m;
 	unsigned int max = ARR_SIZE(insns);
 
 	right = max - 1;
 
 	if (id < insns[0].id || id > insns[right].id)
-		// not found
 		return -1;
 
 	left = 0;
@@ -1004,15 +1011,13 @@ unsigned int find_insn(unsigned int id)
 			left = m + 1;
 	}
 
-	// not found
-	// printf("NOT FOUNDDDDDDDDDDDDDDD id = %u\n", id);
 	return -1;
 }
 
 // given internal insn id, return public instruction info
 void X86_get_insn_id(cs_struct *h, cs_insn *insn, unsigned int id)
 {
-	unsigned int i = find_insn(id);
+	unsigned int i = find_insn_h(h, id);
 	if (i != -1) {
 		insn->id = insns[i].mapid;
 
@@ -1215,6 +1220,19 @@ struct insn_reg2 {
 	x86_reg reg1, reg2;
 	enum cs_ac_type access1, access2;
 };
+
+static inline uint16_t pack_insn_reg(x86_reg reg, enum cs_ac_type access)
+{
+	return (uint16_t)(((unsigned int)access << 12) |
+		((unsigned int)reg & 0x0fff));
+}
+
+static inline x86_reg unpack_insn_reg(uint16_t val, enum cs_ac_type *access)
+{
+	if (access)
+		*access = (enum cs_ac_type)(val >> 12);
+	return (x86_reg)(val & 0x0fff);
+}
 
 static const struct insn_reg insn_regs_att[] = {
 	{ X86_INSB, X86_REG_DX, CS_AC_READ },
@@ -1515,31 +1533,105 @@ static int binary_search2(const struct insn_reg2 *insns, unsigned int max, unsig
 	return -1;
 }
 
+// Build per-handle O(1) lookup tables for instruction mapping.
+// Called from X86_global_init() during cs_open(). Each handle gets its own
+// copy of the lookup tables, making this thread-safe.
+void X86_build_lookup_tables(cs_struct *h)
+{
+	unsigned int i;
+	unsigned int max = ARR_SIZE(insns);
+	unsigned int id_max;
+
+	if (h->x86_insn_lut)
+		return;
+
+	id_max = insns[max - 1].id;
+	h->x86_insn_lut_max = id_max;
+
+	h->x86_insn_lut = (uint16_t *)cs_mem_malloc((id_max + 1) * sizeof(uint16_t));
+	if (!h->x86_insn_lut)
+		return;
+
+	memset(h->x86_insn_lut, 0xff, (id_max + 1) * sizeof(uint16_t));
+
+	for (i = 0; i < max; i++) {
+		h->x86_insn_lut[insns[i].id] = (uint16_t)i;
+	}
+
+	// Build insn_reg lookup table (low 16 bits = Intel, high 16 bits = ATT).
+	h->x86_insn_reg_lut = (uint32_t *)cs_mem_calloc(id_max + 1, sizeof(uint32_t));
+	if (h->x86_insn_reg_lut) {
+		for (i = 0; i < ARR_SIZE(insn_regs_intel); i++) {
+			unsigned int insn_id = insn_regs_intel[i].insn;
+			if (insn_id <= id_max)
+				h->x86_insn_reg_lut[insn_id] =
+					(h->x86_insn_reg_lut[insn_id] & 0xffff0000) |
+					pack_insn_reg(insn_regs_intel[i].reg, insn_regs_intel[i].access);
+		}
+		for (i = 0; i < ARR_SIZE(insn_regs_intel_extra); i++) {
+			unsigned int insn_id = insn_regs_intel_extra[i].insn;
+			if (insn_id && insn_id <= id_max &&
+					!(h->x86_insn_reg_lut[insn_id] & 0xffff))
+				h->x86_insn_reg_lut[insn_id] =
+					(h->x86_insn_reg_lut[insn_id] & 0xffff0000) |
+					pack_insn_reg(insn_regs_intel_extra[i].reg, insn_regs_intel_extra[i].access);
+		}
+
+		for (i = 0; i < ARR_SIZE(insn_regs_att); i++) {
+			unsigned int insn_id = insn_regs_att[i].insn;
+			if (insn_id <= id_max)
+				h->x86_insn_reg_lut[insn_id] =
+					(h->x86_insn_reg_lut[insn_id] & 0x0000ffff) |
+					((uint32_t)pack_insn_reg(insn_regs_att[i].reg, insn_regs_att[i].access) << 16);
+		}
+		for (i = 0; i < ARR_SIZE(insn_regs_att_extra); i++) {
+			unsigned int insn_id = insn_regs_att_extra[i].insn;
+			if (insn_id && insn_id <= id_max &&
+					!(h->x86_insn_reg_lut[insn_id] >> 16))
+				h->x86_insn_reg_lut[insn_id] =
+					(h->x86_insn_reg_lut[insn_id] & 0x0000ffff) |
+					((uint32_t)pack_insn_reg(insn_regs_att_extra[i].reg, insn_regs_att_extra[i].access) << 16);
+		}
+	}
+}
+
 // return register of given instruction id
 // return 0 if not found
 // this is to handle instructions embedding accumulate registers into AsmStrs[]
+// Falls back to binary search when per-handle LUT is not available.
 x86_reg X86_insn_reg_intel(unsigned int id, enum cs_ac_type *access)
 {
+	// The per-handle LUT is used via X86_insn_reg_intel_h() from the printer.
+	// This fallback uses binary search for safety.
 	int i;
 
 	i = binary_search1(insn_regs_intel, ARR_SIZE(insn_regs_intel), id);
 	if (i != -1) {
-		if (access) {
+		if (access)
 			*access = insn_regs_intel[i].access;
-		}
 		return insn_regs_intel[i].reg;
 	}
 
 	i = binary_search1(insn_regs_intel_extra, ARR_SIZE(insn_regs_intel_extra), id);
 	if (i != -1) {
-		if (access) {
+		if (access)
 			*access = insn_regs_intel_extra[i].access;
-		}
 		return insn_regs_intel_extra[i].reg;
 	}
 
-	// not found
 	return 0;
+}
+
+// Fast per-handle variant used from the printer (which has access to cs_struct via MCInst).
+x86_reg X86_insn_reg_intel_h(cs_struct *h, unsigned int id, enum cs_ac_type *access)
+{
+	if (h && h->x86_insn_reg_lut && id <= h->x86_insn_lut_max) {
+		uint16_t val = (uint16_t)(h->x86_insn_reg_lut[id] & 0xffff);
+		if (val)
+			return unpack_insn_reg(val, access);
+		return 0;
+	}
+	return X86_insn_reg_intel(id, access);
 }
 
 bool X86_insn_reg_intel2(unsigned int id, x86_reg *reg1, enum cs_ac_type *access1, x86_reg *reg2, enum cs_ac_type *access2)
@@ -1577,8 +1669,18 @@ x86_reg X86_insn_reg_att(unsigned int id, enum cs_ac_type *access)
 		return insn_regs_att_extra[i].reg;
 	}
 
-	// not found
 	return 0;
+}
+
+x86_reg X86_insn_reg_att_h(cs_struct *h, unsigned int id, enum cs_ac_type *access)
+{
+	if (h && h->x86_insn_reg_lut && id <= h->x86_insn_lut_max) {
+		uint16_t val = (uint16_t)(h->x86_insn_reg_lut[id] >> 16);
+		if (val)
+			return unpack_insn_reg(val, access);
+		return 0;
+	}
+	return X86_insn_reg_att(id, access);
 }
 
 // ATT just reuses Intel data, but with the order of registers reversed
@@ -1603,7 +1705,7 @@ bool X86_insn_reg_att2(unsigned int id, x86_reg *reg1, enum cs_ac_type *access1,
 static bool valid_repne(cs_struct *h, unsigned int opcode)
 {
 	unsigned int id;
-	unsigned int i = find_insn(opcode);
+	unsigned int i = find_insn_h(h, opcode);
 	if (i != -1) {
 		id = insns[i].mapid;
 		switch(id) {
@@ -1671,7 +1773,7 @@ static bool valid_repne(cs_struct *h, unsigned int opcode)
 static bool valid_bnd(cs_struct *h, unsigned int opcode)
 {
 	unsigned int id;
-	unsigned int i = find_insn(opcode);
+	unsigned int i = find_insn_h(h, opcode);
 	if (i != -1) {
 		id = insns[i].mapid;
 		switch(id) {
@@ -1730,7 +1832,7 @@ static bool xchg_mem(unsigned int opcode)
 static bool valid_rep(cs_struct *h, unsigned int opcode)
 {
 	unsigned int id;
-	unsigned int i = find_insn(opcode);
+	unsigned int i = find_insn_h(h, opcode);
 	if (i != -1) {
 		id = insns[i].mapid;
 		switch(id) {
@@ -1788,7 +1890,7 @@ static bool valid_rep(cs_struct *h, unsigned int opcode)
 static bool valid_ret_repz(cs_struct *h, unsigned int opcode)
 {
 	unsigned int id;
-	unsigned int i = find_insn(opcode);
+	unsigned int i = find_insn_h(h, opcode);
 
 	if (i != -1) {
 		id = insns[i].mapid;
@@ -1803,7 +1905,7 @@ static bool valid_ret_repz(cs_struct *h, unsigned int opcode)
 static bool valid_repe(cs_struct *h, unsigned int opcode)
 {
 	unsigned int id;
-	unsigned int i = find_insn(opcode);
+	unsigned int i = find_insn_h(h, opcode);
 	if (i != -1) {
 		id = insns[i].mapid;
 		switch(id) {
@@ -1842,7 +1944,7 @@ static bool valid_repe(cs_struct *h, unsigned int opcode)
 static bool valid_notrack(cs_struct *h, unsigned int opcode)
 {
 	unsigned int id;
-	unsigned int i = find_insn(opcode);
+	unsigned int i = find_insn_h(h, opcode);
 	if (i != -1) {
 		id = insns[i].mapid;
 		switch(id) {
@@ -2109,7 +2211,7 @@ static const insn_op insn_ops[] = {
 // given internal insn id, return operand access info
 const uint8_t *X86_get_op_access(cs_struct *h, unsigned int id, uint64_t *eflags)
 {
-	unsigned int i = find_insn(id);
+	unsigned int i = find_insn_h(h, id);
 	if (i != -1) {
 		*eflags = insn_ops[i].flags;
 		return insn_ops[i].access;

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -1549,8 +1549,7 @@ void X86_build_lookup_tables(cs_struct *h)
 	h->x86_insn_lut_max = id_max;
 
 	h->x86_insn_lut = (uint16_t *)cs_mem_malloc((id_max + 1) * sizeof(uint16_t));
-	if (!h->x86_insn_lut)
-		return;
+	CS_ASSERT_RET(h->x86_insn_lut);
 
 	memset(h->x86_insn_lut, 0xff, (id_max + 1) * sizeof(uint16_t));
 
@@ -1607,15 +1606,17 @@ x86_reg X86_insn_reg_intel(unsigned int id, enum cs_ac_type *access)
 
 	i = binary_search1(insn_regs_intel, ARR_SIZE(insn_regs_intel), id);
 	if (i != -1) {
-		if (access)
+		if (access) {
 			*access = insn_regs_intel[i].access;
+		}
 		return insn_regs_intel[i].reg;
 	}
 
 	i = binary_search1(insn_regs_intel_extra, ARR_SIZE(insn_regs_intel_extra), id);
 	if (i != -1) {
-		if (access)
+		if (access) {
 			*access = insn_regs_intel_extra[i].access;
+		}
 		return insn_regs_intel_extra[i].reg;
 	}
 

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -1559,38 +1559,38 @@ void X86_build_lookup_tables(cs_struct *h)
 
 	// Build insn_reg lookup table (low 16 bits = Intel, high 16 bits = ATT).
 	h->x86_insn_reg_lut = (uint32_t *)cs_mem_calloc(id_max + 1, sizeof(uint32_t));
-	if (h->x86_insn_reg_lut) {
-		for (i = 0; i < ARR_SIZE(insn_regs_intel); i++) {
-			unsigned int insn_id = insn_regs_intel[i].insn;
-			if (insn_id <= id_max)
-				h->x86_insn_reg_lut[insn_id] =
-					(h->x86_insn_reg_lut[insn_id] & 0xffff0000) |
-					pack_insn_reg(insn_regs_intel[i].reg, insn_regs_intel[i].access);
-		}
-		for (i = 0; i < ARR_SIZE(insn_regs_intel_extra); i++) {
-			unsigned int insn_id = insn_regs_intel_extra[i].insn;
-			if (insn_id && insn_id <= id_max &&
-					!(h->x86_insn_reg_lut[insn_id] & 0xffff))
-				h->x86_insn_reg_lut[insn_id] =
-					(h->x86_insn_reg_lut[insn_id] & 0xffff0000) |
-					pack_insn_reg(insn_regs_intel_extra[i].reg, insn_regs_intel_extra[i].access);
-		}
+	CS_ASSERT_RET(h->x86_insn_reg_lut);
 
-		for (i = 0; i < ARR_SIZE(insn_regs_att); i++) {
-			unsigned int insn_id = insn_regs_att[i].insn;
-			if (insn_id <= id_max)
-				h->x86_insn_reg_lut[insn_id] =
-					(h->x86_insn_reg_lut[insn_id] & 0x0000ffff) |
-					((uint32_t)pack_insn_reg(insn_regs_att[i].reg, insn_regs_att[i].access) << 16);
-		}
-		for (i = 0; i < ARR_SIZE(insn_regs_att_extra); i++) {
-			unsigned int insn_id = insn_regs_att_extra[i].insn;
-			if (insn_id && insn_id <= id_max &&
-					!(h->x86_insn_reg_lut[insn_id] >> 16))
-				h->x86_insn_reg_lut[insn_id] =
-					(h->x86_insn_reg_lut[insn_id] & 0x0000ffff) |
-					((uint32_t)pack_insn_reg(insn_regs_att_extra[i].reg, insn_regs_att_extra[i].access) << 16);
-		}
+	for (i = 0; i < ARR_SIZE(insn_regs_intel); i++) {
+		unsigned int insn_id = insn_regs_intel[i].insn;
+		if (insn_id <= id_max)
+			h->x86_insn_reg_lut[insn_id] =
+				(h->x86_insn_reg_lut[insn_id] & 0xffff0000) |
+				pack_insn_reg(insn_regs_intel[i].reg, insn_regs_intel[i].access);
+	}
+	for (i = 0; i < ARR_SIZE(insn_regs_intel_extra); i++) {
+		unsigned int insn_id = insn_regs_intel_extra[i].insn;
+		if (insn_id && insn_id <= id_max &&
+				!(h->x86_insn_reg_lut[insn_id] & 0xffff))
+			h->x86_insn_reg_lut[insn_id] =
+				(h->x86_insn_reg_lut[insn_id] & 0xffff0000) |
+				pack_insn_reg(insn_regs_intel_extra[i].reg, insn_regs_intel_extra[i].access);
+	}
+
+	for (i = 0; i < ARR_SIZE(insn_regs_att); i++) {
+		unsigned int insn_id = insn_regs_att[i].insn;
+		if (insn_id <= id_max)
+			h->x86_insn_reg_lut[insn_id] =
+				(h->x86_insn_reg_lut[insn_id] & 0x0000ffff) |
+				((uint32_t)pack_insn_reg(insn_regs_att[i].reg, insn_regs_att[i].access) << 16);
+	}
+	for (i = 0; i < ARR_SIZE(insn_regs_att_extra); i++) {
+		unsigned int insn_id = insn_regs_att_extra[i].insn;
+		if (insn_id && insn_id <= id_max &&
+				!(h->x86_insn_reg_lut[insn_id] >> 16))
+			h->x86_insn_reg_lut[insn_id] =
+				(h->x86_insn_reg_lut[insn_id] & 0x0000ffff) |
+				((uint32_t)pack_insn_reg(insn_regs_att_extra[i].reg, insn_regs_att_extra[i].access) << 16);
 	}
 }
 

--- a/arch/X86/X86Mapping.h
+++ b/arch/X86/X86Mapping.h
@@ -48,7 +48,9 @@ const char *X86_group_name(csh handle, unsigned int id);
 // return 0 if not found
 // this is to handle instructions embedding accumulate registers into AsmStrs[]
 x86_reg X86_insn_reg_intel(unsigned int id, enum cs_ac_type *access);
+x86_reg X86_insn_reg_intel_h(cs_struct *h, unsigned int id, enum cs_ac_type *access);
 x86_reg X86_insn_reg_att(unsigned int id, enum cs_ac_type *access);
+x86_reg X86_insn_reg_att_h(cs_struct *h, unsigned int id, enum cs_ac_type *access);
 bool X86_insn_reg_intel2(unsigned int id, x86_reg *reg1, enum cs_ac_type *access1, x86_reg *reg2, enum cs_ac_type *access2);
 bool X86_insn_reg_att2(unsigned int id, x86_reg *reg1, enum cs_ac_type *access1, x86_reg *reg2, enum cs_ac_type *access2);
 
@@ -90,6 +92,9 @@ uint8_t X86_immediate_size(unsigned int id, uint8_t *enc_size);
 unsigned short X86_register_map(unsigned short id);
 
 unsigned int find_insn(unsigned int id);
+
+// Build per-handle O(1) lookup tables for x86. Called from X86_global_init().
+void X86_build_lookup_tables(cs_struct *h);
 
 void X86_postprinter(csh handle, cs_insn *insn, char *mnem, MCInst *mci);
 

--- a/arch/X86/X86Module.c
+++ b/arch/X86/X86Module.c
@@ -36,6 +36,9 @@ cs_err X86_global_init(cs_struct *ud)
 	else
 		ud->regsize_map = regsize_map_32;
 
+	// Build per-handle O(1) lookup tables for instruction mapping
+	X86_build_lookup_tables(ud);
+
 	return CS_ERR_OK;
 }
 

--- a/cs.c
+++ b/cs.c
@@ -534,6 +534,8 @@ cs_err CAPSTONE_API cs_close(csh *handle)
 	}
 
 	cs_mem_free(ud->insn_cache);
+	cs_mem_free(ud->x86_insn_lut);
+	cs_mem_free(ud->x86_insn_reg_lut);
 
 	memset(ud, 0, sizeof(*ud));
 	cs_mem_free(ud);

--- a/cs_priv.h
+++ b/cs_priv.h
@@ -98,8 +98,15 @@ extern cs_vsnprintf_t cs_vsnprintf;
 // For any release build CAPSTONE_DEBUG has to be undefined.
 #ifdef CAPSTONE_DEBUG
 #define CS_ASSERT(expr) assert(expr)
+#define CS_ASSERT_RET(expr) assert(expr)
 #else
 #define CS_ASSERT(expr)
+#define CS_ASSERT_RET(expr) \
+	do { \
+		if (!(expr)) { \
+			return; \
+		} \
+	} while (0)
 #endif
 
 #endif

--- a/cs_priv.h
+++ b/cs_priv.h
@@ -71,6 +71,10 @@ struct cs_struct {
 	bool doing_SME_Index; // handling a SME instruction that has index
 	unsigned short *insn_cache;	// index caching for mapping.c
 	GetRegisterName_t get_regname;
+	// per-handle O(1) lookup tables for x86 (freed on cs_close)
+	uint16_t *x86_insn_lut;	// insn id -> index in insns[] array, 0xffff for none
+	uint32_t *x86_insn_reg_lut;	// packed Intel/ATT reg+access entries
+	unsigned int x86_insn_lut_max;	// max insn id in lookup tables
 	bool skipdata;	// set this to True if we skip data when disassembling
 	uint8_t skipdata_size;	// how many bytes to skip
 	cs_opt_skipdata skipdata_setup;	// user-defined skipdata setup


### PR DESCRIPTION
lu: Disassembled 37602620 instructions (35221820 valid, 2380800 bad), 6015.21 ms
v5: Disassembled 37602620 instructions (35221820 valid, 2380800 bad), 7291.75 ms

That's around 20% faster

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

arm64 disassembler uses lut tables to speedup decoding, x86 was the slow one here, so i just make it happen there
...

**Test plan**

```bash
$ cat /tmp/b.sh
#!/bin/sh
C=$1
[ -z "$C" ] && C=2
rm -rf build
export CFLAGS=-O3
cmake -B build
make -C build CFLAGS=-O2 -j
make -C suite/benchmark clean
make -C suite/benchmark
suite/benchmark/test_file_benchmark $C 0 5651232 /usr/bin/vim
0$
```

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
