### PR TITLE
AArch64: enh Add option for explicit shifted wide immediates

### DIFF
--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -492,7 +492,13 @@ void printInst(MCInst *MI, uint64_t Address, const char *Annot, SStream *O)
 			(uint64_t)MCOperand_getImm(MCInst_getOperand(MI, (1)))
 			<< Shift;
 
-		if (AArch64_AM_isMOVZMovAlias(
+		bool SuppressMovAlias =
+			(MI->csh->syntax &
+			 CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM) &&
+			Shift != 0;
+
+		if (!SuppressMovAlias &&
+		    AArch64_AM_isMOVZMovAlias(
 			    Value, Shift, Opcode == AArch64_MOVZXi ? 64 : 32)) {
 			isAlias = true;
 			MCInst_setIsAlias(MI, isAlias);
@@ -525,7 +531,13 @@ void printInst(MCInst *MI, uint64_t Address, const char *Annot, SStream *O)
 		if (RegWidth == 32)
 			Value = Value & 0xffffffff;
 
-		if (AArch64_AM_isMOVNMovAlias(Value, Shift, RegWidth)) {
+		bool SuppressMovAlias =
+			(MI->csh->syntax &
+			 CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM) &&
+			Shift != 0;
+
+		if (!SuppressMovAlias &&
+		    AArch64_AM_isMOVNMovAlias(Value, Shift, RegWidth)) {
 			isAlias = true;
 			MCInst_setIsAlias(MI, isAlias);
 			SStream_concat0(O, "mov ");

--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -227,6 +227,7 @@ __all__ = [
     "CS_OPT_SYNTAX_NO_DOLLAR",
     "CS_OPT_SYNTAX_NO_ALIAS_TEXT",
     "CS_OPT_SYNTAX_NO_ALIAS_TEXT_COMPRESSED",
+    "CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM",
     "CS_OPT_DETAIL",
     "CS_OPT_DETAIL_REAL",
     "CS_OPT_MODE",
@@ -646,6 +647,9 @@ CS_OPT_SYNTAX_NO_ALIAS_TEXT = (
 CS_OPT_SYNTAX_NO_ALIAS_TEXT_COMPRESSED = (
     1 << 11
 )  # Like the one above it, but only supresses compressed instruction aliases
+CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM = (
+    1 << 12
+)  # Prints shifted AArch64 MOVN and MOVZ instructions without MOV aliases
 CS_OPT_DETAIL_REAL = (
     1 << 1
 )  # If enabled, always sets the real instruction detail.Even if the instruction is an alias.

--- a/bindings/python/cstest_py/src/cstest_py/cs_modes.py
+++ b/bindings/python/cstest_py/src/cstest_py/cs_modes.py
@@ -49,5 +49,9 @@ configs = {
     "CS_OPT_SYNTAX_NO_ALIAS_TEXT_COMPRESSED": {
         "type": cs.CS_OPT_SYNTAX,
         "val": cs.CS_OPT_SYNTAX_NO_ALIAS_TEXT_COMPRESSED
+    },
+    "CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM": {
+        "type": cs.CS_OPT_SYNTAX,
+        "val": cs.CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM
     }
 }

--- a/cstool/cstool.c
+++ b/cstool/cstool.c
@@ -76,6 +76,11 @@ static struct {
 	  { CS_ARCH_RISCV, CS_ARCH_MAX },
 	  CS_OPT_SYNTAX_NO_ALIAS_TEXT_COMPRESSED,
 	  0 },
+	{ "+explicitwideimm",
+	  "Prints shifted MOVN and MOVZ instructions without MOV aliases",
+	  { CS_ARCH_AARCH64, CS_ARCH_MAX },
+	  CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM,
+	  0 },
 	// cs_mode only
 	{ "+nofloat",
 	  "Disables floating point support",

--- a/docs/cs_v6_release_guide.md
+++ b/docs/cs_v6_release_guide.md
@@ -120,6 +120,9 @@ Nonetheless, we hope this additional information is useful to you.
 - Adding new instructions of SME, SVE2 extensions. With it the new `sme` and `pred` operands are added.
 - System operands are provided with way more detail in separated operand.
 	- The `EXACTFPIMM` operand also sets the `fp` field.
+- Added `CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM` to print shifted `MOVN` and `MOVZ` instructions in their explicit form, including the `lsl` shift, instead of the equivalent `MOV` alias.
+  - The default output remains unchanged and matches LLVM's default disassembly output.
+  - The corresponding `cstool` option is `+explicitwideimm`.
 
 **PPC**
 

--- a/include/capstone/capstone.h
+++ b/include/capstone/capstone.h
@@ -415,6 +415,9 @@ typedef enum cs_opt_value {
 	CS_OPT_SYNTAX_NO_ALIAS_TEXT_COMPRESSED =
 		1
 		<< 11, ///< Does not print an instruction's alias test if the instruction is an alias
+	CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM =
+		1
+		<< 12, ///< Prints shifted AArch64 MOVN and MOVZ instructions without MOV aliases
 	CS_OPT_DETAIL_REAL =
 		1
 		<< 1, ///< If enabled, always sets the real instruction detail. Even if the instruction is an alias.

--- a/suite/cstest/include/test_mapping.h
+++ b/suite/cstest/include/test_mapping.h
@@ -293,7 +293,10 @@ static const TestOptionMapEntry test_option_map[] = {
 		   .val = CS_OPT_SYNTAX_NO_ALIAS_TEXT } },
 	{ .str = "CS_OPT_SYNTAX_NO_ALIAS_TEXT_COMPRESSED",
 	  .opt = { .type = CS_OPT_SYNTAX,
-		   .val = CS_OPT_SYNTAX_NO_ALIAS_TEXT_COMPRESSED } }
+		   .val = CS_OPT_SYNTAX_NO_ALIAS_TEXT_COMPRESSED } },
+	{ .str = "CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM",
+	  .opt = { .type = CS_OPT_SYNTAX,
+		   .val = CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM } },
 };
 
 static const cs_enum_id_map cs_enum_map[] = {

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6734,3 +6734,128 @@ test_cases:
       -
         asm_text: "ptrue pn10.h"
         op_str: "pn10.h"
+  -
+    input:
+      name: "issue 2890 AArch64 shifted MOVN retains MOV alias by default"
+      bytes: [ 0xe4, 0x02, 0xa0, 0x12 ]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_MODE_ARM, CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "mov w4, #-0x170001"
+        details:
+          aarch64:
+            operands:
+              -
+                type: AARCH64_OP_REG
+                reg: w4
+                access: CS_AC_WRITE
+              -
+                type: AARCH64_OP_IMM
+                imm: -0x170001
+                access: CS_AC_READ
+          regs_write: [ w4 ]
+
+  -
+    input:
+      name: "issue 2890 AArch64 shifted MOVN immediate printing"
+      bytes: [ 0xe4, 0x02, 0xa0, 0x12 ]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_MODE_ARM, CS_OPT_DETAIL, CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "movn w4, #0x17, lsl #16"
+        details:
+          aarch64:
+            operands:
+              -
+                type: AARCH64_OP_REG
+                reg: w4
+                access: CS_AC_WRITE
+              -
+                type: AARCH64_OP_IMM
+                imm: 0x17
+                access: CS_AC_READ
+                shift_type: AARCH64_SFT_LSL
+                shift_value: 16
+          regs_write: [ w4 ]
+
+  -
+    input:
+      name: "issue 2890 AArch64 unshifted MOVN retains MOV alias"
+      bytes: [ 0xe4, 0x02, 0x80, 0x12 ]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_MODE_ARM, CS_OPT_DETAIL, CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "mov w4, #-0x18"
+        details:
+          aarch64:
+            operands:
+              -
+                type: AARCH64_OP_REG
+                reg: w4
+                access: CS_AC_WRITE
+              -
+                type: AARCH64_OP_IMM
+                imm: -0x18
+                access: CS_AC_READ
+          regs_write: [ w4 ]
+
+  -
+    input:
+      name: "issue 2890 AArch64 64-bit shifted MOVN immediate printing"
+      bytes: [ 0xe4, 0x02, 0xe0, 0x92 ]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_MODE_ARM, CS_OPT_DETAIL, CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "movn x4, #0x17, lsl #48"
+        details:
+          aarch64:
+            operands:
+              -
+                type: AARCH64_OP_REG
+                reg: x4
+                access: CS_AC_WRITE
+              -
+                type: AARCH64_OP_IMM
+                imm: 0x17
+                access: CS_AC_READ
+                shift_type: AARCH64_SFT_LSL
+                shift_value: 48
+          regs_write: [ x4 ]
+
+  -
+    input:
+      name: "issue 2890 AArch64 shifted MOVZ immediate printing"
+      bytes: [ 0xe4, 0x02, 0xa0, 0x52 ]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_MODE_ARM, CS_OPT_DETAIL, CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "movz w4, #0x17, lsl #16"
+        details:
+          aarch64:
+            operands:
+              -
+                type: AARCH64_OP_REG
+                reg: w4
+                access: CS_AC_WRITE
+              -
+                type: AARCH64_OP_IMM
+                imm: 0x17
+                access: CS_AC_READ
+                shift_type: AARCH64_SFT_LSL
+                shift_value: 16
+          regs_write: [ w4 ]


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**

* [x] I've documented or updated the documentation of every API function and struct this PR changes.
* [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

AArch64 currently follows LLVM's default disassembly behaviour and prints shifted `MOVN` and `MOVZ` instructions using their equivalent `MOV` aliases. This can hide the encoded immediate and shift amount.

This PR adds the opt-in syntax option:

`CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM`

When enabled, shifted `MOVN` and `MOVZ` instructions are printed in their explicit forms, including the `lsl` shift:

```text
movn w4, #0x17, lsl #16
movz w4, #0x17, lsl #16
```

The existing LLVM-compatible output remains unchanged by default. Unshifted instructions also retain their existing `MOV` aliases when the option is enabled.

The option is exposed through:

* The public C API
* The Python bindings
* `cstool` as `+explicitwideimm`
* The C and Python YAML test runners

The Capstone v6 release guide has also been updated.

**Test plan**

Added regression tests covering:

* Shifted `MOVN` retaining its `MOV` alias by default
* Shifted 32-bit `MOVN` with the option enabled
* Unshifted `MOVN` retaining its alias with the option enabled
* Shifted 64-bit `MOVN` using the 64-bit-only `lsl #48` form
* Shifted `MOVZ` with the option enabled

Manual verification:

```text
$ ./build/cstool aarch64 0xe402a012
mov w4, #-0x170001

$ ./build/cstool aarch64+explicitwideimm 0xe402a012
movn w4, #0x17, lsl #16

$ ./build/cstool aarch64+explicitwideimm 0xe402a052
movz w4, #0x17, lsl #16
```

The following checks passed:

```text
./build/suite/cstest/cstest tests/issues/issues.yaml
cstest_py tests/issues/issues.yaml
ctest --test-dir build --output-on-failure
ctest --test-dir build-ci --output-on-failure
./build-ci/suite/cstest/cstest tests/issues/issues.yaml
git diff --check
```

**Closing issues**

Closes #2890
