### PR TITLE
Load libcapstone with RTLD_DEEPBIND

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -623,11 +623,13 @@ else:
 if not hasattr(sys.modules[__name__], "__file__"):
     __file__ = inspect.getfile(inspect.currentframe())
 
+do_deepbind = False
 if sys.platform == "darwin":
     _lib = "libcapstone.dylib"
 elif sys.platform in ("win32", "cygwin"):
     _lib = "capstone.dll"
 else:
+    do_deepbind = True
     _lib = "libcapstone.so"
 
 _found = False
@@ -635,14 +637,16 @@ _found = False
 
 def _load_lib(path):
     lib_file = join(path, _lib)
+    mode = os.RTLD_DEEPBIND if do_deepbind else 0
     if os.path.exists(lib_file):
-        return ctypes.cdll.LoadLibrary(lib_file)
+        return ctypes.CDLL(lib_file, mode=mode)
     else:
         # if we're on linux, try again with .so.5 extension
         if lib_file.endswith(".so"):
             if os.path.exists(lib_file + ".{}".format(CS_VERSION_MAJOR)):
-                return ctypes.cdll.LoadLibrary(
-                    lib_file + ".{}".format(CS_VERSION_MAJOR)
+                return ctypes.CDLL(
+                    lib_file + ".{}".format(CS_VERSION_MAJOR),
+                    mode=mode
                 )
     return None
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

If another libcapstone is loaded alongside the Python binding's, it might be in a higher scope (global).
Which leads the Python bindings to use the wrong library.
Loading the library with `RTLD_DEEPBIND` should prioritize the
Python loaded library before the on in global scope.

fyi @disconnect3d (because the issue mentions explicitly pwndbg)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

All green Python tests.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes https://github.com/capstone-engine/capstone/issues/2912
