### PR TITLE
mips: zero-extend microMIPS LWM16/SWM16 reglist offset

### DIFF
--- a/arch/Mips/MipsDisassembler.c
+++ b/arch/Mips/MipsDisassembler.c
@@ -2420,7 +2420,7 @@ static DecodeStatus DecodeMemMMReglistImm4Lsl2(MCInst *Inst, uint32_t Insn,
 		Offset = fieldFromInstruction_4(Insn, 4, 4);
 		break;
 	default:
-		Offset = SignExtend32((Insn & 0xf), 4);
+		Offset = fieldFromInstruction_4(Insn, 0, 4);
 		break;
 	}
 

--- a/tests/integration/test_poc.c
+++ b/tests/integration/test_poc.c
@@ -208,6 +208,28 @@ static void test_ub_isintn_xtensa_offset(void)
 	return;
 }
 
+/// Signed left shift of a negative value when decoding a microMIPS
+/// LWM16/SWM16 offset. The ISA defines the offset as zero_extend(offset||0^2),
+/// but the 4-bit field was sign-extended to a negative int and then shifted
+/// left by 2, which is UB whenever the field's top bit is set (field >= 8).
+static void test_ub_shift_mips_mm_reglist(void)
+{
+	static const uint8_t code[] = { 0x45, 0x08 };
+
+	csh handle;
+	if (cs_open(CS_ARCH_MIPS,
+		    CS_MODE_MICRO | CS_MODE_MIPS32 | CS_MODE_BIG_ENDIAN,
+		    &handle) != CS_ERR_OK)
+		return;
+	cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
+
+	cs_insn *insn = NULL;
+	size_t count = cs_disasm(handle, code, sizeof(code), 0x1000, 0, &insn);
+	cs_free(insn, count);
+	cs_close(&handle);
+	return;
+}
+
 int main()
 {
 	test_overflow_cs_insn_bytes();
@@ -216,6 +238,7 @@ int main()
 	test_integer_overflow();
 	test_ub_shift_sh_dsp_p();
 	test_ub_isintn_xtensa_offset();
+	test_ub_shift_mips_mm_reglist();
 
 	return 0;
 }

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6734,3 +6734,15 @@ test_cases:
       -
         asm_text: "ptrue pn10.h"
         op_str: "pn10.h"
+  -
+    input:
+      name: "issue 2989 microMIPS LWM16 reglist offset zero-extended"
+      bytes: [ 0x45, 0x08 ]
+      arch: "CS_ARCH_MIPS"
+      options: [ CS_MODE_MICRO, CS_MODE_MIPS32, CS_MODE_BIG_ENDIAN ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "lwm16 $s0, $ra, 0x20($sp)"
+        op_str: "$s0, $ra, 0x20($sp)"


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Reopening #2989 with the fix reworked per review. That branch was force-pushed so GitHub won't let it be reopened, hence a fresh PR.

`DecodeMemMMReglistImm4Lsl2` decodes the offset of the microMIPS `LWM16`/`SWM16` instructions. The ISA defines the address as:

```
vAddr = zero_extend(offset||0^2) + GPR[sp]
```

so the 4-bit `offset` field is concatenated with two zero bits and zero-extended. The MMR6 path already reads it unsigned via `fieldFromInstruction_4`, but the non-MMR6 path used `SignExtend32((Insn & 0xf), 4)`. Whenever the field's top bit is set (field >= 8) that makes `Offset` negative, so `Offset << 2` is a left shift of a negative value (UB), and the decoded offset came out negative instead of the zero-extended value the ISA requires.

The fix reads the field with `fieldFromInstruction_4(Insn, 0, 4)`, matching the MMR6 branch and the ISA. The shift is then always applied to a non-negative value.

**Test plan**

Built with `-fsanitize=undefined -fno-sanitize-recover=undefined` and confirmed both directions:

- before: `cstool micromips 4508` and `test_poc` abort at `arch/Mips/MipsDisassembler.c:2432` with `runtime error: left shift of negative value -8`.
- after: `test_poc` exits cleanly and `cstool micromips 4508` prints `lwm16 $s0, $ra, 0x20($sp)` (`8 << 2 == 0x20`, the zero-extended value).

Added `test_ub_shift_mips_mm_reglist` to `tests/integration/test_poc.c`, next to the existing `test_ub_shift_sh_dsp_p` signed-shift regression.

**Closing issues**
