### PR TITLE
M68K: Fix FPU condition and FMOVEM decoding

### DIFF
--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -2814,6 +2814,36 @@ static void fmove_fpcr(m68k_info *info, uint32_t extension)
 		special->reg = M68K_REG_FPIAR;
 }
 
+static bool m68k_fmovem_is_valid(uint32_t ir, uint32_t extension)
+{
+	int dir = M68K_FEXT_DIR(extension);
+	m68k_fmovem_mode mode = m68k_fmovem_get_mode(extension);
+	bool is_predecrement = m68k_ea_mode(ir) ==
+			       M68K_EA_MODE_ADDR_INDIRECT_PRE_DEC;
+	bool is_postincrement = m68k_ea_mode(ir) ==
+				M68K_EA_MODE_ADDR_INDIRECT_POST_INC;
+
+	if (BITFIELD(extension, 10, 8) != 0)
+		return false;
+
+	switch (mode) {
+	case M68K_FMOVEM_MODE_STATIC_PREDECREMENT:
+		return dir && is_predecrement;
+	case M68K_FMOVEM_MODE_DYNAMIC_PREDECREMENT:
+		return m68k_fmovem_dynamic_reserved_bits_are_zero(extension) &&
+		       dir && is_predecrement;
+	case M68K_FMOVEM_MODE_STATIC_POSTINCREMENT_OR_CONTROL:
+		return dir ? m68k_ea_is_alterable_control(ir) :
+			     (is_postincrement || m68k_ea_is_control(ir));
+	case M68K_FMOVEM_MODE_DYNAMIC_POSTINCREMENT_OR_CONTROL:
+		return m68k_fmovem_dynamic_reserved_bits_are_zero(extension) &&
+		       (dir ? m68k_ea_is_alterable_control(ir) :
+			      (is_postincrement || m68k_ea_is_control(ir)));
+	default:
+		return false;
+	}
+}
+
 static void fmovem(m68k_info *info, uint32_t extension)
 {
 	cs_m68k_op *op_reglist;
@@ -2821,7 +2851,14 @@ static void fmovem(m68k_info *info, uint32_t extension)
 	int dir = M68K_FEXT_DIR(extension);
 	m68k_fmovem_mode mode = m68k_fmovem_get_mode(extension);
 	uint32_t reglist = m68k_fmovem_register_list(extension);
-	cs_m68k *ext = build_init_op(info, M68K_INS_FMOVEM, 2, 0);
+	cs_m68k *ext;
+
+	if (!m68k_fmovem_is_valid(info->ir, extension)) {
+		invalid_insn(info);
+		return;
+	}
+
+	ext = build_init_op(info, M68K_INS_FMOVEM, 2, 0);
 
 	op_reglist = &ext->operands[0];
 	op_ea = &ext->operands[1];
@@ -2841,26 +2878,9 @@ static void fmovem(m68k_info *info, uint32_t extension)
 
 	switch (mode) {
 	case M68K_FMOVEM_MODE_DYNAMIC_PREDECREMENT:
-		if (m68k_fmovem_dynamic_reserved_bits_are_zero(extension) &&
-		    dir &&
-		    m68k_ea_mode(info->ir) ==
-			    M68K_EA_MODE_ADDR_INDIRECT_PRE_DEC) {
-			op_reglist->reg =
-				M68K_REG_D0 +
-				m68k_fmovem_dynamic_register(extension);
-		}
-		break;
-
 	case M68K_FMOVEM_MODE_DYNAMIC_POSTINCREMENT_OR_CONTROL:
-		if (m68k_fmovem_dynamic_reserved_bits_are_zero(extension) &&
-		    (dir ? m68k_ea_is_alterable_control(info->ir) :
-			   (m68k_ea_is_control(info->ir) ||
-			    m68k_ea_mode(info->ir) ==
-				    M68K_EA_MODE_ADDR_INDIRECT_POST_INC))) {
-			op_reglist->reg =
-				M68K_REG_D0 +
-				m68k_fmovem_dynamic_register(extension);
-		}
+		op_reglist->reg =
+			M68K_REG_D0 + m68k_fmovem_dynamic_register(extension);
 		break;
 
 	case M68K_FMOVEM_MODE_STATIC_PREDECREMENT:
@@ -3298,7 +3318,7 @@ static void d68020_cptrapcc_32(m68k_info *info)
 	extension2 = read_imm_32(info);
 
 	ext = build_init_fpu_condition_op(info, M68K_INS_FTRAPF, extension1, 1,
-					  2);
+					  4);
 
 	op0 = &ext->operands[0];
 

--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -354,9 +354,14 @@ static void get_with_index_address_mode(m68k_info *info, cs_m68k_op *op,
 	}
 }
 
+/* Raw effective-address encoding bits, used before get_ea_mode_op() consumes
+ * any extension words and fills cs_m68k_op.address_mode. The control and
+ * alterable-control classifications follow Table 4-21 on page 4-133 of the
+ * Motorola MC68881/MC68882 Floating-Point Coprocessor User's Manual, first
+ * edition (1987):
+ * https://www.bitsavers.org/components/motorola/68000/68020/MC68881_MC68882_Floating-Point_Coprocessor_Users_Manual_1ed_1987.pdf
+ */
 enum {
-	/* Raw effective-address encoding bits, used before get_ea_mode_op()
-	 * consumes any extension words and fills cs_m68k_op.address_mode. */
 	M68K_EA_REGISTER_MASK = 0x07,
 	M68K_EA_MODE_SHIFT = 3,
 	M68K_EA_FIELD_MASK = 0x3f,
@@ -380,6 +385,8 @@ enum {
 enum {
 	M68K_EA_EXT_ABSOLUTE_SHORT = 0,
 	M68K_EA_EXT_ABSOLUTE_LONG = 1,
+	M68K_EA_EXT_PC_DISPLACEMENT = 2,
+	M68K_EA_EXT_PC_INDEX = 3,
 };
 
 static uint32_t m68k_ea_field(uint32_t ir)
@@ -410,6 +417,26 @@ static bool m68k_ea_is_register_direct(uint32_t ir)
 static bool m68k_ea_is_immediate(uint32_t ir)
 {
 	return m68k_ea_field(ir) == M68K_EA_IMMEDIATE_FIELD;
+}
+
+static bool m68k_ea_is_control(uint32_t ir)
+{
+	uint32_t mode = m68k_ea_mode(ir);
+	return mode == M68K_EA_MODE_ADDR_INDIRECT ||
+	       mode == M68K_EA_MODE_ADDR_INDIRECT_DISP ||
+	       mode == M68K_EA_MODE_ADDR_INDIRECT_INDEX ||
+	       (mode == M68K_EA_MODE_EXTENDED &&
+		m68k_ea_register(ir) <= M68K_EA_EXT_PC_INDEX);
+}
+
+static bool m68k_ea_is_alterable_control(uint32_t ir)
+{
+	uint32_t mode = m68k_ea_mode(ir);
+	return mode == M68K_EA_MODE_ADDR_INDIRECT ||
+	       mode == M68K_EA_MODE_ADDR_INDIRECT_DISP ||
+	       mode == M68K_EA_MODE_ADDR_INDIRECT_INDEX ||
+	       (mode == M68K_EA_MODE_EXTENDED &&
+		m68k_ea_register(ir) <= M68K_EA_EXT_ABSOLUTE_LONG);
 }
 
 static bool m68k_ea_is_data_register_direct_or_immediate(uint32_t ir)
@@ -2792,8 +2819,8 @@ static void fmovem(m68k_info *info, uint32_t extension)
 	cs_m68k_op *op_reglist;
 	cs_m68k_op *op_ea;
 	int dir = M68K_FEXT_DIR(extension);
-	int mode = (extension >> 11) & 0x3;
-	uint32_t reglist = extension & 0xff;
+	m68k_fmovem_mode mode = m68k_fmovem_get_mode(extension);
+	uint32_t reglist = m68k_fmovem_register_list(extension);
 	cs_m68k *ext = build_init_op(info, M68K_INS_FMOVEM, 2, 0);
 
 	op_reglist = &ext->operands[0];
@@ -2813,17 +2840,36 @@ static void fmovem(m68k_info *info, uint32_t extension)
 	}
 
 	switch (mode) {
-	case 1: // Dynamic list in dn register
-		op_reglist->reg = M68K_REG_D0 + ((reglist >> 4) & 7);
+	case M68K_FMOVEM_MODE_DYNAMIC_PREDECREMENT:
+		if (m68k_fmovem_dynamic_reserved_bits_are_zero(extension) &&
+		    dir &&
+		    m68k_ea_mode(info->ir) ==
+			    M68K_EA_MODE_ADDR_INDIRECT_PRE_DEC) {
+			op_reglist->reg =
+				M68K_REG_D0 +
+				m68k_fmovem_dynamic_register(extension);
+		}
 		break;
 
-	case 0:
+	case M68K_FMOVEM_MODE_DYNAMIC_POSTINCREMENT_OR_CONTROL:
+		if (m68k_fmovem_dynamic_reserved_bits_are_zero(extension) &&
+		    (dir ? m68k_ea_is_alterable_control(info->ir) :
+			   (m68k_ea_is_control(info->ir) ||
+			    m68k_ea_mode(info->ir) ==
+				    M68K_EA_MODE_ADDR_INDIRECT_POST_INC))) {
+			op_reglist->reg =
+				M68K_REG_D0 +
+				m68k_fmovem_dynamic_register(extension);
+		}
+		break;
+
+	case M68K_FMOVEM_MODE_STATIC_PREDECREMENT:
 		op_reglist->address_mode = M68K_AM_NONE;
 		op_reglist->type = M68K_OP_REG_BITS;
 		op_reglist->register_bits = reglist << 16;
 		break;
 
-	case 2: // Static list
+	case M68K_FMOVEM_MODE_STATIC_POSTINCREMENT_OR_CONTROL:
 		op_reglist->address_mode = M68K_AM_NONE;
 		op_reglist->type = M68K_OP_REG_BITS;
 		op_reglist->register_bits = ((uint32_t)reverse_bits_8(reglist))
@@ -5256,6 +5302,13 @@ static void build_regs_read_write_counts(m68k_info *info)
 
 	if (!info->extension.op_count)
 		return;
+	if (info->inst->Opcode == M68K_INS_FMOVEM &&
+	    info->extension.op_count == 2 &&
+	    info->extension.operands[1].type == M68K_OP_REG) {
+		update_op_reg_list(info, &info->extension.operands[0], 0);
+		update_op_reg_list(info, &info->extension.operands[1], 0);
+		return;
+	}
 
 	if (info->extension.op_count == 1) {
 		update_op_reg_list(info, &info->extension.operands[0], 1);

--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -596,6 +596,16 @@ static cs_m68k *build_init_op(m68k_info *info, int opcode, int count, int size)
 	return ext;
 }
 
+static cs_m68k *build_init_fpu_condition_op(m68k_info *info, int base_opcode,
+					    uint32_t condition_word, int count,
+					    int size)
+{
+	cs_m68k *ext = build_init_op(info, base_opcode, count, size);
+	MCInst_setOpcode(info->inst, base_opcode + m68k_fpu_condition_index(
+							   condition_word));
+	return ext;
+}
+
 static void build_re_gen_1(m68k_info *info, bool isDreg, int opcode,
 			   uint8_t size)
 {
@@ -2654,19 +2664,14 @@ static void d68020_cpbcc_16(m68k_info *info)
 	cs_m68k *ext;
 	LIMIT_FEATURE(info, M68020_PLUS | CS_MODE_M68K_CF_FPU);
 	int cpid = M68K_CPID(info);
-	int cond = M68K_IR_CONDITION(info);
+	int cond = m68k_coprocessor_condition(info->ir);
 	if (cpid == M68K_CPID_MMU) {
 		if (cond >= M68K_PMMU_MAX_COND ||
 		    m68k_has_feature(info, CS_MODE_M68K_CPU32)) {
 			d68000_invalid(info);
 			return;
 		}
-	} else if (cpid == M68K_CPID_FPU) {
-		if (cond >= M68K_FPU_MAX_COND) {
-			d68000_invalid(info);
-			return;
-		}
-	} else {
+	} else if (cpid != M68K_CPID_FPU) {
 		d68000_invalid(info);
 		return;
 	}
@@ -2677,8 +2682,7 @@ static void d68020_cpbcc_16(m68k_info *info)
 		return;
 	}
 
-	ext = build_init_op(info, M68K_INS_FBF, 1, 2);
-	info->inst->Opcode += M68K_FP_COND(info->ir);
+	ext = build_init_fpu_condition_op(info, M68K_INS_FBF, info->ir, 1, 2);
 	op0 = &ext->operands[0];
 
 	make_cpbcc_operand(op0, M68K_OP_BR_DISP_SIZE_WORD,
@@ -2694,25 +2698,19 @@ static void d68020_cpbcc_32(m68k_info *info)
 	cs_m68k_op *op0;
 	LIMIT_FEATURE(info, M68020_PLUS | CS_MODE_M68K_CF_FPU);
 	int cpid = M68K_CPID(info);
-	int cond = M68K_IR_CONDITION(info);
+	int cond = m68k_coprocessor_condition(info->ir);
 	if (cpid == M68K_CPID_MMU) {
 		if (cond >= M68K_PMMU_MAX_COND ||
 		    m68k_has_feature(info, CS_MODE_M68K_CPU32)) {
 			d68000_invalid(info);
 			return;
 		}
-	} else if (cpid == M68K_CPID_FPU) {
-		if (cond >= M68K_FPU_MAX_COND) {
-			d68000_invalid(info);
-			return;
-		}
-	} else {
+	} else if (cpid != M68K_CPID_FPU) {
 		d68000_invalid(info);
 		return;
 	}
 
-	ext = build_init_op(info, M68K_INS_FBF, 1, 4);
-	info->inst->Opcode += M68K_FP_COND(info->ir);
+	ext = build_init_fpu_condition_op(info, M68K_INS_FBF, info->ir, 1, 4);
 	op0 = &ext->operands[0];
 
 	make_cpbcc_operand(op0, M68K_OP_BR_DISP_SIZE_LONG, read_imm_32(info));
@@ -2744,9 +2742,7 @@ static void d68020_cpdbcc(m68k_info *info)
 	ext1 = read_imm_16(info);
 	ext2 = read_imm_16(info);
 
-	info->inst->Opcode += M68K_FP_COND(ext1);
-
-	ext = build_init_op(info, M68K_INS_FDBF, 2, 0);
+	ext = build_init_fpu_condition_op(info, M68K_INS_FDBF, ext1, 2, 0);
 	op0 = &ext->operands[0];
 	op1 = &ext->operands[1];
 
@@ -3200,10 +3196,11 @@ static void d68040_ptest_or_cprestore(m68k_info *info)
 static void d68020_cpscc(m68k_info *info)
 {
 	cs_m68k *ext;
+	uint32_t condition;
 	LIMIT_FEATURE(info, M68020_PLUS | CS_MODE_M68K_CF_FPU);
 	REQUIRE_CPID_FPU(info);
-	ext = build_init_op(info, M68K_INS_FSF, 1, 1);
-	info->inst->Opcode += M68K_FP_COND(read_imm_16(info));
+	condition = read_imm_16(info);
+	ext = build_init_fpu_condition_op(info, M68K_INS_FSF, condition, 1, 1);
 
 	if (!get_ea_mode_op(info, &ext->operands[0], info->ir, 1)) {
 		invalid_insn(info);
@@ -3219,8 +3216,7 @@ static void d68020_cptrapcc_0(m68k_info *info)
 
 	extension1 = read_imm_16(info);
 
-	build_init_op(info, M68K_INS_FTRAPF, 0, 0);
-	info->inst->Opcode += M68K_FP_COND(extension1);
+	build_init_fpu_condition_op(info, M68K_INS_FTRAPF, extension1, 0, 0);
 }
 
 static void d68020_cptrapcc_16(m68k_info *info)
@@ -3234,8 +3230,8 @@ static void d68020_cptrapcc_16(m68k_info *info)
 	extension1 = read_imm_16(info);
 	extension2 = read_imm_16(info);
 
-	ext = build_init_op(info, M68K_INS_FTRAPF, 1, 2);
-	info->inst->Opcode += M68K_FP_COND(extension1);
+	ext = build_init_fpu_condition_op(info, M68K_INS_FTRAPF, extension1, 1,
+					  2);
 
 	op0 = &ext->operands[0];
 
@@ -3255,8 +3251,8 @@ static void d68020_cptrapcc_32(m68k_info *info)
 	extension1 = read_imm_16(info);
 	extension2 = read_imm_32(info);
 
-	ext = build_init_op(info, M68K_INS_FTRAPF, 1, 2);
-	info->inst->Opcode += M68K_FP_COND(extension1);
+	ext = build_init_fpu_condition_op(info, M68K_INS_FTRAPF, extension1, 1,
+					  2);
 
 	op0 = &ext->operands[0];
 

--- a/arch/M68K/M68KDisassembler.h
+++ b/arch/M68K/M68KDisassembler.h
@@ -174,6 +174,45 @@ static inline uint32_t m68k_coprocessor_condition(uint32_t word)
 /* Direction bit for FMOVE FPCR (bit 13): 0 = ea->fpcr, 1 = fpcr->ea. */
 #define M68K_FEXT_DIR(ext) (((ext) >> 13) & 1)
 
+/* FMOVEM register-list encoding.
+ *
+ * Bits 12:11 select static/dynamic and predecrement versus
+ * postincrement-or-control forms. A static list occupies bits 7:0; a dynamic
+ * list has the reserved-bit format 0rrr0000, with Dn in bits 6:4.
+ *
+ * Reference: Motorola MC68881/MC68882 Floating-Point Coprocessor User's
+ * Manual, first edition (1987), section 4.7.1.6, Table 4-18, pages 4-126
+ * through 4-128:
+ * https://www.bitsavers.org/components/motorola/68000/68020/MC68881_MC68882_Floating-Point_Coprocessor_Users_Manual_1ed_1987.pdf
+ */
+typedef enum {
+	M68K_FMOVEM_MODE_STATIC_PREDECREMENT = 0,
+	M68K_FMOVEM_MODE_DYNAMIC_PREDECREMENT = 1,
+	M68K_FMOVEM_MODE_STATIC_POSTINCREMENT_OR_CONTROL = 2,
+	M68K_FMOVEM_MODE_DYNAMIC_POSTINCREMENT_OR_CONTROL = 3,
+} m68k_fmovem_mode;
+
+static inline m68k_fmovem_mode m68k_fmovem_get_mode(uint32_t extension)
+{
+	return (m68k_fmovem_mode)BITFIELD(extension, 12, 11);
+}
+
+static inline uint32_t m68k_fmovem_register_list(uint32_t extension)
+{
+	return BITFIELD(extension, 7, 0);
+}
+
+static inline bool
+m68k_fmovem_dynamic_reserved_bits_are_zero(uint32_t extension)
+{
+	return BITFIELD(extension, 7, 7) == 0 && BITFIELD(extension, 3, 0) == 0;
+}
+
+static inline uint32_t m68k_fmovem_dynamic_register(uint32_t extension)
+{
+	return BITFIELD(extension, 6, 4);
+}
+
 /* ── FPU condition-code mask ─────────────────────────────────────────
  * The FPU defines predicates 0xxxxx; 1xxxxx encodings are reserved
  * aliases that evaluate identically. Use the low five bits to index the

--- a/arch/M68K/M68KDisassembler.h
+++ b/arch/M68K/M68KDisassembler.h
@@ -117,8 +117,19 @@ typedef uint32_t m68k_feature_mask;
 /* ── IR bit-field helpers ────────────────────────────────────────────
  * Extract commonly-used fields from the first instruction word.      */
 
-/* 6-bit coprocessor condition (bits 5:0 of IR). */
-#define M68K_IR_CONDITION(info) ((info)->ir & 0x3f)
+/* Coprocessor conditional predicate field (bits 5:0).
+ *
+ * Reference: Motorola MC68881/MC68882 Floating-Point Coprocessor User's
+ * Manual, first edition (1987), sections 4.7.2-4.7.3, Tables 4-20 and
+ * 4-22, pages 4-129 through 4-134. A reference copy is available at:
+ * https://www.bitsavers.org/components/motorola/68000/68020/MC68881_MC68882_Floating-Point_Coprocessor_Users_Manual_1ed_1987.pdf
+ */
+#define M68K_COPROCESSOR_CONDITION_MASK 0x3f
+
+static inline uint32_t m68k_coprocessor_condition(uint32_t word)
+{
+	return word & M68K_COPROCESSOR_CONDITION_MASK;
+}
 
 /* 4-bit condition selector used by Bcc/DBcc/Scc/TRAPcc. */
 #define M68K_IR_CONDITION_NIBBLE(info) (((info)->ir >> 8) & 0xf)
@@ -164,14 +175,19 @@ typedef uint32_t m68k_feature_mask;
 #define M68K_FEXT_DIR(ext) (((ext) >> 13) & 1)
 
 /* ── FPU condition-code mask ─────────────────────────────────────────
- * FBcc/FDBcc/FScc/FTRAPcc encode the FP condition in bits 5,3:0
- * of the extension word (or IR for FBcc).  Bit 4 is always 0,
- * yielding the 0x2f mask.                                            */
-#define M68K_FP_COND(x) ((x) & 0x2f)
+ * The FPU defines predicates 0xxxxx; 1xxxxx encodings are reserved
+ * aliases that evaluate identically. Use the low five bits to index the
+ * contiguous FBcc/FDBcc/FScc/FTRAPcc opcode ranges. See the manual
+ * reference above.                                                   */
+#define M68K_FPU_CONDITION_INDEX_MASK 0x1f
+
+static inline uint32_t m68k_fpu_condition_index(uint32_t word)
+{
+	return word & M68K_FPU_CONDITION_INDEX_MASK;
+}
 
 /* Maximum valid condition codes per coprocessor. */
 #define M68K_PMMU_MAX_COND 16
-#define M68K_FPU_MAX_COND 32
 
 /* ── FPU source-format constants (bits 12:10 of ext word) ───────────*/
 #define M68K_FPSRC_LONG 0x00 /* .l  -- 32-bit integer            */

--- a/tests/details/m68k.yaml
+++ b/tests/details/m68k.yaml
@@ -2792,6 +2792,17 @@ test_cases:
     expected:
       insns:
         - asm_text: "fbf.l $2"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_fpu: M68K_FPU_SIZE_SINGLE
+              op_size_cpu: M68K_CPU_SIZE_LONG
+              operands:
+                - type: M68K_OP_BR_DISP
+                  address_mode: M68K_AM_BRANCH_DISPLACEMENT
+                  br_disp: 0
+                  br_disp_size: 4
+            groups: [jump, branch_relative]
 
   # cpbcc CpID=0 condition >= 16 should be invalid
   - input:
@@ -3915,48 +3926,21 @@ test_cases:
             regs_write: [d0]
             regs_impl_read: [fpiar]
             regs_impl_write: [d0]
+  # Static predecrement lists reject memory-to-register and non-predecrement EAs.
   - input:
       bytes: [0xf2, 0x10, 0xc0, 0x03]
       arch: "m68k"
       options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
       address: 0x0
     expected:
-      insns:
-        - asm_text: "fmovem (a0), fp0-fp1"
-          details:
-            m68k:
-              op_size_type: M68K_SIZE_TYPE_CPU
-              operands:
-                - type: M68K_OP_MEM
-                  mem:
-                    base_reg: a0
-                  address_mode: M68K_AM_REGI_ADDR
-                - type: M68K_OP_REG_BITS
-                  register_bits: 196608
-            regs_read: [a0]
-            regs_write: [fp0, fp1]
-            regs_impl_read: [a0]
-            regs_impl_write: [fp0, fp1]
+      insns: []
   - input:
       bytes: [0xf2, 0x10, 0xe0, 0x03]
       arch: "m68k"
       options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
       address: 0x0
     expected:
-      insns:
-        - asm_text: "fmovem fp0-fp1, (a0)"
-          details:
-            m68k:
-              op_size_type: M68K_SIZE_TYPE_CPU
-              operands:
-                - type: M68K_OP_REG_BITS
-                  register_bits: 196608
-                - type: M68K_OP_MEM
-                  mem:
-                    base_reg: a0
-                  address_mode: M68K_AM_REGI_ADDR
-            regs_read: [fp0, fp1, a0]
-            regs_impl_read: [fp0, fp1, a0]
+      insns: []
   - input:
       bytes: [0xf2, 0x18, 0xd0, 0x03]
       arch: "m68k"
@@ -3999,6 +3983,96 @@ test_cases:
             regs_write: [a0]
             regs_impl_read: [fp0, fp1]
             regs_impl_write: [a0]
+
+  # Static postincrement/control lists accept control EAs in both directions.
+  - input:
+      bytes: [0xf2, 0x10, 0xd0, 0x03]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem (a0), fp6-fp7"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              operands:
+                - type: M68K_OP_MEM
+                  mem:
+                    base_reg: a0
+                  address_mode: M68K_AM_REGI_ADDR
+                - type: M68K_OP_REG_BITS
+                  register_bits: 12582912
+            regs_read: [a0]
+            regs_write: [fp6, fp7]
+            regs_impl_read: [a0]
+            regs_impl_write: [fp6, fp7]
+  - input:
+      bytes: [0xf2, 0x10, 0xf0, 0x03]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem fp6-fp7, (a0)"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              operands:
+                - type: M68K_OP_REG_BITS
+                  register_bits: 12582912
+                - type: M68K_OP_MEM
+                  mem:
+                    base_reg: a0
+                  address_mode: M68K_AM_REGI_ADDR
+            regs_read: [fp6, fp7, a0]
+            regs_impl_read: [fp6, fp7, a0]
+
+  # PC-relative is control but not alterable control.
+  - input:
+      bytes: [0xf2, 0x3a, 0xd0, 0x03, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem $4(pc), fp6-fp7"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              operands:
+                - type: M68K_OP_MEM
+                  mem:
+                    disp: 2
+                  address_mode: M68K_AM_PCI_DISP
+                - type: M68K_OP_REG_BITS
+                  register_bits: 12582912
+            regs_write: [fp6, fp7]
+            regs_impl_write: [fp6, fp7]
+  - input:
+      bytes: [0xf2, 0x3a, 0xf0, 0x03, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns: []
+
+  # Static postincrement/control lists reject the opposite update mode.
+  - input:
+      bytes: [0xf2, 0x20, 0xd0, 0x03]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns: []
+  - input:
+      bytes: [0xf2, 0x18, 0xf0, 0x03]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns: []
+
   - input:
       bytes: [0xf2, 0x10, 0xd8, 0x10]
       arch: "m68k"
@@ -4089,48 +4163,108 @@ test_cases:
       options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
       address: 0x0
     expected:
-      insns:
-        - asm_text: "fmovem invalid, (a0)"
+      insns: []
   - input:
       bytes: [0xf2, 0x10, 0xf8, 0x11]
       arch: "m68k"
       options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
       address: 0x0
     expected:
-      insns:
-        - asm_text: "fmovem invalid, (a0)"
+      insns: []
+  - input:
+      bytes: [0xf2, 0x10, 0xd8, 0x90]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns: []
+  - input:
+      bytes: [0xf2, 0x10, 0xd8, 0x11]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns: []
+  - input:
+      bytes: [0xf2, 0x20, 0xe8, 0x90]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns: []
+
+  # Bits 10:8 are fixed to zero for every FMOVEM command word.
+  - input:
+      bytes: [0xf2, 0x10, 0xd1, 0x03]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns: []
+  - input:
+      bytes: [0xf2, 0x10, 0xd9, 0x10]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns: []
+
+  - input:
+      bytes: [0xf2, 0x00, 0xf8, 0x10]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns: []
+  - input:
+      bytes: [0xf2, 0x08, 0xf8, 0x10]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns: []
+  - input:
+      bytes: [0xf2, 0x00, 0xd0, 0x03]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns: []
+  - input:
+      bytes: [0xf2, 0x3c, 0xd0, 0x03]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns: []
   - input:
       bytes: [0xf2, 0x20, 0xc8, 0x10]
       arch: "m68k"
       options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
       address: 0x0
     expected:
-      insns:
-        - asm_text: "fmovem -(a0), invalid"
+      insns: []
   - input:
       bytes: [0xf2, 0x10, 0xe8, 0x10]
       arch: "m68k"
       options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
       address: 0x0
     expected:
-      insns:
-        - asm_text: "fmovem invalid, (a0)"
+      insns: []
   - input:
       bytes: [0xf2, 0x18, 0xf8, 0x10]
       arch: "m68k"
       options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
       address: 0x0
     expected:
-      insns:
-        - asm_text: "fmovem invalid, (a0)+"
+      insns: []
   - input:
       bytes: [0xf2, 0x20, 0xd8, 0x10]
       arch: "m68k"
       options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
       address: 0x0
     expected:
-      insns:
-        - asm_text: "fmovem -(a0), invalid"
+      insns: []
   - input:
       bytes: [0xf2, 0x3a, 0xd8, 0x10, 0x00, 0x00]
       arch: "m68k"
@@ -4139,14 +4273,25 @@ test_cases:
     expected:
       insns:
         - asm_text: "fmovem $4(pc), d1"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              operands:
+                - type: M68K_OP_MEM
+                  mem:
+                    disp: 2
+                  address_mode: M68K_AM_PCI_DISP
+                - type: M68K_OP_REG
+                  reg: d1
+            regs_read: [d1]
+            regs_impl_read: [d1]
   - input:
       bytes: [0xf2, 0x3a, 0xf8, 0x10, 0x00, 0x00]
       arch: "m68k"
       options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
       address: 0x0
     expected:
-      insns:
-        - asm_text: "fmovem invalid, $4(pc)"
+      insns: []
   - input:
       bytes: [0x20, 0x00]
       arch: "m68k"
@@ -4537,11 +4682,11 @@ test_cases:
       address: 0x0
     expected:
       insns:
-        - asm_text: "ftrapf.w #$12345678"
+        - asm_text: "ftrapf.l #$12345678"
           details:
             m68k:
               op_size_type: M68K_SIZE_TYPE_CPU
-              op_size_cpu: M68K_CPU_SIZE_WORD
+              op_size_cpu: M68K_CPU_SIZE_LONG
               operands:
                 - type: M68K_OP_IMM
                   address_mode: M68K_AM_IMMEDIATE
@@ -4556,6 +4701,16 @@ test_cases:
     expected:
       insns:
         - asm_text: fbsf.w $2
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_cpu: M68K_CPU_SIZE_WORD
+              operands:
+                - type: M68K_OP_BR_DISP
+                  address_mode: M68K_AM_BRANCH_DISPLACEMENT
+                  br_disp: 0
+                  br_disp_size: 2
+            groups: [jump, branch_relative]
   - input:
       bytes: [0xf2, 0x94, 0x00, 0x00]
       arch: "m68k"
@@ -4564,6 +4719,16 @@ test_cases:
     expected:
       insns:
         - asm_text: fblt.w $2
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_cpu: M68K_CPU_SIZE_WORD
+              operands:
+                - type: M68K_OP_BR_DISP
+                  address_mode: M68K_AM_BRANCH_DISPLACEMENT
+                  br_disp: 0
+                  br_disp_size: 2
+            groups: [jump, branch_relative]
   - input:
       bytes: [0xf2, 0x98, 0x00, 0x00]
       arch: "m68k"
@@ -4572,6 +4737,16 @@ test_cases:
     expected:
       insns:
         - asm_text: fbngle.w $2
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_cpu: M68K_CPU_SIZE_WORD
+              operands:
+                - type: M68K_OP_BR_DISP
+                  address_mode: M68K_AM_BRANCH_DISPLACEMENT
+                  br_disp: 0
+                  br_disp_size: 2
+            groups: [jump, branch_relative]
   - input:
       bytes: [0xf2, 0x9c, 0x00, 0x00]
       arch: "m68k"
@@ -4580,6 +4755,16 @@ test_cases:
     expected:
       insns:
         - asm_text: fbnge.w $2
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_cpu: M68K_CPU_SIZE_WORD
+              operands:
+                - type: M68K_OP_BR_DISP
+                  address_mode: M68K_AM_BRANCH_DISPLACEMENT
+                  br_disp: 0
+                  br_disp_size: 2
+            groups: [jump, branch_relative]
   - input:
       bytes: [0xf2, 0x48, 0x00, 0x11, 0x00, 0x00]
       arch: "m68k"
@@ -4588,6 +4773,19 @@ test_cases:
     expected:
       insns:
         - asm_text: "fdbseq d0, $4"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              operands:
+                - type: M68K_OP_REG
+                  reg: d0
+                - type: M68K_OP_BR_DISP
+                  address_mode: M68K_AM_BRANCH_DISPLACEMENT
+                  br_disp: 2
+                  br_disp_size: 2
+            groups: [jump, branch_relative]
+            regs_read: [d0]
+            regs_impl_read: [d0]
   - input:
       bytes: [0xf2, 0x48, 0x00, 0x15, 0x00, 0x00]
       arch: "m68k"
@@ -4596,6 +4794,19 @@ test_cases:
     expected:
       insns:
         - asm_text: "fdble d0, $4"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              operands:
+                - type: M68K_OP_REG
+                  reg: d0
+                - type: M68K_OP_BR_DISP
+                  address_mode: M68K_AM_BRANCH_DISPLACEMENT
+                  br_disp: 2
+                  br_disp_size: 2
+            groups: [jump, branch_relative]
+            regs_read: [d0]
+            regs_impl_read: [d0]
   - input:
       bytes: [0xf2, 0x48, 0x00, 0x19, 0x00, 0x00]
       arch: "m68k"
@@ -4604,6 +4815,19 @@ test_cases:
     expected:
       insns:
         - asm_text: "fdbngl d0, $4"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              operands:
+                - type: M68K_OP_REG
+                  reg: d0
+                - type: M68K_OP_BR_DISP
+                  address_mode: M68K_AM_BRANCH_DISPLACEMENT
+                  br_disp: 2
+                  br_disp_size: 2
+            groups: [jump, branch_relative]
+            regs_read: [d0]
+            regs_impl_read: [d0]
   - input:
       bytes: [0xf2, 0x48, 0x00, 0x1d, 0x00, 0x00]
       arch: "m68k"
@@ -4612,6 +4836,19 @@ test_cases:
     expected:
       insns:
         - asm_text: "fdbngt d0, $4"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              operands:
+                - type: M68K_OP_REG
+                  reg: d0
+                - type: M68K_OP_BR_DISP
+                  address_mode: M68K_AM_BRANCH_DISPLACEMENT
+                  br_disp: 2
+                  br_disp_size: 2
+            groups: [jump, branch_relative]
+            regs_read: [d0]
+            regs_impl_read: [d0]
   - input:
       bytes: [0xf2, 0x40, 0x00, 0x12]
       arch: "m68k"
@@ -4620,6 +4857,16 @@ test_cases:
     expected:
       insns:
         - asm_text: fsgt.b d0
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_cpu: M68K_CPU_SIZE_BYTE
+              operands:
+                - type: M68K_OP_REG
+                  address_mode: M68K_AM_REG_DIRECT_DATA
+                  reg: d0
+            regs_write: [d0]
+            regs_impl_write: [d0]
   - input:
       bytes: [0xf2, 0x40, 0x00, 0x16]
       arch: "m68k"
@@ -4628,6 +4875,16 @@ test_cases:
     expected:
       insns:
         - asm_text: fsgl.b d0
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_cpu: M68K_CPU_SIZE_BYTE
+              operands:
+                - type: M68K_OP_REG
+                  address_mode: M68K_AM_REG_DIRECT_DATA
+                  reg: d0
+            regs_write: [d0]
+            regs_impl_write: [d0]
   - input:
       bytes: [0xf2, 0x40, 0x00, 0x1a]
       arch: "m68k"
@@ -4636,6 +4893,16 @@ test_cases:
     expected:
       insns:
         - asm_text: fsnle.b d0
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_cpu: M68K_CPU_SIZE_BYTE
+              operands:
+                - type: M68K_OP_REG
+                  address_mode: M68K_AM_REG_DIRECT_DATA
+                  reg: d0
+            regs_write: [d0]
+            regs_impl_write: [d0]
   - input:
       bytes: [0xf2, 0x40, 0x00, 0x1e]
       arch: "m68k"
@@ -4644,6 +4911,16 @@ test_cases:
     expected:
       insns:
         - asm_text: fssne.b d0
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_cpu: M68K_CPU_SIZE_BYTE
+              operands:
+                - type: M68K_OP_REG
+                  address_mode: M68K_AM_REG_DIRECT_DATA
+                  reg: d0
+            regs_write: [d0]
+            regs_impl_write: [d0]
   - input:
       bytes: [0xf2, 0x7c, 0x00, 0x13]
       arch: "m68k"
@@ -4652,6 +4929,9 @@ test_cases:
     expected:
       insns:
         - asm_text: ftrapge
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
   - input:
       bytes: [0xf2, 0x7c, 0x00, 0x17]
       arch: "m68k"
@@ -4660,6 +4940,9 @@ test_cases:
     expected:
       insns:
         - asm_text: ftrapgle
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
   - input:
       bytes: [0xf2, 0x7c, 0x00, 0x1b]
       arch: "m68k"
@@ -4668,6 +4951,9 @@ test_cases:
     expected:
       insns:
         - asm_text: ftrapnlt
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
   - input:
       bytes: [0xf2, 0x7c, 0x00, 0x1f]
       arch: "m68k"
@@ -4676,6 +4962,9 @@ test_cases:
     expected:
       insns:
         - asm_text: ftrapst
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
 
   # Reserved 1xxxxx predicates are aliases of the corresponding 0xxxxx.
   - input:
@@ -4686,6 +4975,34 @@ test_cases:
     expected:
       insns:
         - asm_text: fbsf.w $2
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_cpu: M68K_CPU_SIZE_WORD
+              operands:
+                - type: M68K_OP_BR_DISP
+                  address_mode: M68K_AM_BRANCH_DISPLACEMENT
+                  br_disp: 0
+                  br_disp_size: 2
+            groups: [jump, branch_relative]
+  - input:
+      bytes: [0xf2, 0xf0, 0x00, 0x00, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: fbsf.l $2
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_cpu: M68K_CPU_SIZE_LONG
+              operands:
+                - type: M68K_OP_BR_DISP
+                  address_mode: M68K_AM_BRANCH_DISPLACEMENT
+                  br_disp: 0
+                  br_disp_size: 4
+            groups: [jump, branch_relative]
   - input:
       bytes: [0xf2, 0x48, 0x00, 0x31, 0x00, 0x00]
       arch: "m68k"
@@ -4694,6 +5011,19 @@ test_cases:
     expected:
       insns:
         - asm_text: "fdbseq d0, $4"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              operands:
+                - type: M68K_OP_REG
+                  reg: d0
+                - type: M68K_OP_BR_DISP
+                  address_mode: M68K_AM_BRANCH_DISPLACEMENT
+                  br_disp: 2
+                  br_disp_size: 2
+            groups: [jump, branch_relative]
+            regs_read: [d0]
+            regs_impl_read: [d0]
   - input:
       bytes: [0xf2, 0x40, 0x00, 0x32]
       arch: "m68k"
@@ -4702,6 +5032,16 @@ test_cases:
     expected:
       insns:
         - asm_text: fsgt.b d0
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_cpu: M68K_CPU_SIZE_BYTE
+              operands:
+                - type: M68K_OP_REG
+                  address_mode: M68K_AM_REG_DIRECT_DATA
+                  reg: d0
+            regs_write: [d0]
+            regs_impl_write: [d0]
   - input:
       bytes: [0xf2, 0x7c, 0x00, 0x33]
       arch: "m68k"
@@ -4710,6 +5050,25 @@ test_cases:
     expected:
       insns:
         - asm_text: ftrapge
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+  - input:
+      bytes: [0xf2, 0x7b, 0x00, 0x33, 0x12, 0x34, 0x56, 0x78]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "ftrapge.l #$12345678"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              op_size_cpu: M68K_CPU_SIZE_LONG
+              operands:
+                - type: M68K_OP_IMM
+                  address_mode: M68K_AM_IMMEDIATE
+                  imm: 0x12345678
   - input:
       bytes: [0xf2, 0x00, 0x05, 0x3a]
       arch: "m68k"

--- a/tests/details/m68k.yaml
+++ b/tests/details/m68k.yaml
@@ -4000,7 +4000,7 @@ test_cases:
             regs_impl_read: [fp0, fp1]
             regs_impl_write: [a0]
   - input:
-      bytes: [0xf2, 0x10, 0xc8, 0x10]
+      bytes: [0xf2, 0x10, 0xd8, 0x10]
       arch: "m68k"
       options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
       address: 0x0
@@ -4017,10 +4017,136 @@ test_cases:
                   address_mode: M68K_AM_REGI_ADDR
                 - type: M68K_OP_REG
                   reg: d1
-            regs_read: [a0]
-            regs_write: [d1]
-            regs_impl_read: [a0]
-            regs_impl_write: [d1]
+            regs_read: [a0, d1]
+            regs_impl_read: [a0, d1]
+  - input:
+      bytes: [0xf2, 0x10, 0xf8, 0x10]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem d1, (a0)"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              operands:
+                - type: M68K_OP_REG
+                  reg: d1
+                - type: M68K_OP_MEM
+                  mem:
+                    base_reg: a0
+                  address_mode: M68K_AM_REGI_ADDR
+            regs_read: [d1, a0]
+            regs_impl_read: [d1, a0]
+  - input:
+      bytes: [0xf2, 0x18, 0xd8, 0x10]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem (a0)+, d1"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              operands:
+                - type: M68K_OP_MEM
+                  mem:
+                    base_reg: a0
+                  address_mode: M68K_AM_REGI_ADDR_POST_INC
+                - type: M68K_OP_REG
+                  reg: d1
+            regs_read: [d1]
+            regs_write: [a0]
+            regs_impl_read: [d1]
+            regs_impl_write: [a0]
+  - input:
+      bytes: [0xf2, 0x20, 0xe8, 0x10]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem d1, -(a0)"
+          details:
+            m68k:
+              op_size_type: M68K_SIZE_TYPE_CPU
+              operands:
+                - type: M68K_OP_REG
+                  reg: d1
+                - type: M68K_OP_MEM
+                  mem:
+                    base_reg: a0
+                  address_mode: M68K_AM_REGI_ADDR_PRE_DEC
+            regs_read: [d1]
+            regs_write: [a0]
+            regs_impl_read: [d1]
+            regs_impl_write: [a0]
+  - input:
+      bytes: [0xf2, 0x10, 0xf8, 0x90]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem invalid, (a0)"
+  - input:
+      bytes: [0xf2, 0x10, 0xf8, 0x11]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem invalid, (a0)"
+  - input:
+      bytes: [0xf2, 0x20, 0xc8, 0x10]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem -(a0), invalid"
+  - input:
+      bytes: [0xf2, 0x10, 0xe8, 0x10]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem invalid, (a0)"
+  - input:
+      bytes: [0xf2, 0x18, 0xf8, 0x10]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem invalid, (a0)+"
+  - input:
+      bytes: [0xf2, 0x20, 0xd8, 0x10]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem -(a0), invalid"
+  - input:
+      bytes: [0xf2, 0x3a, 0xd8, 0x10, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem $4(pc), d1"
+  - input:
+      bytes: [0xf2, 0x3a, 0xf8, 0x10, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fmovem invalid, $4(pc)"
   - input:
       bytes: [0x20, 0x00]
       arch: "m68k"

--- a/tests/details/m68k.yaml
+++ b/tests/details/m68k.yaml
@@ -2783,15 +2783,15 @@ test_cases:
             regs_impl_read: [fp0]
             regs_impl_write: [fp0]
 
-  # cpbcc CpID=1 condition >= 32 should be invalid
+  # FPU cpbcc 1xxxxx predicates alias the corresponding 0xxxxx predicate.
   - input:
-      bytes: [0xf2, 0xe0]
+      bytes: [0xf2, 0xe0, 0x00, 0x00, 0x00, 0x00]
       arch: "m68k"
       options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_020]
       address: 0x0
     expected:
       insns:
-        - asm_text: "dc.w $f2e0"
+        - asm_text: "fbf.l $2"
 
   # cpbcc CpID=0 condition >= 16 should be invalid
   - input:
@@ -4420,6 +4420,170 @@ test_cases:
                 - type: M68K_OP_IMM
                   address_mode: M68K_AM_IMMEDIATE
                   imm: 0x12345678
+
+  # MC68881/MC68882 signaling/IEEE-aware condition predicates 0x10-0x1f.
+  - input:
+      bytes: [0xf2, 0x90, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: fbsf.w $2
+  - input:
+      bytes: [0xf2, 0x94, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: fblt.w $2
+  - input:
+      bytes: [0xf2, 0x98, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: fbngle.w $2
+  - input:
+      bytes: [0xf2, 0x9c, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: fbnge.w $2
+  - input:
+      bytes: [0xf2, 0x48, 0x00, 0x11, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fdbseq d0, $4"
+  - input:
+      bytes: [0xf2, 0x48, 0x00, 0x15, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fdble d0, $4"
+  - input:
+      bytes: [0xf2, 0x48, 0x00, 0x19, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fdbngl d0, $4"
+  - input:
+      bytes: [0xf2, 0x48, 0x00, 0x1d, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fdbngt d0, $4"
+  - input:
+      bytes: [0xf2, 0x40, 0x00, 0x12]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: fsgt.b d0
+  - input:
+      bytes: [0xf2, 0x40, 0x00, 0x16]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: fsgl.b d0
+  - input:
+      bytes: [0xf2, 0x40, 0x00, 0x1a]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: fsnle.b d0
+  - input:
+      bytes: [0xf2, 0x40, 0x00, 0x1e]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: fssne.b d0
+  - input:
+      bytes: [0xf2, 0x7c, 0x00, 0x13]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: ftrapge
+  - input:
+      bytes: [0xf2, 0x7c, 0x00, 0x17]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: ftrapgle
+  - input:
+      bytes: [0xf2, 0x7c, 0x00, 0x1b]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: ftrapnlt
+  - input:
+      bytes: [0xf2, 0x7c, 0x00, 0x1f]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: ftrapst
+
+  # Reserved 1xxxxx predicates are aliases of the corresponding 0xxxxx.
+  - input:
+      bytes: [0xf2, 0xb0, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: fbsf.w $2
+  - input:
+      bytes: [0xf2, 0x48, 0x00, 0x31, 0x00, 0x00]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "fdbseq d0, $4"
+  - input:
+      bytes: [0xf2, 0x40, 0x00, 0x32]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: fsgt.b d0
+  - input:
+      bytes: [0xf2, 0x7c, 0x00, 0x33]
+      arch: "m68k"
+      options: [CS_OPT_DETAIL, CS_MODE_BIG_ENDIAN, CS_MODE_M68K_CF_FPU]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: ftrapge
   - input:
       bytes: [0xf2, 0x00, 0x05, 0x3a]
       arch: "m68k"


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

### Fix M68K floating-point decoding according to the MC68881/MC68882 manual:
Decode signaling FPU predicates and 1xxxxx predicate aliases correctly.
Validate FMOVEM direction, register-list mode, effective address, and reserved bits.
Reject invalid FMOVEM encodings instead of printing operands such as invalid.
Correct dynamic register-list access details and expand regression coverage.

- Signaling predicate:
Before: f2 90 00 00 → fbf.w $2
After: f2 90 00 00 → fbsf.w $2

- Reserved predicate alias:
Before: f2 e0 00 00 00 00 → rejected
After: f2 e0 00 00 00 00 → fbf.l $2

- Invalid FMOVEM:
Before: f2 3a f8 10 00 00 → fmovem invalid, $4(pc)
After: the encoding is rejected


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
