### PR TITLE
AArch64: Fix truncation of literal load target address (#2878)

### DIFF
--- a/arch/AArch64/AArch64Mapping.c
+++ b/arch/AArch64/AArch64Mapping.c
@@ -2493,6 +2493,18 @@ void AArch64_set_detail_op_reg(MCInst *MI, unsigned OpNum, aarch64_reg Reg)
 	AArch64_inc_op_count(MI);
 }
 
+/// Check if the previous operand is a memory operand whose base register was
+/// just set, but which has no index and no displacement yet.
+/// This indicates the following immediate is this memory operand's
+/// displacement (e.g. the offset in `ldr x0, [x1, #8]`).
+static bool prev_is_mem_base(MCInst *MI)
+{
+	return AArch64_get_detail(MI)->op_count > 0 &&
+	       AArch64_get_detail_op(MI, -1)->type == AARCH64_OP_MEM &&
+	       AArch64_get_detail_op(MI, -1)->mem.index == AARCH64_REG_INVALID &&
+	       AArch64_get_detail_op(MI, -1)->mem.disp == 0;
+}
+
 /// Check if the previous operand is a memory operand
 /// with only the base register set AND if this base register
 /// is write-back.
@@ -2530,13 +2542,24 @@ void AArch64_set_detail_op_imm(MCInst *MI, unsigned OpNum,
 		}
 		return;
 	}
-	if (map_get_op_type(MI, OpNum) & CS_OP_MEM || prev_is_membase_wb(MI)) {
+	// An operand can be flagged as both immediate and memory
+	// (CS_OP_IMM | CS_OP_MEM). It is only stored as a memory displacement if
+	// a memory operand is actually being assembled, i.e. its base register
+	// was set right before this operand or the previous operand is a
+	// write-back base for a post-indexed offset. Otherwise the value is a
+	// standalone immediate (e.g. the PC-relative target of a literal load
+	// like `ldr x0, <label>`), which must not be truncated into the 32 bit
+	// memory displacement field.
+	if ((map_get_op_type(MI, OpNum) & CS_OP_MEM && prev_is_mem_base(MI)) ||
+	    prev_is_membase_wb(MI)) {
 		AArch64_set_detail_op_mem(MI, OpNum, Imm);
 		return;
 	}
 
-	CS_ASSERT_RET(!(map_get_op_type(MI, OpNum) & CS_OP_MEM));
-	CS_ASSERT_RET((map_get_op_type(MI, OpNum) & ~CS_OP_BOUND) == CS_OP_IMM);
+	// Operands flagged as memory only reach this point when they are not
+	// part of a memory operand currently being assembled (see above), so
+	// they are emitted as a plain immediate.
+	CS_ASSERT_RET(map_get_op_type(MI, OpNum) & CS_OP_IMM);
 	CS_ASSERT_RET(ImmType == AARCH64_OP_IMM || ImmType == AARCH64_OP_CIMM);
 
 	AArch64_get_detail_op(MI, 0)->type = ImmType;

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6646,3 +6646,22 @@ test_cases:
           regs_read: [ rax ]
           regs_write: [ sp ]
           groups: [ mode64 ]
+  -
+    input:
+      name: "AArch64 - #2878 - literal load target must not be truncated to 32 bits"
+      bytes: [ 0xa8, 0x79, 0x29, 0x58 ]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_MODE_ARM, CS_OPT_DETAIL ]
+      address: 0x100c894d4
+    expected:
+      insns:
+      -
+        asm_text: "ldr x8, 0x100cdc408"
+        details:
+          aarch64:
+            operands:
+              -
+                type: AARCH64_OP_REG
+              -
+                type: AARCH64_OP_IMM
+                imm: 0x100cdc408


### PR DESCRIPTION
## Fixes #2878

### Problem

The target address of AArch64 literal load instructions (e.g. `ldr x8, <label>`) was truncated to 32 bits:

```
> cstool -d aarch64 a8792958 0x100c894d4
100c894d4  a8 79 29 58  ldr	x8, 0x100cdc408
	...
		operands[1].type: MEM
			operands[1].mem.disp: 0xcdc408    <-- truncated from 0x100cdc408
```

### Cause

Literal load instructions map their `$label` operand as `CS_OP_IMM | CS_OP_MEM`. The `AlignedLabel` operand group computes the absolute PC-relative target address (`MI->address + offset`) and passes it to `AArch64_set_detail_op_imm()`. Because the `MEM` bit is set, that helper stored the value into the memory displacement field `mem.disp`, which is an `int32_t`. Target addresses above 32 bits were therefore silently truncated (`0x100cdc408` → `0xcdc408`).

### Fix

Emit the literal load target as a 64-bit immediate, like `adr`/`adrp` do and as Capstone did prior to 6.x. This restores the correct operand type (`IMM`) and avoids the truncation:

```
100c894d4  a8 79 29 58  ldr	x8, 0x100cdc408
	...
		operands[1].type: IMM = 0x100cdc408
```

Regular base+offset loads (`ldr x0, [x1, #0x18]`) and branch targets are unaffected.

### Tests

- Added a regression test in `tests/issues/issues.yaml`.
- All existing AArch64 detail and MC tests pass (8689 cases, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)