### PR TITLE
m68k: fix off-by-one bounds check in M68K_insn_name

### DIFF
--- a/arch/M68K/M68KInstPrinter.c
+++ b/arch/M68K/M68KInstPrinter.c
@@ -582,7 +582,7 @@ const char *M68K_insn_name(csh handle, unsigned int id)
 #ifdef CAPSTONE_DIET
 	return NULL;
 #else
-	if (id > ARR_SIZE(s_instruction_names)) {
+	if (id >= ARR_SIZE(s_instruction_names)) {
 		return NULL;
 	}
 	return s_instruction_names[id];

--- a/tests/unit/m68k_insn_name_segv.c
+++ b/tests/unit/m68k_insn_name_segv.c
@@ -13,6 +13,15 @@ int main(int argc, char **argv)
 	fflush(stdout);
 	name = cs_insn_name(h, 0xdeadbeefu);
 	printf("name=%p %s\n", (void *)name, name ? name : "null");
+
+	// M68K_INS_ENDING is one past the last valid id and must not be read.
+	name = cs_insn_name(h, M68K_INS_ENDING);
+	printf("ending name=%p %s\n", (void *)name, name ? name : "null");
+	if (name != NULL) {
+		cs_close(&h);
+		return 1;
+	}
+
 	cs_close(&h);
 	return 0;
 }


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

`M68K_insn_name()` looks up `s_instruction_names[id]` after the guard `id > ARR_SIZE(s_instruction_names)`. Valid indices are `0 .. ARR_SIZE-1`, so the equal case (`id == ARR_SIZE`, which is `M68K_INS_ENDING == 403`) passes the guard and reads one pointer past the end of the global array, handing the caller a wild pointer to dereference. Every other arch name lookup uses `>=`; this brings M68K in line.

Reachable from the public API via `cs_insn_name(handle, M68K_INS_ENDING)`.

**Test plan**

`tests/unit/m68k_insn_name_segv.c` only probed a far-out id (`0xdeadbeef`) that the `>` guard already rejects, so it never reached the boundary. Extended it to call `cs_insn_name(h, M68K_INS_ENDING)` and assert NULL. Built with `-fsanitize=address`, the test aborts with a global-buffer-overflow at `M68KInstPrinter.c:588` before this patch and exits clean after.

**Closing issues**

(none)