### PR TITLE
Python: use setattr to rewire Cs.disasm to avoid type checking errors

### DIFF
--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -1442,7 +1442,7 @@ class Cs(object):
             from . import ccapstone
 
             # rewire disasm to use the faster version
-            self.disasm = ccapstone.Cs(self).disasm
+            setattr(self, "disasm", ccapstone.Cs(self).disasm)
         except:
             pass
 


### PR DESCRIPTION
This happens when you run `uvx ty check` on any project that calls `cs.disasm(code, address, 1)`:

```
error[invalid-argument-type]: Argument to function `Cs.disasm` is incorrect
  --> test.py:15:36
   |
15 |         insn = list(self.cs.disasm(code, address, 1))[0]
   |                                    ^^^^ Expected `Cs`, found `bytes`
   |
info: Function defined here
    --> .venv/lib/python3.14/site-packages/capstone/__init__.py:1466:9
     |
1466 |     def disasm(self, code, offset, count=0):
     |         ^^^^^^ ---- Parameter declared here
     |
info: Union variant `def disasm(self, code, offset, count=0) -> Unknown` is incompatible with this call site
info: Attempted to call union type `(bound method Cs.disasm(code, offset, count=0) -> Unknown) | (def disasm(self, code, offset, count=0) -> Unknown)`
```

Needs to be backported to v5.

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
