### PR TITLE
guard operand append past MAX_MC_OPS in MCInst.c

### DIFF
--- a/MCInst.c
+++ b/MCInst.c
@@ -57,7 +57,7 @@ void MCInst_clear(MCInst *inst)
 // does not free @Op
 void MCInst_insert0(MCInst *inst, int index, MCOperand *Op)
 {
-	CS_ASSERT_RET(index < MAX_MC_OPS);
+	CS_ASSERT_RET(index < MAX_MC_OPS && inst->size < MAX_MC_OPS);
 	int i;
 
 	for (i = inst->size; i > index; i--)
@@ -193,6 +193,7 @@ MCOperand *MCOperand_CreateReg1(MCInst *mcInst, unsigned Reg)
 
 void MCOperand_CreateReg0(MCInst *mcInst, unsigned Reg)
 {
+	CS_ASSERT_RET(mcInst->size < MAX_MC_OPS);
 	MCOperand *op = &(mcInst->Operands[mcInst->size]);
 	mcInst->size++;
 
@@ -214,7 +215,7 @@ MCOperand *MCOperand_CreateImm1(MCInst *mcInst, int64_t Val)
 
 void MCOperand_CreateImm0(MCInst *mcInst, int64_t Val)
 {
-	assert(mcInst->size < MAX_MC_OPS);
+	CS_ASSERT_RET(mcInst->size < MAX_MC_OPS);
 	MCOperand *op = &(mcInst->Operands[mcInst->size]);
 	mcInst->size++;
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

`MCInst_addOperand2()` guards its append with `CS_ASSERT_RET(inst->size < MAX_MC_OPS)`, which stays active in release builds. The three other functions that grow `MCInst.Operands[]` do not have an equivalent guard:

- `MCOperand_CreateImm0()` uses a plain `assert(mcInst->size < MAX_MC_OPS)`. With `CAPSTONE_DEBUG` off (the default), `NDEBUG` is set and the assert is compiled out, leaving the write to `Operands[size]` unchecked.
- `MCOperand_CreateReg0()` has no bounds check at all.
- `MCInst_insert0()` only checks `index`, not `size`, so at capacity its shift loop `Operands[i] = Operands[i - 1]` starts at `i == size == MAX_MC_OPS` and writes one past the array.

Since both decoders and printers reach these three helpers directly with counts derived from the instruction bytes, a decode path that appends more than `MAX_MC_OPS` operands turns into an out-of-bounds write of the stack-allocated `MCInst` in shipped builds instead of a caught assert. This is the same operand-array overflow class fixed for SH in #2968. The patch routes all three through the release-active `CS_ASSERT_RET(size < MAX_MC_OPS)` already used by `MCInst_addOperand2`.

These are internal helpers, so there is no public API or struct documentation to update.

**Test plan**

- Release build of the full library stays green, and `clang-format` reports no changes on the touched file.
- The guard only returns when `size` reaches `MAX_MC_OPS`, which valid input never hits, so decoder output is unchanged. Verified by diffing 3.8M disassembly results (mnemonic, op_str, and detail group count, with `CS_OPT_DETAIL` on) across 22 architectures between an unpatched and a patched build. The two outputs are byte-identical.

**Closing issues**

<!-- none -->
