### PR TITLE
Add null check for 'MCRegisterInfo' in arch/xx/xxModule.c and for insn_cache->detail in cs.c

### DIFF
--- a/Mapping.c
+++ b/Mapping.c
@@ -13,6 +13,9 @@ static unsigned short *make_id2insn(const insn_map *insns, unsigned int size)
 
 	unsigned short *cache =
 		(unsigned short *)cs_mem_calloc(max_id + 1, sizeof(*cache));
+	if (cache == NULL) {
+		return NULL;
+	}
 
 	for (i = 1; i < size; i++)
 		cache[insns[i].id] = i;
@@ -30,6 +33,9 @@ unsigned short insn_find(const insn_map *insns, unsigned int max,
 
 	if (*cache == NULL)
 		*cache = make_id2insn(insns, max);
+	if (*cache == NULL) {
+		return 0;
+	}
 
 	return (*cache)[id];
 }

--- a/arch/AArch64/AArch64Module.c
+++ b/arch/AArch64/AArch64Module.c
@@ -14,6 +14,9 @@ cs_err AArch64_global_init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
 	mri = cs_mem_malloc(sizeof(*mri));
+	if (mri == NULL) {
+		return CS_ERR_MEM;
+	}
 
 	AArch64_init(mri);
 	ud->printer = AArch64_printInst;

--- a/arch/ARM/ARMModule.c
+++ b/arch/ARM/ARMModule.c
@@ -14,6 +14,9 @@ cs_err ARM_global_init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
 	mri = cs_mem_malloc(sizeof(*mri));
+	if (mri == NULL) {
+		return CS_ERR_MEM;
+	}
 
 	ARM_init(mri);
 	ARM_getRegName(ud, 0);	// use default get_regname

--- a/arch/MOS65XX/MOS65XXModule.c
+++ b/arch/MOS65XX/MOS65XXModule.c
@@ -14,6 +14,10 @@ cs_err MOS65XX_global_init(cs_struct *ud)
 	mos65xx_info *info;
 
 	info = cs_mem_malloc(sizeof(*info));
+	if (info == NULL) {
+		return CS_ERR_MEM;
+	}
+
 	info->hex_prefix = NULL;
 	info->cpu_type = MOS65XX_CPU_TYPE_6502;
 	info->long_m = 0;

--- a/arch/Mips/MipsModule.c
+++ b/arch/Mips/MipsModule.c
@@ -24,6 +24,9 @@ cs_err Mips_global_init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
 	mri = cs_mem_malloc(sizeof(*mri));
+	if (mri == NULL) {
+		return CS_ERR_MEM;
+	}
 
 	Mips_init(mri);
 	ud->printer = Mips_printInst;

--- a/arch/PowerPC/PPCModule.c
+++ b/arch/PowerPC/PPCModule.c
@@ -14,6 +14,9 @@ cs_err PPC_global_init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
 	mri = (MCRegisterInfo *) cs_mem_malloc(sizeof(*mri));
+	if (mri == NULL) {
+		return CS_ERR_MEM;
+	}
 
 	PPC_init(mri);
 	ud->printer = PPC_printInst;

--- a/arch/RISCV/RISCVModule.c
+++ b/arch/RISCV/RISCVModule.c
@@ -15,6 +15,9 @@ cs_err RISCV_global_init(cs_struct * ud)
 {
 	MCRegisterInfo *mri;
 	mri = cs_mem_malloc(sizeof(*mri));
+	if (mri == NULL) {
+		return CS_ERR_MEM;
+	}
 
 	RISCV_init(mri);
 	ud->printer = RISCV_printInst;

--- a/arch/Sparc/SparcModule.c
+++ b/arch/Sparc/SparcModule.c
@@ -14,6 +14,9 @@ cs_err Sparc_global_init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
 	mri = cs_mem_malloc(sizeof(*mri));
+	if (mri == NULL) {
+		return CS_ERR_MEM;
+	}
 
 	Sparc_init(mri);
 	ud->printer = Sparc_printInst;

--- a/arch/SystemZ/SystemZModule.c
+++ b/arch/SystemZ/SystemZModule.c
@@ -14,6 +14,9 @@ cs_err SystemZ_global_init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
 	mri = cs_mem_malloc(sizeof(*mri));
+	if (mri == NULL) {
+		return CS_ERR_MEM;
+	}
 
 	SystemZ_init(mri);
 	ud->printer = SystemZ_printInst;

--- a/arch/TMS320C64x/TMS320C64xModule.c
+++ b/arch/TMS320C64x/TMS320C64xModule.c
@@ -15,6 +15,9 @@ cs_err TMS320C64x_global_init(cs_struct *ud)
 	MCRegisterInfo *mri;
 
 	mri = cs_mem_malloc(sizeof(*mri));
+	if (mri == NULL) {
+		return CS_ERR_MEM;
+	}
 
 	TMS320C64x_init(mri);
 	ud->printer = TMS320C64x_printInst;

--- a/arch/TriCore/TriCoreModule.c
+++ b/arch/TriCore/TriCoreModule.c
@@ -13,6 +13,9 @@ cs_err TRICORE_global_init(cs_struct *ud)
 	MCRegisterInfo *mri;
 
 	mri = cs_mem_malloc(sizeof(*mri));
+	if (mri == NULL) {
+		return CS_ERR_MEM;
+	}
 
 	TriCore_init_mri(mri);
 	ud->printer = TriCore_printInst;

--- a/arch/X86/X86Module.c
+++ b/arch/X86/X86Module.c
@@ -14,6 +14,9 @@ cs_err X86_global_init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
 	mri = cs_mem_malloc(sizeof(*mri));
+	if (mri == NULL) {
+		return CS_ERR_MEM;
+	}
 
 	X86_init(mri);
 

--- a/arch/XCore/XCoreModule.c
+++ b/arch/XCore/XCoreModule.c
@@ -14,6 +14,9 @@ cs_err XCore_global_init(cs_struct *ud)
 {
 	MCRegisterInfo *mri;
 	mri = cs_mem_malloc(sizeof(*mri));
+	if (mri == NULL) {
+		return CS_ERR_MEM;
+	}
 
 	XCore_init(mri);
 	ud->printer = XCore_printInst;

--- a/cs.c
+++ b/cs.c
@@ -781,6 +781,9 @@ cs_err CAPSTONE_API cs_option(csh ud, cs_opt_type type, size_t value)
 					// 2. add this instruction if we have not had it yet
 					if (!tmp) {
 						tmp = cs_mem_malloc(sizeof(*tmp));
+						if (!tmp) {
+							return CS_ERR_MEM;
+						}
 						tmp->insn.id = opt->id;
 						(void)strncpy(tmp->insn.mnemonic, opt->mnemonic, sizeof(tmp->insn.mnemonic) - 1);
 						tmp->insn.mnemonic[sizeof(tmp->insn.mnemonic) - 1] = '\0';
@@ -923,6 +926,11 @@ size_t CAPSTONE_API cs_disasm(csh ud, const uint8_t *buffer, size_t size, uint64
 		if (handle->detail) {
 			// allocate memory for @detail pointer
 			insn_cache->detail = cs_mem_malloc(sizeof(cs_detail));
+			if (insn_cache->detail == NULL) {
+				// insufficient memory
+				handle->errnum = CS_ERR_MEM;
+				break;
+			}
 		} else {
 			insn_cache->detail = NULL;
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

If the memory is insufficient, check the null pointer and set the error code to 'CS_ERR_MEM'.


**Test plan**

The standard test suite should do fine.


**Closing issues**

closes https://github.com/capstone-engine/capstone/issues/1763 
closes https://github.com/capstone-engine/capstone/issues/1764 