### PR TITLE
Alpha: fix decoder bugs and add test coverage

### DIFF
--- a/arch/Alpha/AlphaDisassembler.c
+++ b/arch/Alpha/AlphaDisassembler.c
@@ -41,7 +41,7 @@ static DecodeStatus DecodeGPRCRegisterClass(MCInst *Inst, unsigned RegNo,
 	if (RegNo > 31)
 		return MCDisassembler_Fail;
 
-	unsigned Register = GPRC[RegNo];
+	unsigned Register = Alpha_R0 + RegNo;
 	MCOperand_CreateReg0(Inst, (Register));
 	return MCDisassembler_Success;
 }

--- a/arch/Alpha/AlphaGenCSMappingInsn.inc
+++ b/arch/Alpha/AlphaGenCSMappingInsn.inc
@@ -2296,7 +2296,7 @@
 },
 {
   /* COND_BRANCH imm:$opc, GPRC:$R, bb:$dst */
-  Alpha_COND_BRANCH_I /* 318 */, Alpha_INS_COND_BRANCH,
+  Alpha_COND_BRANCH_I /* 318 */, Alpha_INS_CALL_PAL,
   #ifndef CAPSTONE_DIET
     { 0 }, { 0 }, { Alpha_GRP_JUMP, Alpha_GRP_BRANCH_RELATIVE, 0 }, 1, 0, {{ 0 }},
 

--- a/arch/Alpha/AlphaGenCSMappingInsnName.inc
+++ b/arch/Alpha/AlphaGenCSMappingInsnName.inc
@@ -47,6 +47,7 @@
   "cmptun/su", // Alpha_INS_CMPTUNsSU
   "cmpule", // Alpha_INS_CMPULE
   "cmpult", // Alpha_INS_CMPULT
+  "call_pal", // Alpha_INS_CALL_PAL
   "COND_BRANCH", // Alpha_INS_COND_BRANCH
   "cpyse", // Alpha_INS_CPYSE
   "cpysn", // Alpha_INS_CPYSN

--- a/arch/Alpha/AlphaGenCSMappingInsnOp.inc
+++ b/arch/Alpha/AlphaGenCSMappingInsnOp.inc
@@ -2067,8 +2067,11 @@
   { CS_OP_REG, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* RA */
   { 0 }
 }},
-{ /* Alpha_RETDAG (446) - Alpha_INS_RET - ret $$31,($$26),1 */
+{ /* Alpha_RETDAG (446) - Alpha_INS_RET - ret $RD,($RS),$DISP */
 {
+  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* RD */
+  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* RS */
+  { CS_OP_IMM, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* DISP */
   { 0 }
 }},
 { /* Alpha_RETDAGp (447) - Alpha_INS_RET - ret $$31,($$26),1 */

--- a/arch/Alpha/AlphaGenCSMappingInsnOp.inc
+++ b/arch/Alpha/AlphaGenCSMappingInsnOp.inc
@@ -1191,11 +1191,9 @@
   { CS_OP_IMM, CS_AC_READ, { CS_DATA_TYPE_Other, CS_DATA_TYPE_LAST },  }, /* dst */
   { 0 }
 }},
-{ /* Alpha_COND_BRANCH_I (318) - Alpha_INS_COND_BRANCH - COND_BRANCH imm:$opc, GPRC:$R, bb:$dst */
+{ /* Alpha_COND_BRANCH_I (318) - Alpha_INS_CALL_PAL - call_pal imm:$func */
 {
-  { CS_OP_IMM, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* opc */
-  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* R */
-  { CS_OP_IMM, CS_AC_READ, { CS_DATA_TYPE_Other, CS_DATA_TYPE_LAST },  }, /* dst */
+  { CS_OP_IMM, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* func */
   { 0 }
 }},
 { /* Alpha_CPYSES (319) - Alpha_INS_CPYSE - cpyse $RA,$RB,$RC */

--- a/arch/Alpha/AlphaGenCSMappingInsnOp.inc
+++ b/arch/Alpha/AlphaGenCSMappingInsnOp.inc
@@ -1723,13 +1723,18 @@
   { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* RA */
   { 0 }
 }},
-{ /* Alpha_JMP (396) - Alpha_INS_JMP - jmp $$31,{$RS},0 */
+{ /* Alpha_JMP (396) - Alpha_INS_JMP - jmp $RD,($RS),$DISP */
 {
+  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* RD */
   { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* RS */
+  { CS_OP_IMM, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* DISP */
   { 0 }
 }},
-{ /* Alpha_JSR (397) - Alpha_INS_JSR - jsr $$26,($$27),0 */
+{ /* Alpha_JSR (397) - Alpha_INS_JSR - jsr $RD,($RS),$DISP */
 {
+  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* RD */
+  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* RS */
+  { CS_OP_IMM, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST },  }, /* DISP */
   { 0 }
 }},
 { /* Alpha_JSR_COROUTINE (398) - Alpha_INS_JSR_COROUTINE - jsr_coroutine $RD,($RS),$DISP */

--- a/arch/Alpha/AlphaGenDisassemblerTables.inc
+++ b/arch/Alpha/AlphaGenDisassemblerTables.inc
@@ -430,16 +430,16 @@ static const uint8_t DecoderTable32[] = {
 /* 2036 */    MCD_OPC_FilterValue, 24, 174, 0, 0, // Skip to: 2215
 /* 2041 */    MCD_OPC_ExtractField, 0, 16,  // Inst{15-0} ...
 /* 2044 */    MCD_OPC_FilterValue, 0, 11, 0, 0, // Skip to: 2060
-/* 2049 */    MCD_OPC_CheckField, 16, 10, 0, 139, 2, 0, // Skip to: 2707
+/* 2049 */    MCD_OPC_CheckField, 16, 10, 0, 0, 0, 0, // (no-op: accept any Ra/Rb)
 /* 2056 */    MCD_OPC_Decode, 241, 3, 14, // Opcode: TRAPB
 /* 2060 */    MCD_OPC_FilterValue, 128, 8, 11, 0, 0, // Skip to: 2077
-/* 2066 */    MCD_OPC_CheckField, 16, 10, 0, 122, 2, 0, // Skip to: 2707
+/* 2066 */    MCD_OPC_CheckField, 16, 10, 0, 0, 0, 0, // (no-op: accept any Ra/Rb)
 /* 2073 */    MCD_OPC_Decode, 215, 2, 14, // Opcode: EXCB
 /* 2077 */    MCD_OPC_FilterValue, 128, 128, 1, 11, 0, 0, // Skip to: 2095
-/* 2084 */    MCD_OPC_CheckField, 16, 10, 0, 104, 2, 0, // Skip to: 2707
+/* 2084 */    MCD_OPC_CheckField, 16, 10, 0, 0, 0, 0, // (no-op: accept any Ra/Rb)
 /* 2091 */    MCD_OPC_Decode, 166, 3, 14, // Opcode: MB
 /* 2095 */    MCD_OPC_FilterValue, 128, 136, 1, 11, 0, 0, // Skip to: 2113
-/* 2102 */    MCD_OPC_CheckField, 16, 10, 0, 86, 2, 0, // Skip to: 2707
+/* 2102 */    MCD_OPC_CheckField, 16, 10, 0, 0, 0, 0, // (no-op: accept any Ra/Rb)
 /* 2109 */    MCD_OPC_Decode, 246, 3, 14, // Opcode: WMB
 /* 2113 */    MCD_OPC_FilterValue, 128, 128, 2, 4, 0, 0, // Skip to: 2124
 /* 2120 */    MCD_OPC_Decode, 248, 2, 15, // Opcode: FETCH

--- a/arch/Alpha/AlphaGenDisassemblerTables.inc
+++ b/arch/Alpha/AlphaGenDisassemblerTables.inc
@@ -30,7 +30,7 @@ static InsnType fname(InsnType insn, unsigned startBit, unsigned numBits) \
 static const uint8_t DecoderTable32[] = {
 /* 0 */       MCD_OPC_ExtractField, 26, 6,  // Inst{31-26} ...
 /* 3 */       MCD_OPC_FilterValue, 0, 4, 0, 0, // Skip to: 12
-/* 8 */       MCD_OPC_Decode, 190, 2, 0, // Opcode: COND_BRANCH_I
+/* 8 */       MCD_OPC_Decode, 190, 2, 31, // Opcode: COND_BRANCH_I (CALL_PAL: 26-bit imm)
 /* 12 */      MCD_OPC_FilterValue, 8, 4, 0, 0, // Skip to: 21
 /* 17 */      MCD_OPC_Decode, 144, 3, 1, // Opcode: LDA
 /* 21 */      MCD_OPC_FilterValue, 9, 4, 0, 0, // Skip to: 30
@@ -930,6 +930,10 @@ static DecodeStatus fname(DecodeStatus S, unsigned Idx, InsnType insn, MCInst *M
     if (DecodeF4RCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
     tmp = fieldname(insn, 16, 5); \
     if (DecodeF8RCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
+    return S; \
+  case 31: \
+    tmp = fieldname(insn, 0, 26); \
+    MCOperand_CreateImm0(MI, tmp); \
     return S; \
   } \
 }

--- a/arch/Alpha/AlphaGenDisassemblerTables.inc
+++ b/arch/Alpha/AlphaGenDisassemblerTables.inc
@@ -462,17 +462,17 @@ static const uint8_t DecoderTable32[] = {
 /* 2215 */    MCD_OPC_FilterValue, 26, 101, 0, 0, // Skip to: 2321
 /* 2220 */    MCD_OPC_ExtractField, 14, 2,  // Inst{15-14} ...
 /* 2223 */    MCD_OPC_FilterValue, 0, 18, 0, 0, // Skip to: 2246
-/* 2228 */    MCD_OPC_CheckField, 21, 5, 31, 216, 1, 0, // Skip to: 2707
-/* 2235 */    MCD_OPC_CheckField, 0, 14, 0, 209, 1, 0, // Skip to: 2707
-/* 2242 */    MCD_OPC_Decode, 140, 3, 17, // Opcode: JMP
+/* 2228 */    MCD_OPC_CheckField, 21, 5, 31, 0, 0, 0, // (no-op: accept any Ra)
+/* 2235 */    MCD_OPC_CheckField, 0, 14, 0, 0, 0, 0, // (no-op: accept any hint)
+/* 2242 */    MCD_OPC_Decode, 140, 3, 18, // Opcode: JMP (Ra + Rb + hint14)
 /* 2246 */    MCD_OPC_FilterValue, 1, 37, 0, 0, // Skip to: 2288
 /* 2251 */    MCD_OPC_ExtractField, 16, 10,  // Inst{25-16} ...
 /* 2254 */    MCD_OPC_FilterValue, 251, 5, 11, 0, 0, // Skip to: 2271
-/* 2260 */    MCD_OPC_CheckField, 0, 14, 0, 184, 1, 0, // Skip to: 2707
-/* 2267 */    MCD_OPC_Decode, 143, 3, 14, // Opcode: JSRs
-/* 2271 */    MCD_OPC_FilterValue, 219, 6, 174, 1, 0, // Skip to: 2707
-/* 2277 */    MCD_OPC_CheckField, 0, 14, 0, 167, 1, 0, // Skip to: 2707
-/* 2284 */    MCD_OPC_Decode, 141, 3, 14, // Opcode: JSR
+/* 2260 */    MCD_OPC_CheckField, 0, 14, 0, 0, 0, 0, // (no-op: accept any hint)
+/* 2267 */    MCD_OPC_Decode, 141, 3, 18, // Opcode: JSR (Ra + Rb + hint14)
+/* 2271 */    MCD_OPC_FilterValue, 219, 6, 7, 0, 0, // Skip to: 2284 (not to 2707)
+/* 2277 */    MCD_OPC_CheckField, 0, 14, 0, 0, 0, 0, // (no-op: accept any hint)
+/* 2284 */    MCD_OPC_Decode, 141, 3, 18, // Opcode: JSR (Ra + Rb + hint14)
 /* 2288 */    MCD_OPC_FilterValue, 2, 19, 0, 0, // Skip to: 2312
 /* 2293 */    MCD_OPC_CheckField, 16, 10, 250, 7, 150, 1, 0, // Skip to: 2707
 /* 2301 */    MCD_OPC_CheckField, 0, 14, 1, 143, 1, 0, // Skip to: 2707

--- a/arch/Alpha/AlphaGenDisassemblerTables.inc
+++ b/arch/Alpha/AlphaGenDisassemblerTables.inc
@@ -527,8 +527,8 @@ static const uint8_t DecoderTable32[] = {
 /* 2540 */    MCD_OPC_FilterValue, 47, 4, 0, 0, // Skip to: 2549
 /* 2545 */    MCD_OPC_Decode, 226, 3, 24, // Opcode: STQ_C
 /* 2549 */    MCD_OPC_FilterValue, 48, 11, 0, 0, // Skip to: 2565
-/* 2554 */    MCD_OPC_CheckField, 21, 5, 31, 146, 0, 0, // Skip to: 2707
-/* 2561 */    MCD_OPC_Decode, 155, 2, 25, // Opcode: BR
+/* 2554 */    MCD_OPC_CheckField, 21, 5, 31, 0, 0, 0, // Skip to: 2561 (no-op: accept any Ra)
+/* 2561 */    MCD_OPC_Decode, 155, 2, 27, // Opcode: BR (decode Ra + disp21)
 /* 2565 */    MCD_OPC_FilterValue, 49, 4, 0, 0, // Skip to: 2574
 /* 2570 */    MCD_OPC_Decode, 230, 2, 26, // Opcode: FBEQ
 /* 2574 */    MCD_OPC_FilterValue, 50, 4, 0, 0, // Skip to: 2583
@@ -536,8 +536,8 @@ static const uint8_t DecoderTable32[] = {
 /* 2583 */    MCD_OPC_FilterValue, 51, 4, 0, 0, // Skip to: 2592
 /* 2588 */    MCD_OPC_Decode, 233, 2, 26, // Opcode: FBLE
 /* 2592 */    MCD_OPC_FilterValue, 52, 11, 0, 0, // Skip to: 2608
-/* 2597 */    MCD_OPC_CheckField, 21, 5, 26, 103, 0, 0, // Skip to: 2707
-/* 2604 */    MCD_OPC_Decode, 156, 2, 25, // Opcode: BSR
+/* 2597 */    MCD_OPC_CheckField, 21, 5, 26, 0, 0, 0, // Skip to: 2604 (no-op: accept any Ra)
+/* 2604 */    MCD_OPC_Decode, 156, 2, 27, // Opcode: BSR (decode Ra + disp21)
 /* 2608 */    MCD_OPC_FilterValue, 53, 4, 0, 0, // Skip to: 2617
 /* 2613 */    MCD_OPC_Decode, 235, 2, 26, // Opcode: FBNE
 /* 2617 */    MCD_OPC_FilterValue, 54, 4, 0, 0, // Skip to: 2626

--- a/arch/Alpha/AlphaGenDisassemblerTables.inc
+++ b/arch/Alpha/AlphaGenDisassemblerTables.inc
@@ -448,12 +448,12 @@ static const uint8_t DecoderTable32[] = {
 /* 2135 */    MCD_OPC_FilterValue, 128, 128, 3, 4, 0, 0, // Skip to: 2146
 /* 2142 */    MCD_OPC_Decode, 192, 3, 15, // Opcode: RPCC
 /* 2146 */    MCD_OPC_FilterValue, 128, 192, 3, 11, 0, 0, // Skip to: 2164
-/* 2153 */    MCD_OPC_CheckField, 16, 5, 0, 35, 2, 0, // Skip to: 2707
+/* 2153 */    MCD_OPC_CheckField, 16, 5, 0, 0, 0, 0, // (no-op: accept any Rb)
 /* 2160 */    MCD_OPC_Decode, 189, 3, 16, // Opcode: RC
 /* 2164 */    MCD_OPC_FilterValue, 128, 208, 3, 4, 0, 0, // Skip to: 2175
 /* 2171 */    MCD_OPC_Decode, 212, 2, 15, // Opcode: ECB
 /* 2175 */    MCD_OPC_FilterValue, 128, 224, 3, 11, 0, 0, // Skip to: 2193
-/* 2182 */    MCD_OPC_CheckField, 16, 5, 0, 6, 2, 0, // Skip to: 2707
+/* 2182 */    MCD_OPC_CheckField, 16, 5, 0, 0, 0, 0, // (no-op: accept any Rb)
 /* 2189 */    MCD_OPC_Decode, 193, 3, 16, // Opcode: RS
 /* 2193 */    MCD_OPC_FilterValue, 128, 240, 3, 4, 0, 0, // Skip to: 2204
 /* 2200 */    MCD_OPC_Decode, 244, 3, 15, // Opcode: WH64
@@ -474,9 +474,9 @@ static const uint8_t DecoderTable32[] = {
 /* 2277 */    MCD_OPC_CheckField, 0, 14, 0, 0, 0, 0, // (no-op: accept any hint)
 /* 2284 */    MCD_OPC_Decode, 141, 3, 18, // Opcode: JSR (Ra + Rb + hint14)
 /* 2288 */    MCD_OPC_FilterValue, 2, 19, 0, 0, // Skip to: 2312
-/* 2293 */    MCD_OPC_CheckField, 16, 10, 250, 7, 150, 1, 0, // Skip to: 2707
-/* 2301 */    MCD_OPC_CheckField, 0, 14, 1, 143, 1, 0, // Skip to: 2707
-/* 2308 */    MCD_OPC_Decode, 190, 3, 14, // Opcode: RETDAG
+/* 2293 */    MCD_OPC_CheckField, 16, 10, 250, 7, 0, 0, 0, // (no-op: accept any Ra/Rb)
+/* 2301 */    MCD_OPC_CheckField, 0, 14, 1, 0, 0, 0, // (no-op: accept any hint)
+/* 2308 */    MCD_OPC_Decode, 190, 3, 18, // Opcode: RETDAG (Ra + Rb + hint14)
 /* 2312 */    MCD_OPC_FilterValue, 3, 134, 1, 0, // Skip to: 2707
 /* 2317 */    MCD_OPC_Decode, 142, 3, 18, // Opcode: JSR_COROUTINE
 /* 2321 */    MCD_OPC_FilterValue, 28, 115, 0, 0, // Skip to: 2441

--- a/arch/Alpha/AlphaInstPrinter.c
+++ b/arch/Alpha/AlphaInstPrinter.c
@@ -85,6 +85,19 @@ const char *Alpha_LLVM_getRegisterName(csh handle, unsigned int id)
 
 void Alpha_LLVM_printInstruction(MCInst *MI, SStream *O, void *Info)
 {
+	unsigned Opcode = MCInst_getOpcode(MI);
+	/*
+	 * The generated AsmWriter hardcodes "$31" for BR and restricts BSR to
+	 * Ra=26. Format 27 now decodes Ra as operand[0] and disp21 as
+	 * operand[1], so we must print them explicitly here.
+	 */
+	if (Opcode == Alpha_BR || Opcode == Alpha_BSR) {
+		SStream_concat0(O, Opcode == Alpha_BR ? "br " : "bsr ");
+		printOperand(MI, 0, O);
+		SStream_concat1(O, ',');
+		printOperandAddr(MI, MI->address, 1, O);
+		return;
+	}
 	printAliasInstr(MI, MI->address, O);
 	printInstruction(MI, MI->address, O);
 }

--- a/arch/Alpha/AlphaInstPrinter.c
+++ b/arch/Alpha/AlphaInstPrinter.c
@@ -91,6 +91,11 @@ void Alpha_LLVM_printInstruction(MCInst *MI, SStream *O, void *Info)
 	 * Ra=26. Format 27 now decodes Ra as operand[0] and disp21 as
 	 * operand[1], so we must print them explicitly here.
 	 */
+	if (Opcode == Alpha_COND_BRANCH_I) {
+		SStream_concat0(O, "call_pal ");
+		printOperand(MI, 0, O);
+		return;
+	}
 	if (Opcode == Alpha_BR || Opcode == Alpha_BSR) {
 		SStream_concat0(O, Opcode == Alpha_BR ? "br " : "bsr ");
 		printOperand(MI, 0, O);

--- a/arch/Alpha/AlphaInstPrinter.c
+++ b/arch/Alpha/AlphaInstPrinter.c
@@ -101,8 +101,11 @@ void Alpha_LLVM_printInstruction(MCInst *MI, SStream *O, void *Info)
 	 * The generated AsmWriter hardcodes operands for specific canonical
 	 * forms, so print all three operands explicitly here.
 	 */
-	if (Opcode == Alpha_JMP || Opcode == Alpha_JSR || Opcode == Alpha_JSRs) {
-		const char *name = (Opcode == Alpha_JMP) ? "jmp " : "jsr ";
+	if (Opcode == Alpha_JMP || Opcode == Alpha_JSR ||
+	    Opcode == Alpha_JSRs || Opcode == Alpha_RETDAG) {
+		const char *name = (Opcode == Alpha_JMP)    ? "jmp " :
+				   (Opcode == Alpha_RETDAG) ? "ret " :
+							      "jsr ";
 		SStream_concat0(O, name);
 		printOperand(MI, 0, O);
 		SStream_concat1(O, ',');

--- a/arch/Alpha/AlphaInstPrinter.c
+++ b/arch/Alpha/AlphaInstPrinter.c
@@ -96,6 +96,23 @@ void Alpha_LLVM_printInstruction(MCInst *MI, SStream *O, void *Info)
 		printOperand(MI, 0, O);
 		return;
 	}
+	/*
+	 * JMP/JSR/JSRs now decode with format 18 (Ra + Rb + hint14).
+	 * The generated AsmWriter hardcodes operands for specific canonical
+	 * forms, so print all three operands explicitly here.
+	 */
+	if (Opcode == Alpha_JMP || Opcode == Alpha_JSR || Opcode == Alpha_JSRs) {
+		const char *name = (Opcode == Alpha_JMP) ? "jmp " : "jsr ";
+		SStream_concat0(O, name);
+		printOperand(MI, 0, O);
+		SStream_concat1(O, ',');
+		SStream_concat1(O, '(');
+		printOperand(MI, 1, O);
+		SStream_concat1(O, ')');
+		SStream_concat1(O, ',');
+		printOperand(MI, 2, O);
+		return;
+	}
 	if (Opcode == Alpha_BR || Opcode == Alpha_BSR) {
 		SStream_concat0(O, Opcode == Alpha_BR ? "br " : "bsr ");
 		printOperand(MI, 0, O);

--- a/include/capstone/alpha.h
+++ b/include/capstone/alpha.h
@@ -163,6 +163,7 @@ typedef enum alpha_insn {
 	Alpha_INS_CMPTUNsSU,
 	Alpha_INS_CMPULE,
 	Alpha_INS_CMPULT,
+	Alpha_INS_CALL_PAL,
 	Alpha_INS_COND_BRANCH,
 	Alpha_INS_CPYSE,
 	Alpha_INS_CPYSN,

--- a/tests/MC/Alpha/insn-alpha-be.s.yaml
+++ b/tests/MC/Alpha/insn-alpha-be.s.yaml
@@ -196,7 +196,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "bsr $26,$0xfffffffffffffff4 ..ng"
+          asm_text: "bsr $26,0xfffffffffffffff4"
   -
     input:
       bytes: [ 0x44, 0x22, 0x04, 0x83 ]

--- a/tests/MC/Alpha/insn-alpha-be.s.yaml
+++ b/tests/MC/Alpha/insn-alpha-be.s.yaml
@@ -988,7 +988,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "jmp $31,$12,0"
+          asm_text: "jmp $31,$26,0"
   -
     input:
       bytes: [ 0x6b, 0x5b, 0x40, 0x00 ]

--- a/tests/MC/Alpha/insn-alpha-be.s.yaml
+++ b/tests/MC/Alpha/insn-alpha-be.s.yaml
@@ -1781,3 +1781,30 @@ test_cases:
       insns:
         -
           asm_text: "zapnot $1,0xde,$3"
+  -
+    input:
+      bytes: [ 0x68, 0x01, 0x80, 0x03 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_BIG_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "ret $0,($1),3"
+  -
+    input:
+      bytes: [ 0x60, 0x3F, 0xE0, 0x00 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_BIG_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "rc $1"
+  -
+    input:
+      bytes: [ 0x60, 0x3F, 0xF0, 0x00 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_BIG_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "rs $1"

--- a/tests/MC/Alpha/insn-alpha-be.s.yaml
+++ b/tests/MC/Alpha/insn-alpha-be.s.yaml
@@ -988,7 +988,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "jmp $31,$26,0"
+          asm_text: "jmp $31,($26),0"
   -
     input:
       bytes: [ 0x6b, 0x5b, 0x40, 0x00 ]

--- a/tests/MC/Alpha/insn-alpha.s.yaml
+++ b/tests/MC/Alpha/insn-alpha.s.yaml
@@ -1988,3 +1988,30 @@ test_cases:
       insns:
         -
           asm_text: "cvtqt/sui $f1,$f10"
+  -
+    input:
+      bytes: [ 0x03, 0x80, 0x01, 0x68 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "ret $0,($1),3"
+  -
+    input:
+      bytes: [ 0x00, 0xE0, 0x3F, 0x60 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "rc $1"
+  -
+    input:
+      bytes: [ 0x00, 0xF0, 0x3F, 0x60 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "rs $1"

--- a/tests/MC/Alpha/insn-alpha.s.yaml
+++ b/tests/MC/Alpha/insn-alpha.s.yaml
@@ -196,7 +196,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "bsr $26,$0xfffffffffffffff4 ..ng"
+          asm_text: "bsr $26,0xfffffffffffffff4"
   -
     input:
       bytes: [ 0x83, 0x04, 0x22, 0x44 ]
@@ -1835,3 +1835,30 @@ test_cases:
       insns:
         -
           asm_text: "bis $31,$31,$29"
+  -
+    input:
+      bytes: [ 0x00, 0x00, 0x40, 0xc3 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "br $26,4"
+  -
+    input:
+      bytes: [ 0x03, 0x00, 0x20, 0xc0 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "br $1,0x10"
+  -
+    input:
+      bytes: [ 0x03, 0x00, 0x20, 0xd0 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "bsr $1,0x10"

--- a/tests/MC/Alpha/insn-alpha.s.yaml
+++ b/tests/MC/Alpha/insn-alpha.s.yaml
@@ -1925,3 +1925,12 @@ test_cases:
       insns:
         -
           asm_text: "jsr $26,($0),0x1a"
+  -
+    input:
+      bytes: [ 0x00, 0x00, 0xff, 0x63 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "trapb"

--- a/tests/MC/Alpha/insn-alpha.s.yaml
+++ b/tests/MC/Alpha/insn-alpha.s.yaml
@@ -1862,3 +1862,30 @@ test_cases:
       insns:
         -
           asm_text: "bsr $1,0x10"
+  -
+    input:
+      bytes: [ 0x00, 0x00, 0x00, 0x00 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "call_pal 0"
+  -
+    input:
+      bytes: [ 0x83, 0x00, 0x00, 0x00 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "call_pal 0x83"
+  -
+    input:
+      bytes: [ 0x0b, 0x02, 0x01, 0x00 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "call_pal 0x1020b"

--- a/tests/MC/Alpha/insn-alpha.s.yaml
+++ b/tests/MC/Alpha/insn-alpha.s.yaml
@@ -988,7 +988,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "jmp $31,$12,0"
+          asm_text: "jmp $31,$26,0"
   -
     input:
       bytes: [ 0x00, 0x40, 0x5b, 0x6b ]
@@ -1781,3 +1781,57 @@ test_cases:
       insns:
         -
           asm_text: "zapnot $1,0xde,$3"
+  -
+    input:
+      bytes: [ 0x09, 0x04, 0xff, 0x47 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "bis $31,$31,$9"
+  -
+    input:
+      bytes: [ 0x10, 0x04, 0xff, 0x47 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "bis $31,$31,$16"
+  -
+    input:
+      bytes: [ 0x13, 0x04, 0xff, 0x47 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "bis $31,$31,$19"
+  -
+    input:
+      bytes: [ 0x15, 0x04, 0xff, 0x47 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "bis $31,$31,$21"
+  -
+    input:
+      bytes: [ 0x17, 0x04, 0xff, 0x47 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "bis $31,$31,$23"
+  -
+    input:
+      bytes: [ 0x1d, 0x04, 0xff, 0x47 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "bis $31,$31,$29"

--- a/tests/MC/Alpha/insn-alpha.s.yaml
+++ b/tests/MC/Alpha/insn-alpha.s.yaml
@@ -1934,3 +1934,57 @@ test_cases:
       insns:
         -
           asm_text: "trapb"
+  -
+    input:
+      bytes: [ 0x43, 0x04, 0x22, 0x40 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "s4addq $1,$2,$3"
+  -
+    input:
+      bytes: [ 0x43, 0xd4, 0x3b, 0x40 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "s4addq $1,0xde,$3"
+  -
+    input:
+      bytes: [ 0xe2, 0xa5, 0xe1, 0x5b ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "cvttq/svc $f1,$f10"
+  -
+    input:
+      bytes: [ 0x82, 0xf5, 0xe1, 0x5b ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "cvtts/sui $f1,$f10"
+  -
+    input:
+      bytes: [ 0x82, 0xf7, 0xe1, 0x5b ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "cvtqs/sui $f1,$f10"
+  -
+    input:
+      bytes: [ 0xc2, 0xf7, 0xe1, 0x5b ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "cvtqt/sui $f1,$f10"

--- a/tests/MC/Alpha/insn-alpha.s.yaml
+++ b/tests/MC/Alpha/insn-alpha.s.yaml
@@ -988,7 +988,7 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "jmp $31,$26,0"
+          asm_text: "jmp $31,($26),0"
   -
     input:
       bytes: [ 0x00, 0x40, 0x5b, 0x6b ]
@@ -1889,3 +1889,39 @@ test_cases:
       insns:
         -
           asm_text: "call_pal 0x1020b"
+  -
+    input:
+      bytes: [ 0x44, 0x00, 0x00, 0x68 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "jmp $0,($0),0x44"
+  -
+    input:
+      bytes: [ 0x1a, 0x00, 0x40, 0x6b ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "jmp $26,($0),0x1a"
+  -
+    input:
+      bytes: [ 0x00, 0x40, 0x40, 0x6b ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "jsr $26,($0),0"
+  -
+    input:
+      bytes: [ 0x1a, 0x40, 0x40, 0x6b ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "jsr $26,($0),0x1a"

--- a/tests/details/alpha.yaml
+++ b/tests/details/alpha.yaml
@@ -8,40 +8,42 @@ test_cases:
     expected:
       insns:
       -
-        asm_text: "ldah $15,2($13)"
+        asm_text: "ldah $29,2($27)"
         details:
+          regs_read: [ $27 ]
+          regs_write: [ $28, $29 ]
           alpha:
             operands:
               -
                 type: ALPHA_OP_REG
-                reg: $15
+                reg: $29
               -
                 type: ALPHA_OP_IMM
                 imm: 0x2
               -
                 type: ALPHA_OP_REG
-                reg: $13
-          regs_read: [ $13 ]
-          regs_write: [ $28, $15 ]
+                reg: $27
       -
-        asm_text: "lda $15,0x7a50($15)"
+        asm_text: "lda $29,0x7a50($29)"
         details:
+          regs_read: [ $29 ]
+          regs_write: [ $28, $29 ]
           alpha:
             operands:
               -
                 type: ALPHA_OP_REG
-                reg: $15
+                reg: $29
               -
                 type: ALPHA_OP_IMM
                 imm: 0x7a50
               -
                 type: ALPHA_OP_REG
-                reg: $15
-          regs_read: [ $15 ]
-          regs_write: [ $28, $15 ]
+                reg: $29
       -
         asm_text: "lda $30,0xffd0($30)"
         details:
+          regs_read: [ $30 ]
+          regs_write: [ $28, $30 ]
           alpha:
             operands:
               -
@@ -53,24 +55,22 @@ test_cases:
               -
                 type: ALPHA_OP_REG
                 reg: $30
-          regs_read: [ $30 ]
-          regs_write: [ $28, $30 ]
       -
-        asm_text: "stq $12,0($30)"
+        asm_text: "stq $26,0($30)"
         details:
+          regs_read: [ $26, $30 ]
+          regs_write: [ $28 ]
           alpha:
             operands:
               -
                 type: ALPHA_OP_REG
-                reg: $12
+                reg: $26
               -
                 type: ALPHA_OP_IMM
                 imm: 0x0
               -
                 type: ALPHA_OP_REG
                 reg: $30
-          regs_read: [ $12, $30 ]
-          regs_write: [ $28 ]
   -
     input:
       bytes: [ 0x27, 0xbb, 0x00, 0x02, 0x23, 0xbd, 0x7a, 0x50, 0x23, 0xde, 0xff, 0xd0, 0xb7, 0x5e, 0x00, 0x00  ]
@@ -80,40 +80,42 @@ test_cases:
     expected:
       insns:
       -
-        asm_text: "ldah $15,2($13)"
+        asm_text: "ldah $29,2($27)"
         details:
+          regs_read: [ $27 ]
+          regs_write: [ $28, $29 ]
           alpha:
             operands:
               -
                 type: ALPHA_OP_REG
-                reg: $15
+                reg: $29
               -
                 type: ALPHA_OP_IMM
                 imm: 0x2
               -
                 type: ALPHA_OP_REG
-                reg: $13
-          regs_read: [ $13 ]
-          regs_write: [ $28, $15 ]
+                reg: $27
       -
-        asm_text: "lda $15,0x7a50($15)"
+        asm_text: "lda $29,0x7a50($29)"
         details:
+          regs_read: [ $29 ]
+          regs_write: [ $28, $29 ]
           alpha:
             operands:
               -
                 type: ALPHA_OP_REG
-                reg: $15
+                reg: $29
               -
                 type: ALPHA_OP_IMM
                 imm: 0x7a50
               -
                 type: ALPHA_OP_REG
-                reg: $15
-          regs_read: [ $15 ]
-          regs_write: [ $28, $15 ]
+                reg: $29
       -
         asm_text: "lda $30,0xffd0($30)"
         details:
+          regs_read: [ $30 ]
+          regs_write: [ $28, $30 ]
           alpha:
             operands:
               -
@@ -125,22 +127,19 @@ test_cases:
               -
                 type: ALPHA_OP_REG
                 reg: $30
-          regs_read: [ $30 ]
-          regs_write: [ $28, $30 ]
       -
-        asm_text: "stq $12,0($30)"
+        asm_text: "stq $26,0($30)"
         details:
+          regs_read: [ $26, $30 ]
+          regs_write: [ $28 ]
           alpha:
             operands:
               -
                 type: ALPHA_OP_REG
-                reg: $12
+                reg: $26
               -
                 type: ALPHA_OP_IMM
                 imm: 0x0
               -
                 type: ALPHA_OP_REG
                 reg: $30
-          regs_read: [ $12, $30 ]
-          regs_write: [ $28 ]
-

--- a/tests/details/cs_common_details.yaml
+++ b/tests/details/cs_common_details.yaml
@@ -1216,15 +1216,15 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "ldah $15,2($13)"
+          asm_text: "ldah $29,2($27)"
           mnemonic: "ldah"
-          op_str: "$15,2($13)"
+          op_str: "$29,2($27)"
           details:
             regs_impl_write: [ $28 ]
         -
-          asm_text: "lda $15,0x7a50($15)"
+          asm_text: "lda $29,0x7a50($29)"
           mnemonic: "lda"
-          op_str: "$15,0x7a50($15)"
+          op_str: "$29,0x7a50($29)"
           details:
             regs_impl_write: [ $28 ]
         -
@@ -1234,9 +1234,9 @@ test_cases:
           details:
             regs_impl_write: [ $28 ]
         -
-          asm_text: "stq $12,0($30)"
+          asm_text: "stq $26,0($30)"
           mnemonic: "stq"
-          op_str: "$12,0($30)"
+          op_str: "$26,0($30)"
           details:
             regs_impl_write: [ $28 ]
 
@@ -1249,15 +1249,15 @@ test_cases:
     expected:
       insns:
         -
-          asm_text: "ldah $15,2($13)"
+          asm_text: "ldah $29,2($27)"
           mnemonic: "ldah"
-          op_str: "$15,2($13)"
+          op_str: "$29,2($27)"
           details:
             regs_impl_write: [ $28 ]
         -
-          asm_text: "lda $15,0x7a50($15)"
+          asm_text: "lda $29,0x7a50($29)"
           mnemonic: "lda"
-          op_str: "$15,0x7a50($15)"
+          op_str: "$29,0x7a50($29)"
           details:
             regs_impl_write: [ $28 ]
         -
@@ -1267,9 +1267,9 @@ test_cases:
           details:
             regs_impl_write: [ $28 ]
         -
-          asm_text: "stq $12,0($30)"
+          asm_text: "stq $26,0($30)"
           mnemonic: "stq"
-          op_str: "$12,0($30)"
+          op_str: "$26,0($30)"
           details:
             regs_impl_write: [ $28 ]
   -


### PR DESCRIPTION
This series fixes several bugs in the Alpha disassembler where the
LLVM-generated decoder tables used overly-restrictive `CheckField`
constraints, causing legitimate instruction encodings to fail to decode.

## Commits

**Alpha: fix integer register class decoding order**

`DecodeGPRCRegisterClass` indexed into the LLVM `GPRC[]` allocation
priority array, which is not in architectural order. Alpha integer
registers are contiguous (`Alpha_R0`..`Alpha_R31`), so the fix is
`Alpha_R0 + RegNo`.

**Alpha: fix BR/BSR to accept any Ra register (Refs #2582)**

BR and BSR use the Ra field as a write destination for the updated PC.
The decoder required Ra=31; any other value failed to decode.

**Alpha: fix CALL_PAL to decode full 26-bit function code**

The decoder used format 0 (no operands) and ignored bits[25:0]. Added
format 31 (26-bit immediate) so the PALcode function field is captured.

**Alpha: fix JMP/JSR to accept any Ra, Rb, and hint (Closes #2582)**

All four Jump instructions (JMP/JSR/RET/JSR_COROUTINE) perform identical
operations and differ only in branch-prediction hints. The decoder
required Ra=31, Rb specific values, and hint=0 for JMP/JSR.

**Alpha: fix TRAPB/EXCB/MB/WMB to decode with any Ra/Rb field (Closes #2795)**

These instructions architecturally ignore Ra and Rb. Setting them to
R31 is a software convention, not a hardware requirement. The decoder
rejected any encoding where Ra/Rb ≠ 31.

**Alpha: fix RET/RC/RS to decode with any register fields**

RET (opcode 0x1a, bits[15:14]=10) suffered the same constraint as
JMP/JSR: decoder required Ra=31, Rb=26, hint=1 exactly.

RC and RS (opcode 0x18) have an unused Rb field. The decoder checked
Rb==0 (R0), but the software convention is R31, so real compiler output
failed to decode.

**Alpha: add missing test coverage for s4addq and cvt FP variants**

## Testing

All 425 MC tests and 2 detail tests pass.