### PR TITLE
fix AArch64 predicate-as-counter register printed in hex

### DIFF
--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -1294,7 +1294,7 @@ DEFINE_printRegWithShiftExtend(false, 128, x, 0);
 				0 && \
 				"Unsupported predicate-as-counter register"); \
 		SStream_concat(O, "%s", "pn"); \
-		printUInt32(O, (Reg - AArch64_PN0)); \
+		SStream_concat(O, "%u", (Reg - AArch64_PN0)); \
 		switch (EltSize) { \
 		case 0: \
 			break; \

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6687,3 +6687,15 @@ test_cases:
           regs_read: [ rax ]
           regs_write: [ sp ]
           groups: [ mode64 ]
+  -
+    input:
+      name: "issue 2973 AArch64 predicate-as-counter register printed in hex"
+      bytes: [ 0x12, 0x78, 0x60, 0x25 ]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_MODE_ARM ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "ptrue pn10.h"
+        op_str: "pn10.h"


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

AArch64 predicate-as-counter registers `pn10`–`pn15` were printed in hexadecimal
(e.g. `ptrue pn0xa.h` instead of `ptrue pn10.h`).

The cause is in the `printPredicateAsCounter` macro in `arch/AArch64/AArch64InstPrinter.c`.
It printed the register index via `printUInt32()`, which automatically switches to a
`0x%x` hex representation once the value exceeds `HEX_THRESHOLD` (defined as `9` in `utils.h`):

```c
void printUInt32(SStream *ss, uint32_t val) {
    if (val > HEX_THRESHOLD)
        SStream_concat(ss, "0x%x", val);   // pn10 -> "pn0xa"
    else
        SStream_concat(ss, "%u", val);
}
```
So pn0–pn9 printed correctly, but the index 10–15 (registers pn10–pn15)
was rendered as 0xa–0xf.

The register number must always be printed in decimal, matching upstream LLVM
(O << "pn" << (Reg - AArch64::PN0)). The fix prints the index directly in decimal
instead of routing it through the hex-thresholding helper:

  SStream_concat(O, "%s", "pn");
```
- printUInt32(O, (Reg - AArch64_PN0));
+ SStream_concat(O, "%u", (Reg - AArch64_PN0));
```
This is a one-line, output-only change; the decoded register value/detail is unaffected.

**Test plan**

Added a regression test case to tests/issues/issues.yaml for ptrue pn10.h
(bytes [0x12, 0x78, 0x60, 0x25]).

>[!IMPORTANT]
the test runners (cstest / cstest_py) normalize hex numbers to decimal when
comparing asm_text (see replace_hex() in suite/cstest/src/helper.c and
normalize_asm_text() in cstest_py), so an asm_text-only check passes even with the
bug present(e.g. tests\MC\AArch64\SVE2p1\ptrue.s.yaml). 
To make the test actually catch the regression, the expected op_str field
is set explicitly (op_str: "pn10.h").

Verified locally with cstest/cstest_py
Also confirmed via cstool directly

**Closing issues**
closes #2973 
