### PR TITLE
Fix crash due to invalid register

### DIFF
--- a/arch/RISCV/RISCVMapping.c
+++ b/arch/RISCV/RISCVMapping.c
@@ -58,6 +58,13 @@ void RISCV_add_cs_detail_0(MCInst *MI, riscv_op_group opgroup, unsigned OpNum)
 	    opgroup == RISCV_OP_GROUP_FRMArgLegacy)
 		return;
 
+	if (opgroup == RISCV_OP_GROUP_VMaskReg) {
+		MCOperand *mask = MCInst_getOperand(MI, OpNum);
+		if (MCOperand_isReg(mask) &&
+		    MCOperand_getReg(mask) == RISCV_NoRegister)
+			return;
+	}
+
 	if (opgroup == RISCV_OP_GROUP_FPImmOperand) {
 		unsigned Imm = (unsigned)MCInst_getOperand(MI, OpNum)->ImmVal;
 		cs_riscv_op *op = RISCV_get_detail_op_at(MI, OpNum);

--- a/arch/RISCV/RISCVMapping.c
+++ b/arch/RISCV/RISCVMapping.c
@@ -57,7 +57,8 @@ void RISCV_add_cs_detail_0(MCInst *MI, riscv_op_group opgroup, unsigned OpNum)
 	if (opgroup == RISCV_OP_GROUP_FRMArg ||
 	    opgroup == RISCV_OP_GROUP_FRMArgLegacy)
 		return;
-
+	
+	// unmasked instructions, the mask register is not real
 	if (opgroup == RISCV_OP_GROUP_VMaskReg) {
 		MCOperand *mask = MCInst_getOperand(MI, OpNum);
 		if (MCOperand_isReg(mask) &&

--- a/tests/MC/RISCV/macc_riscv64_riscv_v.txt.yaml
+++ b/tests/MC/RISCV/macc_riscv64_riscv_v.txt.yaml
@@ -3,21 +3,48 @@ test_cases:
     input:
       bytes: [ 0x57, 0x24, 0x4a, 0xb4 ]
       arch: "CS_ARCH_RISCV"
-      options: [ "CS_MODE_RISCV64", "CS_MODE_RISCV_V" ]
+      options: [ "CS_MODE_RISCV64", "CS_MODE_RISCV_V", "CS_OPT_DETAIL" ]
     expected:
       insns:
         -
           asm_text: "vmacc.vv v8, v20, v4, v0.t"
+          details:
+            riscv:
+              operands:
+                - type: RISCV_OP_REG
+                  reg: v8
+                  access: CS_AC_READ_WRITE
+                - type: RISCV_OP_REG
+                  reg: v20
+                  access: CS_AC_READ
+                - type: RISCV_OP_REG
+                  reg: v4
+                  access: CS_AC_READ
+                - type: RISCV_OP_REG
+                  reg: v0
+                  access: CS_AC_READ
 
   -
     input:
       bytes: [ 0x57, 0x24, 0x4a, 0xb6 ]
       arch: "CS_ARCH_RISCV"
-      options: [ "CS_MODE_RISCV64", "CS_MODE_RISCV_V" ]
+      options: [ "CS_MODE_RISCV64", "CS_MODE_RISCV_V", "CS_OPT_DETAIL" ]
     expected:
       insns:
         -
           asm_text: "vmacc.vv v8, v20, v4"
+          details:
+            riscv:
+              operands:
+                - type: RISCV_OP_REG
+                  reg: v8
+                  access: CS_AC_READ_WRITE
+                - type: RISCV_OP_REG
+                  reg: v20
+                  access: CS_AC_READ
+                - type: RISCV_OP_REG
+                  reg: v4
+                  access: CS_AC_READ
 
   -
     input:

--- a/tests/MC/RISCV/macc_riscv64_riscv_v.txt.yaml
+++ b/tests/MC/RISCV/macc_riscv64_riscv_v.txt.yaml
@@ -3,48 +3,21 @@ test_cases:
     input:
       bytes: [ 0x57, 0x24, 0x4a, 0xb4 ]
       arch: "CS_ARCH_RISCV"
-      options: [ "CS_MODE_RISCV64", "CS_MODE_RISCV_V", "CS_OPT_DETAIL" ]
+      options: [ "CS_MODE_RISCV64", "CS_MODE_RISCV_V" ]
     expected:
       insns:
         -
           asm_text: "vmacc.vv v8, v20, v4, v0.t"
-          details:
-            riscv:
-              operands:
-                - type: RISCV_OP_REG
-                  reg: v8
-                  access: CS_AC_READ_WRITE
-                - type: RISCV_OP_REG
-                  reg: v20
-                  access: CS_AC_READ
-                - type: RISCV_OP_REG
-                  reg: v4
-                  access: CS_AC_READ
-                - type: RISCV_OP_REG
-                  reg: v0
-                  access: CS_AC_READ
 
   -
     input:
       bytes: [ 0x57, 0x24, 0x4a, 0xb6 ]
       arch: "CS_ARCH_RISCV"
-      options: [ "CS_MODE_RISCV64", "CS_MODE_RISCV_V", "CS_OPT_DETAIL" ]
+      options: [ "CS_MODE_RISCV64", "CS_MODE_RISCV_V" ]
     expected:
       insns:
         -
           asm_text: "vmacc.vv v8, v20, v4"
-          details:
-            riscv:
-              operands:
-                - type: RISCV_OP_REG
-                  reg: v8
-                  access: CS_AC_READ_WRITE
-                - type: RISCV_OP_REG
-                  reg: v20
-                  access: CS_AC_READ
-                - type: RISCV_OP_REG
-                  reg: v4
-                  access: CS_AC_READ
 
   -
     input:

--- a/tests/details/riscv.yaml
+++ b/tests/details/riscv.yaml
@@ -6225,3 +6225,47 @@ test_cases:
       insns:
         - asm_text: "addi a0, a1, 0"
         - asm_text: "c.li a0, 0x15"
+
+  - input:
+      bytes: [0x57, 0x24, 0x4a, 0xb4]
+      arch: "CS_ARCH_RISCV"
+      options: [CS_MODE_RISCV64, CS_MODE_RISCV_V, CS_OPT_DETAIL]
+    expected:
+      insns:
+        - asm_text: "vmacc.vv v8, v20, v4, v0.t"
+          details:
+            riscv:
+              operands:
+                - type: RISCV_OP_REG
+                  reg: v8
+                  access: CS_AC_READ_WRITE
+                - type: RISCV_OP_REG
+                  reg: v20
+                  access: CS_AC_READ
+                - type: RISCV_OP_REG
+                  reg: v4
+                  access: CS_AC_READ
+                - type: RISCV_OP_REG
+                  reg: v0
+                  access: CS_AC_READ
+
+  - input:
+      bytes: [0x57, 0x24, 0x4a, 0xb6]
+      arch: "CS_ARCH_RISCV"
+      options: [CS_MODE_RISCV64, CS_MODE_RISCV_V, CS_OPT_DETAIL]
+    expected:
+      insns:
+        - asm_text: "vmacc.vv v8, v20, v4"
+          details:
+            riscv:
+              operands:
+                - type: RISCV_OP_REG
+                  reg: v8
+                  access: CS_AC_READ_WRITE
+                - type: RISCV_OP_REG
+                  reg: v20
+                  access: CS_AC_READ
+                - type: RISCV_OP_REG
+                  reg: v4
+                  access: CS_AC_READ
+


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

There is a type of operands in RISC-V vector instructions that is internally represented as an invalid register (as a marker), this invalid register value used to escape to Capstone's public API, now it no longer escapes.

One of the problems of the leak was a crash in `cstool`, but this was just a symptom to the real problem.  

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
