### PR TITLE
Fixed CONTRIBUTING.md not listing all Architectures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,12 @@ Capstone source is organized as followings.
 ├── arch            <- code handling disasm engine for each arch
 │   ├── AArch64     <- AArch64 engine
 │   ├── Alpha       <- Alpha engine
+│   ├── ARC         <- ARC engine
 │   ├── ARM         <- ARM engine
 │   ├── BPF         <- Berkeley Packet Filter engine
 │   ├── EVM         <- Ethereum engine
 │   ├── HPPA        <- HPPA engine
+│   ├── LoongArch   <- LoongArch engine
 │   ├── M680X       <- M680X engine
 │   ├── M68K        <- M68K engine
 │   ├── Mips        <- Mips engine
@@ -23,7 +25,10 @@ Capstone source is organized as followings.
 │   ├── SystemZ     <- SystemZ engine
 │   ├── TMS320C64x  <- TMS320C64x engine
 │   ├── TriCore     <- TriCore engine
-│   └── WASM        <- WASM engine
+│   ├── WASM        <- WASM engine
+│   ├── X86         <- x86 engine
+│   ├── XCore       <- XCore engine
+│   └── Xtensa      <- Xtensa engine
 ├── bindings        <- all bindings are under this dir
 │   ├── java        <- Java bindings
 │   ├── ocaml       <- Ocaml bindings


### PR DESCRIPTION
In the source guide in CONTRIBUTING.md some architectures where skipped. I added them

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes. _Doesn't Apply_
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible) _Doesn't Apply_

**Detailed description**

So, I noticed that about 5 architectures in the /arch directory where not mentioned in CONTRIBUTING.md's "Code Structure" section. So I added them. That's it.

...

**Test plan**

To test my modifications, you can try opening CONTRIBUTING.md and check if the markup isn't broken.

...

**Closing issues**

No issues closed

...
