### PR TITLE
xtensa: sign-extend scaled offsets in decodeOffset_* helpers

### DIFF
--- a/arch/Xtensa/XtensaDisassembler.c
+++ b/arch/Xtensa/XtensaDisassembler.c
@@ -788,12 +788,9 @@ static DecodeStatus decodeOffset_16_16Operand(MCInst *Inst, uint64_t Imm,
 					      int64_t Address,
 					      const void *Decoder)
 {
-	CS_ASSERT_RET_VAL(isIntN(8, Imm) && "Invalid immediate",
+	CS_ASSERT_RET_VAL(isUIntN(4, Imm) && "Invalid immediate",
 			  MCDisassembler_Fail);
-	if ((Imm & 0xf) != 0)
-		MCOperand_CreateImm0(Inst, (Imm << 4));
-	else
-		MCOperand_CreateImm0(Inst, (Imm));
+	MCOperand_CreateImm0(Inst, SignExtend64(Imm << 4, 8));
 	return MCDisassembler_Success;
 }
 
@@ -801,12 +798,9 @@ static DecodeStatus decodeOffset_256_8Operand(MCInst *Inst, uint64_t Imm,
 					      int64_t Address,
 					      const void *Decoder)
 {
-	CS_ASSERT_RET_VAL(isIntN(16, Imm) && "Invalid immediate",
+	CS_ASSERT_RET_VAL(isUIntN(8, Imm) && "Invalid immediate",
 			  MCDisassembler_Fail);
-	if ((Imm & 0x7) != 0)
-		MCOperand_CreateImm0(Inst, (Imm << 3));
-	else
-		MCOperand_CreateImm0(Inst, (Imm));
+	MCOperand_CreateImm0(Inst, SignExtend64(Imm << 3, 11));
 	return MCDisassembler_Success;
 }
 
@@ -814,12 +808,9 @@ static DecodeStatus decodeOffset_256_16Operand(MCInst *Inst, uint64_t Imm,
 					       int64_t Address,
 					       const void *Decoder)
 {
-	CS_ASSERT_RET_VAL(isIntN(16, Imm) && "Invalid immediate",
+	CS_ASSERT_RET_VAL(isUIntN(8, Imm) && "Invalid immediate",
 			  MCDisassembler_Fail);
-	if ((Imm & 0xf) != 0)
-		MCOperand_CreateImm0(Inst, (Imm << 4));
-	else
-		MCOperand_CreateImm0(Inst, (Imm));
+	MCOperand_CreateImm0(Inst, SignExtend64(Imm << 4, 12));
 	return MCDisassembler_Success;
 }
 
@@ -827,12 +818,9 @@ static DecodeStatus decodeOffset_256_4Operand(MCInst *Inst, uint64_t Imm,
 					      int64_t Address,
 					      const void *Decoder)
 {
-	CS_ASSERT_RET_VAL(isIntN(16, Imm) && "Invalid immediate",
+	CS_ASSERT_RET_VAL(isUIntN(8, Imm) && "Invalid immediate",
 			  MCDisassembler_Fail);
-	if ((Imm & 0x2) != 0)
-		MCOperand_CreateImm0(Inst, (Imm << 2));
-	else
-		MCOperand_CreateImm0(Inst, (Imm));
+	MCOperand_CreateImm0(Inst, SignExtend64(Imm << 2, 10));
 	return MCDisassembler_Success;
 }
 
@@ -840,12 +828,9 @@ static DecodeStatus decodeOffset_128_2Operand(MCInst *Inst, uint64_t Imm,
 					      int64_t Address,
 					      const void *Decoder)
 {
-	CS_ASSERT_RET_VAL(isUIntN(8, Imm) && "Invalid immediate",
+	CS_ASSERT_RET_VAL(isUIntN(7, Imm) && "Invalid immediate",
 			  MCDisassembler_Fail);
-	if ((Imm & 0x1) != 0)
-		MCOperand_CreateImm0(Inst, (Imm << 1));
-	else
-		MCOperand_CreateImm0(Inst, (Imm));
+	MCOperand_CreateImm0(Inst, (Imm << 1));
 	return MCDisassembler_Success;
 }
 
@@ -853,7 +838,7 @@ static DecodeStatus decodeOffset_128_1Operand(MCInst *Inst, uint64_t Imm,
 					      int64_t Address,
 					      const void *Decoder)
 {
-	CS_ASSERT_RET_VAL(isUIntN(8, Imm) && "Invalid immediate",
+	CS_ASSERT_RET_VAL(isUIntN(7, Imm) && "Invalid immediate",
 			  MCDisassembler_Fail);
 	MCOperand_CreateImm0(Inst, (Imm));
 	return MCDisassembler_Success;
@@ -863,12 +848,9 @@ static DecodeStatus decodeOffset_64_16Operand(MCInst *Inst, uint64_t Imm,
 					      int64_t Address,
 					      const void *Decoder)
 {
-	CS_ASSERT_RET_VAL(isIntN(16, Imm) && "Invalid immediate",
+	CS_ASSERT_RET_VAL(isUIntN(6, Imm) && "Invalid immediate",
 			  MCDisassembler_Fail);
-	if ((Imm & 0xf) != 0)
-		MCOperand_CreateImm0(Inst, (Imm << 4));
-	else
-		MCOperand_CreateImm0(Inst, (Imm));
+	MCOperand_CreateImm0(Inst, SignExtend64(Imm << 4, 10));
 	return MCDisassembler_Success;
 }
 

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -6271,6 +6271,70 @@ test_cases:
 
   -
     input:
+      name: "Xtensa decodeOffset_64_16Operand sign extension"
+      bytes: [ 0x2f, 0x71, 0x01, 0x4e ]
+      arch: "CS_ARCH_XTENSA"
+      options: [ CS_MODE_XTENSA_ESP32, CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "ee.vmulas.u16.accx.ld.ip.qup q4, a2, -0xf0, q5, q6, q0, q1"
+          details:
+            xtensa:
+              operands:
+                - type: XTENSA_OP_REG
+                  reg: q4
+                  access: CS_AC_WRITE
+                - type: XTENSA_OP_REG
+                  reg: a2
+                  access: CS_AC_READ
+                - type: XTENSA_OP_IMM
+                  imm: -0xf0
+                  access: CS_AC_READ
+                - type: XTENSA_OP_REG
+                  reg: q5
+                  access: CS_AC_READ
+                - type: XTENSA_OP_REG
+                  reg: q6
+                  access: CS_AC_READ
+                - type: XTENSA_OP_REG
+                  reg: q0
+                  access: CS_AC_READ
+                - type: XTENSA_OP_REG
+                  reg: q1
+                  access: CS_AC_READ
+            regs_read: [ a2, q5, q6, q0, q1 ]
+            regs_write: [ q4 ]
+            groups: [ HasESP32S3Ops ]
+
+  -
+    input:
+      name: "Xtensa decodeOffset_128_2Operand offset scaling"
+      bytes: [ 0x74, 0xe0, 0xb5 ]
+      arch: "CS_ARCH_XTENSA"
+      options: [ CS_MODE_XTENSA_ESP32, CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+        - asm_text: "ee.vldbc.16.ip q7, a7, 0xc0"
+          details:
+            xtensa:
+              operands:
+                - type: XTENSA_OP_REG
+                  reg: q7
+                  access: CS_AC_WRITE
+                - type: XTENSA_OP_REG
+                  reg: a7
+                  access: CS_AC_READ
+                - type: XTENSA_OP_IMM
+                  imm: 0xc0
+                  access: CS_AC_READ
+            regs_read: [ a7 ]
+            regs_write: [ q7 ]
+            groups: [ HasESP32S3Ops ]
+
+  -
+    input:
       name: "#2722 - CS_OPT_UNSIGNED is ignored for most archs"
       bytes: [ 0x20, 0xf0, 0x5f, 0xf8 ]
       arch: "CS_ARCH_AARCH64"


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

The `decodeOffset_*` helpers in `arch/Xtensa/XtensaDisassembler.c` decode the scaled memory offset of the ESP32-S3 `ee.*` instructions. Each one scales the field only when it is not already aligned, and never sign extends it:

```c
if ((Imm & 0xf) != 0)
	MCOperand_CreateImm0(Inst, (Imm << 4));
else
	MCOperand_CreateImm0(Inst, (Imm));
```

These offsets are signed, and two generated artifacts in the tree pin down the exact shape. The decoder tables give each field's width, and the printer gives the range it accepts. `decodeOffset_64_16Operand` reads a 6 bit field and `printOffset_64_16_AsmOperand` accepts `[-512,496]` in steps of 16, which is exactly the 64 values of `SignExtend64(Imm << 4, 10)`. The rest of the family lines up the same way: 4 bit against `[-128,112]`, and three 8 bit fields against `[-1024,1016]`, `[-2048,2032]` and `[-512,508]`. `decodeOffset_128_1Operand` and `decodeOffset_128_2Operand` are the unsigned ones (`[0,127]` and `[0,254]`), so they only need the scale.

Two things follow from the missing sign extension. When the decoded value lands outside the printer's range, `CS_ASSERT_RET` drops the operand, so release builds print the instruction with an operand missing and assert builds abort in the printer. When it happens to land inside the range, it is silently wrong.

`cstool esp32 2f71014e` before:

```
ee.vmulas.u16.accx.ld.ip.qup	q4, a2, , q5, q6, q0, q1
```

and after:

```
ee.vmulas.u16.accx.ld.ip.qup	q4, a2, -0xf0, q5, q6, q0, q1
```

The 6 bit field here is 49, so the offset is `SignExtend64(49 << 4, 10)`, or -240. The old code produced 784 and the printer rejected it.

I also tightened each `CS_ASSERT_RET_VAL` to the field width the tables actually pass. `Imm` is the raw unsigned field, so the previous `isIntN(8, Imm)` / `isIntN(16, Imm)` guards were true for every input. This does touch the line from #2986: the swapped-argument fix there was right, the guard just never matched the field.

**Test plan**

Added `tests/issues/issues.yaml` (the `64_16` sign extension and the `128_2` scaling).

To check the change does not move anything it should not, I diffed cstool over 12000 random 4 byte words in `esp32` and `esp32s2` against an unpatched build. 574 outputs differ: 506 recover an operand the printer had dropped, and 68 correct a silently wrong offset, for example `ee.vldbc.16.ip q7, a7, 0x60` becoming `0xc0` and `ee.vst.l.64.ip q7, a3, 0x50` becoming `0x280`. None of them change a value that was already correct. The existing Xtensa cases under `tests/` decode identically before and after, including the `#2986` word, whose offset field is 0.

**Closing issues**
