### PR TITLE
sh: fix signed shift overflow in sh_disassemble dsp decode

### DIFF
--- a/arch/SH/SHDisassembler.c
+++ b/arch/SH/SHDisassembler.c
@@ -2170,8 +2170,8 @@ static bool sh_disassemble(const uint8_t *code, MCInst *MI, uint64_t address,
 					insn <<= 16;
 					insn |= code[2] << 8 | code[3];
 				} else
-					insn |= (code[3] << 24) |
-						(code[2] << 16);
+					insn |= ((uint32_t)code[3] << 24) |
+						((uint32_t)code[2] << 16);
 				dsp_result = decode_dsp_p(insn, MI, mode, info,
 							  detail);
 				break;

--- a/tests/integration/test_poc.c
+++ b/tests/integration/test_poc.c
@@ -110,11 +110,32 @@ static void test_overflow_set_reg_mem_n(void)
 	return;
 }
 
+/// Signed left shift overflow when assembling a little-endian SH-DSP
+/// parallel instruction word. code[3] is promoted to int and shifted
+/// left by 24, which is UB whenever its top bit is set (code[3] >= 0x80).
+static void test_ub_shift_sh_dsp_p(void)
+{
+	static const uint8_t code[] = { 0x00, 0xf8, 0x00, 0x80 };
+
+	csh handle;
+	if (cs_open(CS_ARCH_SH, CS_MODE_SH4A | CS_MODE_SHDSP, &handle) !=
+	    CS_ERR_OK)
+		return;
+	cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
+
+	cs_insn *insn = NULL;
+	size_t count = cs_disasm(handle, code, sizeof(code), 0x1000, 0, &insn);
+	cs_free(insn, count);
+	cs_close(&handle);
+	return;
+}
+
 int main()
 {
 	test_overflow_cs_insn_bytes();
 	test_overflow_cs_insn_bytes_iter();
 	test_overflow_set_reg_mem_n();
+	test_ub_shift_sh_dsp_p();
 
 	return 0;
 }


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Signed left shift overflow in the SH DSP instruction decoder:
- `sh_disassemble` assembles a 4-byte little-endian SH-DSP parallel word with `code[3] << 24`
- `code[3]` is a `uint8_t` promoted to `int`, so any value `>= 0x80` overflows `int`, which is undefined behavior
- reachable via `cs_disasm` in little-endian `CS_MODE_SHDSP` for words with top nibble `0xf` and bits[11:10] == 2

Cast the bytes to `uint32_t` before shifting, matching `readBytes32` in utils.c.

**Test plan**

Build with `-DENABLE_ASAN=1` and run `integration_test_poc`. Before the fix, disassembling `00 f8 00 80` (SH4A|SHDSP) aborts under UBSan:

```
arch/SH/SHDisassembler.c:2173:23: runtime error: left shift of 128 by 24 places cannot be represented in type 'int'
    #0 sh_disassemble SHDisassembler.c:2173
    #1 SH_getInstruction SHDisassembler.c:2218
    #2 cs_disasm cs.c:1328
```

After the fix the test runs clean. Added `test_ub_shift_sh_dsp_p` to tests/integration/test_poc.c covering this input.

**Closing issues**

<!-- none -->