### PR TITLE
xtensa: fix swapped isIntN arguments in decodeOffset_16_16Operand

### DIFF
--- a/arch/Xtensa/XtensaDisassembler.c
+++ b/arch/Xtensa/XtensaDisassembler.c
@@ -788,7 +788,7 @@ static DecodeStatus decodeOffset_16_16Operand(MCInst *Inst, uint64_t Imm,
 					      int64_t Address,
 					      const void *Decoder)
 {
-	CS_ASSERT_RET_VAL(isIntN(Imm, 8) && "Invalid immediate",
+	CS_ASSERT_RET_VAL(isIntN(8, Imm) && "Invalid immediate",
 			  MCDisassembler_Fail);
 	if ((Imm & 0xf) != 0)
 		MCOperand_CreateImm0(Inst, (Imm << 4));

--- a/tests/integration/test_poc.c
+++ b/tests/integration/test_poc.c
@@ -130,12 +130,33 @@ static void test_ub_shift_sh_dsp_p(void)
 	return;
 }
 
+/// Swapped isIntN() arguments in decodeOffset_16_16Operand: the untrusted
+/// immediate is passed as the bit width N. When the 4-bit offset field is 0,
+/// N becomes 0 and isIntN shifts by (unsigned)(0 - 1), which is UB. The word
+/// below is an ee.ldf.128.ip with a zero offset field.
+static void test_ub_isintn_xtensa_offset(void)
+{
+	static const uint8_t code[] = { 0x2f, 0x70, 0x44, 0x84 };
+
+	csh handle;
+	if (cs_open(CS_ARCH_XTENSA, CS_MODE_XTENSA_ESP32, &handle) != CS_ERR_OK)
+		return;
+	cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
+
+	cs_insn *insn = NULL;
+	size_t count = cs_disasm(handle, code, sizeof(code), 0x1000, 0, &insn);
+	cs_free(insn, count);
+	cs_close(&handle);
+	return;
+}
+
 int main()
 {
 	test_overflow_cs_insn_bytes();
 	test_overflow_cs_insn_bytes_iter();
 	test_overflow_set_reg_mem_n();
 	test_ub_shift_sh_dsp_p();
+	test_ub_isintn_xtensa_offset();
 
 	return 0;
 }

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6239,11 +6239,35 @@ test_cases:
       name: "#2986 Xtensa decodeOffset_16_16Operand swapped isIntN arguments"
       bytes: [ 0x2f, 0x70, 0x44, 0x84 ]
       arch: "CS_ARCH_XTENSA"
-      options: [ CS_MODE_XTENSA_ESP32 ]
+      options: [ CS_MODE_XTENSA_ESP32, CS_OPT_DETAIL ]
       address: 0x0
     expected:
       insns:
         - asm_text: "ee.ldf.128.ip f8, f9, f7, f4, a2, 0"
+          details:
+            xtensa:
+              operands:
+                - type: XTENSA_OP_REG
+                  reg: f8
+                  access: CS_AC_WRITE
+                - type: XTENSA_OP_REG
+                  reg: f9
+                  access: CS_AC_WRITE
+                - type: XTENSA_OP_REG
+                  reg: f7
+                  access: CS_AC_WRITE
+                - type: XTENSA_OP_REG
+                  reg: f4
+                  access: CS_AC_WRITE
+                - type: XTENSA_OP_REG
+                  reg: a2
+                  access: CS_AC_READ
+                - type: XTENSA_OP_IMM
+                  imm: 0
+                  access: CS_AC_READ
+            regs_read: [ a2 ]
+            regs_write: [ f8, f9, f7, f4 ]
+            groups: [ HasESP32S3Ops ]
 
   -
     input:

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6236,6 +6236,17 @@ test_cases:
 
   -
     input:
+      name: "#2986 Xtensa decodeOffset_16_16Operand swapped isIntN arguments"
+      bytes: [ 0x2f, 0x70, 0x44, 0x84 ]
+      arch: "CS_ARCH_XTENSA"
+      options: [ CS_MODE_XTENSA_ESP32 ]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "ee.ldf.128.ip f8, f9, f7, f4, a2, 0"
+
+  -
+    input:
       name: "#2722 - CS_OPT_UNSIGNED is ignored for most archs"
       bytes: [ 0x20, 0xf0, 0x5f, 0xf8 ]
       arch: "CS_ARCH_AARCH64"


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

`decodeOffset_16_16Operand` passes the untrusted immediate as the width argument to `isIntN`:
- the call is `isIntN(Imm, 8)`, but the signature is `isIntN(unsigned N, int64_t x)`, so `Imm` is used as the bit count
- the three sibling offset decoders correctly use `isIntN(16, Imm)`
- `Imm` is a 4-bit field, so `Imm == 0` shifts by `(unsigned)(0 - 1)` inside `isIntN`, which UBSan flags at `MathExtras.h:62`; it also wrongly rejects offsets 1..4

Swapped the arguments back to `isIntN(8, Imm)`.

**Test plan**

`ee.ldf.128.ip` with a zero offset field reaches it: `cstool -d esp32 2f704484`. On an ASAN/UBSan build the old code aborts with `shift exponent 4294967295 is too large`; after the fix it decodes clean as `ee.ldf.128.ip f8, f9, f7, f4, a2, 0`. Added `test_ub_isintn_xtensa_offset` to `tests/integration/test_poc.c` for that word.

**Closing issues**
