### PR TITLE
mips: fix left shift of negative value in DecodeMemMMReglistImm4Lsl2

### DIFF
--- a/arch/Mips/MipsDisassembler.c
+++ b/arch/Mips/MipsDisassembler.c
@@ -2429,7 +2429,7 @@ static DecodeStatus DecodeMemMMReglistImm4Lsl2(MCInst *Inst, uint32_t Insn,
 		return MCDisassembler_Fail;
 
 	MCOperand_CreateReg0(Inst, (Mips_SP));
-	MCOperand_CreateImm0(Inst, (Offset << 2));
+	MCOperand_CreateImm0(Inst, (Offset * 4));
 
 	return MCDisassembler_Success;
 }

--- a/arch/Mips/MipsDisassembler.c
+++ b/arch/Mips/MipsDisassembler.c
@@ -2420,7 +2420,7 @@ static DecodeStatus DecodeMemMMReglistImm4Lsl2(MCInst *Inst, uint32_t Insn,
 		Offset = fieldFromInstruction_4(Insn, 4, 4);
 		break;
 	default:
-		Offset = SignExtend32((Insn & 0xf), 4);
+		Offset = (Insn & 0xf);
 		break;
 	}
 
@@ -2429,7 +2429,7 @@ static DecodeStatus DecodeMemMMReglistImm4Lsl2(MCInst *Inst, uint32_t Insn,
 		return MCDisassembler_Fail;
 
 	MCOperand_CreateReg0(Inst, (Mips_SP));
-	MCOperand_CreateImm0(Inst, (Offset * 4));
+	MCOperand_CreateImm0(Inst, (Offset << 2));
 
 	return MCDisassembler_Success;
 }

--- a/tests/integration/test_poc.c
+++ b/tests/integration/test_poc.c
@@ -130,12 +130,35 @@ static void test_ub_shift_sh_dsp_p(void)
 	return;
 }
 
+/// Signed left shift of a negative value when decoding a microMIPS
+/// LWM16/SWM16 offset. The 4-bit field is sign-extended to a negative int
+/// and then shifted left by 2, which is UB whenever the field's top bit
+/// is set (offset field >= 8).
+static void test_ub_shift_mips_mm_reglist(void)
+{
+	static const uint8_t code[] = { 0x45, 0x08 };
+
+	csh handle;
+	if (cs_open(CS_ARCH_MIPS,
+		    CS_MODE_MICRO | CS_MODE_MIPS32 | CS_MODE_BIG_ENDIAN,
+		    &handle) != CS_ERR_OK)
+		return;
+	cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
+
+	cs_insn *insn = NULL;
+	size_t count = cs_disasm(handle, code, sizeof(code), 0x1000, 0, &insn);
+	cs_free(insn, count);
+	cs_close(&handle);
+	return;
+}
+
 int main()
 {
 	test_overflow_cs_insn_bytes();
 	test_overflow_cs_insn_bytes_iter();
 	test_overflow_set_reg_mem_n();
 	test_ub_shift_sh_dsp_p();
+	test_ub_shift_mips_mm_reglist();
 
 	return 0;
 }

--- a/tests/integration/test_poc.c
+++ b/tests/integration/test_poc.c
@@ -131,9 +131,9 @@ static void test_ub_shift_sh_dsp_p(void)
 }
 
 /// Signed left shift of a negative value when decoding a microMIPS
-/// LWM16/SWM16 offset. The 4-bit field is sign-extended to a negative int
-/// and then shifted left by 2, which is UB whenever the field's top bit
-/// is set (offset field >= 8).
+/// LWM16/SWM16 offset. The ISA defines the offset as zero_extend(offset||0^2),
+/// but the 4-bit field was sign-extended to a negative int and then shifted
+/// left by 2, which is UB whenever the field's top bit is set (field >= 8).
 static void test_ub_shift_mips_mm_reglist(void)
 {
 	static const uint8_t code[] = { 0x45, 0x08 };


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

`DecodeMemMMReglistImm4Lsl2` decodes the offset of the microMIPS `LWM16`/`SWM16` instructions. The ISA defines the address as:

```
vAddr = zero_extend(offset||0^2) + GPR[sp]
```

so the 4-bit `offset` field is concatenated with two zero bits and then zero-extended. The MMR6 path already treats it as unsigned (`fieldFromInstruction_4`), but the non-MMR6 path sign-extended the field (`SignExtend32((Insn & 0xf), 4)`) before the `<< 2`. That was wrong in two ways: whenever the field's top bit is set (field >= 8) the value became negative, so `Offset << 2` is a left shift of a negative value (UB), and the decoded offset came out negative instead of the zero-extended value the ISA requires.

`ubsan` on the unpatched tree:

```
arch/Mips/MipsDisassembler.c:2432:37: runtime error: left shift of negative value -8
```

Fix is to zero-extend the field to match both the ISA and the MMR6 path. The shift is then always applied to a non-negative value, so the UB is gone and the offset is correct.

**Test plan**

Added `test_ub_shift_mips_mm_reglist` to `tests/integration/test_poc.c`, next to the existing `test_ub_shift_sh_dsp_p` signed-shift regression. Building with `-fsanitize=undefined -fno-sanitize-recover=undefined` and running `test_poc` aborts at `MipsDisassembler.c:2432` before the change and exits cleanly after. `cstool micromips 4508` now prints `lwm16 $s0, $ra, 0x20($sp)` (the zero-extended `8 << 2 == 0x20`).
