### PR TITLE
Backport #2886 -  cs_disasm_iter: return early on zero-size input

### DIFF
--- a/cs.c
+++ b/cs.c
@@ -1114,6 +1114,9 @@ CAPSTONE_EXPORT
 bool CAPSTONE_API cs_disasm_iter(csh ud, const uint8_t **code, size_t *size,
 		uint64_t *address, cs_insn *insn)
 {
+	if (*size == 0)
+		return false;
+
 	struct cs_struct *handle;
 	uint16_t insn_size;
 	MCInst mci;


### PR DESCRIPTION
Prevent calling backend decoder with no remaining bytes, which could lead to out-of-bounds reads.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
